### PR TITLE
fix baseurl/deepseek config error + unit test for same

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.2.1"
+version = "0.2.3"
 description = "Define, Prompt and Test MCP enabled Agents and Workflows"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_agent/llm/providers/augmented_llm_generic.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_generic.py
@@ -10,11 +10,11 @@ DEFAULT_OLLAMA_API_KEY = "ollama"
 
 class GenericAugmentedLLM(OpenAIAugmentedLLM):
     def __init__(self, *args, **kwargs) -> None:
-        kwargs["provider_name"] = "GenericOpenAI"  # Set provider name in kwargs
+        kwargs["provider_name"] = "GenericOpenAI"
         super().__init__(*args, **kwargs)  # Properly pass args and kwargs to parent
 
     def _initialize_default_params(self, kwargs: dict) -> RequestParams:
-        """Initialize Deepseek-specific default parameters"""
+        """Initialize Generic  parameters"""
         chosen_model = kwargs.get("model", DEFAULT_OLLAMA_MODEL)
 
         return RequestParams(
@@ -40,7 +40,8 @@ class GenericAugmentedLLM(OpenAIAugmentedLLM):
         return api_key or "ollama"
 
     def _base_url(self) -> str:
-        if self.context.config and self.context.config.deepseek:
-            base_url = self.context.config.deepseek.base_url
+        base_url = None
+        if self.context.config and self.context.config.generic:
+            base_url = self.context.config.generic.base_url
 
         return base_url if base_url else DEFAULT_OLLAMA_BASE_URL

--- a/tests/unit/mcp_agent/llm/test_model_factory.py
+++ b/tests/unit/mcp_agent/llm/test_model_factory.py
@@ -7,6 +7,7 @@ from mcp_agent.llm.model_factory import (
     ReasoningEffort,
 )
 from mcp_agent.llm.providers.augmented_llm_anthropic import AnthropicAugmentedLLM
+from mcp_agent.llm.providers.augmented_llm_generic import GenericAugmentedLLM
 from mcp_agent.llm.providers.augmented_llm_openai import OpenAIAugmentedLLM
 
 
@@ -74,3 +75,12 @@ def test_llm_class_creation():
         # Note: You may need to adjust params based on what the factory requires
         instance = factory(None)
         assert isinstance(instance, expected_class)
+
+
+def test_allows_generic_model():
+    """Test that generic model names are allowed"""
+    generic_model = "generic.llama3.2:latest"
+    factory = ModelFactory.create_factory(generic_model)
+    instance = factory(None)
+    assert isinstance(instance, GenericAugmentedLLM)
+    assert instance._base_url() == "http://localhost:11434/v1"

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fix base_url handling for generic llm (hidden by tests having configuration)