### PR TITLE
Fix/chain passthrough text

### DIFF
--- a/src/mcp_agent/agents/workflow/chain_agent.py
+++ b/src/mcp_agent/agents/workflow/chain_agent.py
@@ -77,7 +77,7 @@ class ChainAgent(BaseAgent):
             response: PromptMessageMultipart = await self.agents[0].generate(multipart_messages)
             # Process the rest of the agents in the chain
             for agent in self.agents[1:]:
-                next_message = Prompt.user(response.content)
+                next_message = Prompt.user(response.content[0].text)
                 response = await agent.generate([next_message])
 
             return response

--- a/tests/integration/workflow/chain/test_chain_passthrough.py
+++ b/tests/integration/workflow/chain/test_chain_passthrough.py
@@ -1,51 +1,52 @@
-import pytest
 import asyncio
 
-from mcp_agent.core.fastagent import FastAgent
+import pytest
 
-# Create the application
-# fast = FastAgent("Agent Chaining")
+from mcp_agent.core.fastagent import FastAgent
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_chain_passthrough(fast_agent): # CHAIN OF 3 BASIC AGENTS
+async def test_chain_passthrough(fast_agent):  # CHAIN OF 3 BASIC AGENTS
     fast = fast_agent
 
     @fast.agent(
         "url_fetcher",
         instruction="Look at the articles on the page of the given url and summarize each of the articles.",
-        model='passthrough',
+        model="passthrough",
     )
     @fast.agent(
         "summary_writer",
         instruction="""
         Write the given text to a file named summary.txt, and output which article topic is the most relevant to college students.
         """,
-        model='passthrough',
+        model="passthrough",
     )
     @fast.agent(
         "google_sheets_writer",
         instruction="""
         Based on the given text, write some key points to research on the topic to a new google spreadsheet with a title "Research on <topic>".
         """,
-        model='passthrough',
+        model="passthrough",
     )
     @fast.chain(
         name="topic_writer",
         sequence=["url_fetcher", "summary_writer", "google_sheets_writer"],
+        cumulative=False,
     )
-    async def chain_workflow(): # Renamed from main to avoid conflicts, and wrapped inside the test
+    @fast.chain(
+        name="topic_writer_cumulative",
+        sequence=["url_fetcher", "summary_writer", "google_sheets_writer"],
+        cumulative=True,
+    )
+    async def chain_workflow():  # Renamed from main to avoid conflicts, and wrapped inside the test
         async with fast.run() as agent:
             input_url = "https://www.nytimes.com"
             result = await agent.topic_writer.send(input_url)
             assert result == input_url
 
+            result = await agent.topic_writer_cumulative.send("X")
+            # we expect the result to include tagged responses from all agents.
+            assert "X\nX\nX\nX" in result
 
-    # alternative syntax for above is result = agent["post_writer"].send(message)
-    # alternative syntax for above is result = agent["post_writer"].prompt()
-
-    await chain_workflow() # Call the inner function
-
-# if __name__ == "__main__":
-#     asyncio.run(main())
+    await chain_workflow()  # Call the inner function

--- a/tests/integration/workflow/chain/test_chain_passthrough.py
+++ b/tests/integration/workflow/chain/test_chain_passthrough.py
@@ -1,0 +1,51 @@
+import pytest
+import asyncio
+
+from mcp_agent.core.fastagent import FastAgent
+
+# Create the application
+# fast = FastAgent("Agent Chaining")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_chain_passthrough(fast_agent): # CHAIN OF 3 BASIC AGENTS
+    fast = fast_agent
+
+    @fast.agent(
+        "url_fetcher",
+        instruction="Look at the articles on the page of the given url and summarize each of the articles.",
+        model='passthrough',
+    )
+    @fast.agent(
+        "summary_writer",
+        instruction="""
+        Write the given text to a file named summary.txt, and output which article topic is the most relevant to college students.
+        """,
+        model='passthrough',
+    )
+    @fast.agent(
+        "google_sheets_writer",
+        instruction="""
+        Based on the given text, write some key points to research on the topic to a new google spreadsheet with a title "Research on <topic>".
+        """,
+        model='passthrough',
+    )
+    @fast.chain(
+        name="topic_writer",
+        sequence=["url_fetcher", "summary_writer", "google_sheets_writer"],
+    )
+    async def chain_workflow(): # Renamed from main to avoid conflicts, and wrapped inside the test
+        async with fast.run() as agent:
+            input_url = "https://www.nytimes.com"
+            result = await agent.topic_writer.send(input_url)
+            assert result == input_url
+
+
+    # alternative syntax for above is result = agent["post_writer"].send(message)
+    # alternative syntax for above is result = agent["post_writer"].prompt()
+
+    await chain_workflow() # Call the inner function
+
+# if __name__ == "__main__":
+#     asyncio.run(main())


