### PR TITLE
Add base_url configuration support for Anthropic API to allow custom …

### DIFF
--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "AnthropicSettings": {
       "additionalProperties": true,
-      "description": "Settings for using Anthropic models in the MCP Agent application.",
+      "description": "Settings for using Anthropic models in the fast-agent application.",
       "properties": {
         "api_key": {
           "anyOf": [
@@ -15,6 +15,18 @@
           ],
           "default": null,
           "title": "Api Key"
+        },
+        "base_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Url"
         }
       },
       "title": "AnthropicSettings",
@@ -22,7 +34,7 @@
     },
     "DeepSeekSettings": {
       "additionalProperties": true,
-      "description": "Settings for using OpenAI models in the MCP Agent application.",
+      "description": "Settings for using OpenAI models in the fast-agent application.",
       "properties": {
         "api_key": {
           "anyOf": [
@@ -53,7 +65,7 @@
       "type": "object"
     },
     "LoggerSettings": {
-      "description": "Logger settings for the MCP Agent application.",
+      "description": "Logger settings for the fast-agent application.",
       "properties": {
         "type": {
           "default": "file",
@@ -411,7 +423,7 @@
     },
     "OpenAISettings": {
       "additionalProperties": true,
-      "description": "Settings for using OpenAI models in the MCP Agent application.",
+      "description": "Settings for using OpenAI models in the fast-agent application.",
       "properties": {
         "api_key": {
           "anyOf": [
@@ -451,8 +463,74 @@
       "title": "OpenAISettings",
       "type": "object"
     },
+    "OpenTelemetrySettings": {
+      "description": "OTEL settings for the fast-agent application.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "service_name": {
+          "default": "fast-agent",
+          "title": "Service Name",
+          "type": "string"
+        },
+        "service_instance_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Service Instance Id"
+        },
+        "service_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Service Version"
+        },
+        "otlp_endpoint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Otlp Endpoint",
+          "description": "OTLP endpoint for OpenTelemetry tracing"
+        },
+        "console_debug": {
+          "default": false,
+          "title": "Console Debug",
+          "type": "boolean",
+          "description": "Log spans to console"
+        },
+        "sample_rate": {
+          "default": 1.0,
+          "title": "Sample Rate",
+          "type": "number",
+          "description": "Sample rate for tracing (1.0 = sample everything)"
+        }
+      },
+      "title": "OpenTelemetrySettings",
+      "type": "object"
+    },
     "TemporalSettings": {
-      "description": "Temporal settings for the MCP Agent application.",
+      "description": "Temporal settings for the fast-agent application.",
       "properties": {
         "host": {
           "title": "Host",
@@ -513,7 +591,7 @@
       ],
       "title": "Execution Engine",
       "type": "string",
-      "description": "Execution engine for the MCP Agent application"
+      "description": "Execution engine for the fast-agent application"
     },
     "default_model": {
       "anyOf": [
@@ -549,7 +627,27 @@
         }
       ],
       "default": null,
-      "description": "Settings for using Anthropic models in the MCP Agent application"
+      "description": "Settings for using Anthropic models in the fast-agent application"
+    },
+    "otel": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OpenTelemetrySettings"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": {
+        "enabled": true,
+        "service_name": "fast-agent",
+        "service_instance_id": null,
+        "service_version": null,
+        "otlp_endpoint": null,
+        "console_debug": false,
+        "sample_rate": 1.0
+      },
+      "description": "OpenTelemetry logging settings for the fast-agent application"
     },
     "openai": {
       "anyOf": [
@@ -561,7 +659,7 @@
         }
       ],
       "default": null,
-      "description": "Settings for using OpenAI models in the MCP Agent application"
+      "description": "Settings for using OpenAI models in the fast-agent application"
     },
     "deepseek": {
       "anyOf": [
@@ -573,7 +671,7 @@
         }
       ],
       "default": null,
-      "description": "Settings for using DeepSeek models in the MCP Agent application"
+      "description": "Settings for using DeepSeek models in the fast-agent application"
     },
     "logger": {
       "anyOf": [
@@ -599,7 +697,7 @@
         "show_tools": true,
         "truncate_tools": true
       },
-      "description": "Logger settings for the MCP Agent application"
+      "description": "Logger settings for the fast-agent application"
     }
   },
   "title": "MCP Agent Configuration Schema",

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -105,6 +105,8 @@ class AnthropicSettings(BaseModel):
 
     api_key: str | None = None
 
+    base_url: str | None = None
+
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 

--- a/src/mcp_agent/llm/providers/augmented_llm_anthropic.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_anthropic.py
@@ -69,6 +69,9 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
             use_history=True,
         )
 
+    def _base_url(self) -> str:
+        return self.context.config.anthropic.base_url if self.context.config.anthropic else None
+
     async def generate_internal(
         self,
         message_param,
@@ -80,8 +83,12 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
         """
 
         api_key = self._api_key(self.context.config)
+        base_url = self._base_url()
+        if base_url and base_url.endswith("/v1"):
+            base_url = base_url.rstrip("/v1")
+
         try:
-            anthropic = Anthropic(api_key=api_key)
+            anthropic = Anthropic(api_key=api_key, base_url=base_url)
             messages: List[MessageParam] = []
             params = self.get_request_params(request_params)
         except AuthenticationError as e:


### PR DESCRIPTION
# Add base_url configuration support for Anthropic API

This pull request adds support for configuring a custom base URL for the Anthropic API. This enhancement allows users to:

- Connect to alternative Anthropic API endpoints
- Use proxy services for Anthropic API calls
- Configure regional endpoints when needed

The implementation reads the base_url from the configuration file and passes it to the Anthropic client during initialization. If not specified, the default Anthropic API endpoint will be used.

This change maintains backward compatibility with existing configurations while adding flexibility for users with custom deployment needs.

Tested with both default and custom base URL configurations to ensure proper functionality.