### PR TITLE
Changed RouterResult 'result' parameter from 'Agent' to 'BaseAgent'.

### DIFF
--- a/src/mcp_agent/agents/workflow/router_agent.py
+++ b/src/mcp_agent/agents/workflow/router_agent.py
@@ -74,7 +74,7 @@ class RoutingResponse(BaseModel):
 class RouterResult(BaseModel):
     """Router result with agent reference and confidence rating."""
 
-    result: Agent
+    result: BaseAgent
     confidence: str
     reasoning: Optional[str] = None
 


### PR DESCRIPTION
With the RouterResult 'result' in router_agent.py configured as 'Agent', the pydantic validation was failing whenever a Router agent selected a Parallel Agent type (or any other agent type besides 'Agent'). Since all the other agents seem to inherit BaseAgent, not Agent, I think this fix makes sense. 