### PR TITLE
fix consistent naming of fastagent.secrets.yaml file

### DIFF
--- a/src/mcp_agent/cli/commands/setup.py
+++ b/src/mcp_agent/cli/commands/setup.py
@@ -73,7 +73,7 @@ mcp:
 
 GITIGNORE_TEMPLATE = """
 # FastAgent secrets file
-fastagent-secrets.yaml
+fastagent.secrets.yaml
 
 # Python
 __pycache__/
@@ -215,7 +215,7 @@ def init(
         if "fastagent.secrets.yaml" in created:
             console.print("\n[yellow]Important:[/yellow] Remember to:")
             console.print(
-                "1. Add your API keys to fastagent-secrets.yaml or set OPENAI_API_KEY and ANTHROPIC_API_KEY environment variables"
+                "1. Add your API keys to fastagent.secrets.yaml or set OPENAI_API_KEY and ANTHROPIC_API_KEY environment variables"
             )
             console.print(
                 "2. Keep fastagent.secrets.yaml secure and never commit it to version control"


### PR DESCRIPTION
The PR fixes a typo in the YAML filename within the previously generated .gitignore file by the CLI. 