### PR TITLE
Fix: level logic fix

### DIFF
--- a/src/mcp_agent/cli/terminal.py
+++ b/src/mcp_agent/cli/terminal.py
@@ -14,7 +14,7 @@ class Application:
             self.error_console = error_console
 
     def log(self, message: str, level: str = "info") -> None:
-        if level == "info" or (level == "debug" and self.verbosity > 0):
+        if (level == "info" or (level == "debug" and self.verbosity > 0) or level ==  "error"):
             if level == "error":
                 self.error_console.print(f"[{level.upper()}] {message}")
             else:


### PR DESCRIPTION
target file : src/mcp_agent/cli/terminal.py

[ORIGINAL]
def log(self, message: str, level: str = "info") -> None:
if level == "info" or
(level == "debug" and self.verbosity > 0) : # error 레벨 추가
if level == "error":
self.error_console.print(f"[{level.upper()}] {message}")
else:
self.console.print(f"[{level.upper()}] {message}")

[FIX]
def log(self, message: str, level: str = "info") -> None:
if (level == "info" or
(level == "debug" and self.verbosity > 0) or
level == "error"): # error 레벨 추가
if level == "error":
self.error_console.print(f"[{level.upper()}] {message}")
else:
self.console.print(f"[{level.upper()}] {message}")

simple error