### PR DESCRIPTION
The chain agent wasn't passing messages correctly between agents in a normal (non-cumulative) sequence. It was sending the whole response.content list instead of just the text inside response.content[0].text.
This broke the test_chain_passthrough (added this in [workflow chain tests](https://github.com/evalstate/fast-agent/compare/main...plapagesse:fast-agent:fix/chain_passthrough_text?expand=1#diff-29543c0175a0eae9559bea74e5408fc20c9f47ef192ae829b289955169e4d506) folder) test because the final output ended up nested inside content objects instead of being the raw input string.
The fix: changed Prompt.user(response.content) to Prompt.user(response.content[0].text) to grab just the text. This makes the chain work as expected and fixes the test.

chaining basic passthrough agents 

## before: 

╭─────────────────────────────────────────────────────── (url_fetcher) [USER] ─╮
│                                                                              │
│  https://www.nytimes.com                                                     │
│                                                                              │
╰─ passthrough turn 1 ─────────────────────────────────────────────────────────╯


╭─ [ASSISTANT] (url_fetcher) ──────────────────────────────────────────────────╮
│                                                                              │
│  https://www.nytimes.com                                                     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


╭──────────────────────────────────────────────────── (summary_writer) [USER] ─╮
│                                                                              │
│  [TextContent(type='text', text='https://www.nytimes.com',                   │
│  annotations=None)]                                                          │
│                                                                              │
╰─ passthrough turn 1 ─────────────────────────────────────────────────────────╯


╭─ [ASSISTANT] (summary_writer) ───────────────────────────────────────────────╮
│                                                                              │
│  [TextContent(type='text', text='https://www.nytimes.com',                   │
│  annotations=None)]                                                          │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


╭────────────────────────────────────────────── (google_sheets_writer) [USER] ─╮
│                                                                              │
│  [TextContent(type='text', text="[TextContent(type='text',                   │
│  text='https://www.nytimes.com', annotations=None)]", annotations=None)]     │
│                                                                              │
╰─ passthrough turn 1 ─────────────────────────────────────────────────────────╯


╭─ [ASSISTANT] (google_sheets_writer) ─────────────────────────────────────────╮
│                                                                              │
│  [TextContent(type='text', text="[TextContent(type='text',                   │
│  text='https://www.nytimes.com', annotations=None)]", annotations=None)]     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯




## after: 


───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── (url_fetcher) [USER] ─╮
│                                                                                                                                                                                 │
│  https://www.nytimes.com                                                                                                                                                        │
│                                                                                                                                                                                 │
╰─ passthrough turn 1 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


╭─ [ASSISTANT] (url_fetcher) ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                 │
│  https://www.nytimes.com                                                                                                                                                        │
│                                                                                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── (summary_writer) [USER] ─╮
│                                                                                                                                                                                 │
│  https://www.nytimes.com                                                                                                                                                        │
│                                                                                                                                                                                 │
╰─ passthrough turn 1 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


╭─ [ASSISTANT] (summary_writer) ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                 │
│  https://www.nytimes.com                                                                                                                                                        │
│                                                                                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── (google_sheets_writer) [USER] ─╮
│                                                                                                                                                                                 │
│  https://www.nytimes.com                                                                                                                                                        │
│                                                                                                                                                                                 │
╰─ passthrough turn 1 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


╭─ [ASSISTANT] (google_sheets_writer) ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                 │
│  https://www.nytimes.com                                                                                                                                                        │
│                                                                                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
