### PR TITLE
Support for Generic OpenAI LLMs (with ollama defaults)

### DIFF
--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -64,6 +64,38 @@
       "title": "DeepSeekSettings",
       "type": "object"
     },
+    "GenericSettings": {
+      "additionalProperties": true,
+      "description": "Settings for using OpenAI models in the fast-agent application.",
+      "properties": {
+        "api_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Api Key"
+        },
+        "base_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Url"
+        }
+      },
+      "title": "GenericSettings",
+      "type": "object"
+    },
     "LoggerSettings": {
       "description": "Logger settings for the fast-agent application.",
       "properties": {
@@ -672,6 +704,18 @@
       ],
       "default": null,
       "description": "Settings for using DeepSeek models in the fast-agent application"
+    },
+    "generic": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GenericSettings"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Settings for using Generic models in the fast-agent application"
     },
     "logger": {
       "anyOf": [

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -136,6 +136,18 @@ class DeepSeekSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
+class GenericSettings(BaseModel):
+    """
+    Settings for using OpenAI models in the fast-agent application.
+    """
+
+    api_key: str | None = None
+
+    base_url: str | None = None
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+
 class TemporalSettings(BaseModel):
     """
     Temporal settings for the fast-agent application.
@@ -249,6 +261,9 @@ class Settings(BaseSettings):
 
     deepseek: DeepSeekSettings | None = None
     """Settings for using DeepSeek models in the fast-agent application"""
+
+    generic: GenericSettings | None = None
+    """Settings for using Generic models in the fast-agent application"""
 
     logger: LoggerSettings | None = LoggerSettings()
     """Logger settings for the fast-agent application"""

--- a/src/mcp_agent/llm/model_factory.py
+++ b/src/mcp_agent/llm/model_factory.py
@@ -9,6 +9,7 @@ from mcp_agent.llm.augmented_llm_passthrough import PassthroughLLM
 from mcp_agent.llm.augmented_llm_playback import PlaybackLLM
 from mcp_agent.llm.providers.augmented_llm_anthropic import AnthropicAugmentedLLM
 from mcp_agent.llm.providers.augmented_llm_deepseek import DeepSeekAugmentedLLM
+from mcp_agent.llm.providers.augmented_llm_generic import GenericAugmentedLLM
 from mcp_agent.llm.providers.augmented_llm_openai import OpenAIAugmentedLLM
 from mcp_agent.mcp.interfaces import AugmentedLLMProtocol
 
@@ -32,6 +33,7 @@ class Provider(Enum):
     OPENAI = auto()
     FAST_AGENT = auto()
     DEEPSEEK = auto()
+    GENERIC = auto()
 
 
 class ReasoningEffort(Enum):
@@ -60,6 +62,7 @@ class ModelFactory:
         "openai": Provider.OPENAI,
         "fast-agent": Provider.FAST_AGENT,
         "deepseek": Provider.DEEPSEEK,
+        "generic": Provider.GENERIC,
     }
 
     # Mapping of effort strings to enum values
@@ -116,6 +119,7 @@ class ModelFactory:
         Provider.OPENAI: OpenAIAugmentedLLM,
         Provider.FAST_AGENT: PassthroughLLM,
         Provider.DEEPSEEK: DeepSeekAugmentedLLM,
+        Provider.GENERIC: GenericAugmentedLLM,
     }
 
     # Mapping of special model names to their specific LLM classes

--- a/src/mcp_agent/llm/providers/augmented_llm_generic.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_generic.py
@@ -1,0 +1,46 @@
+import os
+
+from mcp_agent.core.request_params import RequestParams
+from mcp_agent.llm.providers.augmented_llm_openai import OpenAIAugmentedLLM
+
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1"
+DEFAULT_OLLAMA_MODEL = "llama3.2:latest"
+DEFAULT_OLLAMA_API_KEY = "ollama"
+
+
+class GenericAugmentedLLM(OpenAIAugmentedLLM):
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs["provider_name"] = "GenericOpenAI"  # Set provider name in kwargs
+        super().__init__(*args, **kwargs)  # Properly pass args and kwargs to parent
+
+    def _initialize_default_params(self, kwargs: dict) -> RequestParams:
+        """Initialize Deepseek-specific default parameters"""
+        chosen_model = kwargs.get("model", DEFAULT_OLLAMA_MODEL)
+
+        return RequestParams(
+            model=chosen_model,
+            systemPrompt=self.instruction,
+            parallel_tool_calls=True,
+            max_iterations=10,
+            use_history=True,
+        )
+
+    def _api_key(self) -> str:
+        config = self.context.config
+        api_key = None
+
+        if config and config.generic:
+            api_key = config.generic.api_key
+            if api_key == "<your-api-key-here>":
+                api_key = None
+
+        if api_key is None:
+            api_key = os.getenv("GENERIC_API_KEY")
+
+        return api_key or "ollama"
+
+    def _base_url(self) -> str:
+        if self.context.config and self.context.config.deepseek:
+            base_url = self.context.config.deepseek.base_url
+
+        return base_url if base_url else DEFAULT_OLLAMA_BASE_URL

--- a/src/mcp_agent/llm/providers/augmented_llm_openai.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_openai.py
@@ -115,7 +115,6 @@ class OpenAIAugmentedLLM(AugmentedLLM[ChatCompletionMessageParam, ChatCompletion
         self,
         message,
         request_params: RequestParams | None = None,
-        response_model: Type[ModelT] | None = None,
     ) -> List[ChatCompletionMessage]:
         """
         Process a query using an LLM and available tools.
@@ -192,16 +191,9 @@ class OpenAIAugmentedLLM(AugmentedLLM[ChatCompletionMessageParam, ChatCompletion
             self.logger.debug(f"{arguments}")
             self._log_chat_progress(self.chat_turn(), model=model)
 
-            if response_model is None:
-                executor_result = await self.executor.execute(
-                    openai_client.chat.completions.create, **arguments
-                )
-            else:
-                executor_result = await self.executor.execute(
-                    openai_client.beta.chat.completions.parse,
-                    **arguments,
-                    response_format=response_model,
-                )
+            executor_result = await self.executor.execute(
+                openai_client.chat.completions.create, **arguments
+            )
 
             response = executor_result[0]
 

--- a/tests/e2e/smoke/test_e2e_smoke.py
+++ b/tests/e2e/smoke/test_e2e_smoke.py
@@ -250,3 +250,35 @@ async def test_structured_weather_forecast_prompting_style(fast_agent, model_nam
             print(f"Weather forecast for {forecast.location}: {forecast.summary}")
 
     await weather_forecast()
+
+
+@pytest.mark.skip(reason="Generic OpenAI endpoint")
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "generic.qwen2.5:latest",
+        "generic.llama3.2:latest",
+    ],
+)
+async def test_generic_model_textual_prompting(fast_agent, model_name):
+    """Test that the agent can process an image and respond appropriately."""
+    fast = fast_agent
+
+    # Define the agent
+    @fast.agent(
+        "agent",
+        instruction="You are a helpful AI Agent",
+        model=model_name,
+    )
+    async def agent_function():
+        async with fast.run() as agent:
+            response = await agent.send(Prompt.user("write a 50 word story about cats"))
+            response_text = response.strip()
+            words = response_text.split()
+            word_count = len(words)
+            assert 40 <= word_count <= 60, f"Expected between 40-60 words, got {word_count}"
+
+    await agent_function()


### PR DESCRIPTION
Adds support for Generic OpenAI endpoints, with locally running ollama for defaults. This allows the use of Ollama models by specifying a model name such as `generic.llama3.2:latest`. This feature should be considered advanced/experimental. 