### PR TITLE
Add support for the expose_agents parameter to expose specified tools to the caller

### DIFF
--- a/tests/integration/api/integration_agent.py
+++ b/tests/integration/api/integration_agent.py
@@ -16,6 +16,7 @@ fast = FastAgent("Integration Test Agent")
     name="test",  # Important: This name matches what we use in the CLI test
     instruction="You are a test agent that simply echoes back any input received.",
 )
+@fast.agent(name="test_two", instruction="You have been chosen by pansusu.")
 async def main() -> None:
     async with fast.run() as agent:
         # This executes only for interactive mode, not needed for command-line testing

--- a/tests/integration/api/test_cli_and_mcp_server.py
+++ b/tests/integration/api/test_cli_and_mcp_server.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from typing import TYPE_CHECKING
 
+from mcp import ListToolsResult
 import pytest
 
 from mcp_agent.mcp.helpers.content_helpers import get_text
@@ -166,9 +167,74 @@ async def test_agent_server_option_sse(fast_agent):
                 assert "connected" == await agent.send("connected")
                 result = await agent.send('***CALL_TOOL test_send {"message": "sse server test"}')
                 assert "sse server test" == result
+                tools_result: ListToolsResult = await agent.client.list_tools()
+                assert 2 == len(tools_result.tools)
 
         await agent_function()
 
+    finally:
+        # Terminate the server process
+        if server_proc.poll() is None:  # If still running
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_agent_server_option_sse_with_filtering(fast_agent):
+    """Test that FastAgent supports --server flag with SSE transport."""
+
+    # Start the SSE server in a subprocess
+    import asyncio
+    import os
+    import subprocess
+
+    # Get the path to the test agent
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    test_agent_path = os.path.join(test_dir, "integration_agent.py")
+
+    # Port must match what's in the fastagent.config.yaml
+    port = 8723
+
+    # Start the server process
+    server_proc = subprocess.Popen(
+        [
+            "uv",
+            "run",
+            test_agent_path,
+            "--server",
+            "--transport",
+            "sse",
+            "--port",
+            str(port),
+            "--quiet",
+            "--expose_agents test_two",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=test_dir,
+    )
+
+    try:
+        # Give the server a moment to start
+        await asyncio.sleep(3)
+
+        # Now connect to it via the configured MCP server
+        @fast_agent.agent(name="client", servers=["sse"])
+        async def agent_function():
+            async with fast_agent.run() as agent:
+                # Try connecting and sending a message
+                assert "connected" == await agent.send("connected")
+                result = await agent.send('***CALL_TOOL test_two_send {"message": "filtered"}')
+                assert "filtered" == result
+                tools_result: ListToolsResult = await agent.client.list_tools()
+                assert 1 == len(tools_result.tools)
+
+        await agent_function()
     finally:
         # Terminate the server process
         if server_proc.poll() is None:  # If still running


### PR DESCRIPTION
Add expose_agents parameter to run_with_mcp_server

This enhancement allows server administrators to control which agents are exposed to clients when running the FastAgent as an MCP server. By specifying a list of agent names in the expose_agents parameter, only those agents will be available to clients connecting to the server, improving security and resource management.
