### PR TITLE
enhancement: allow sse_read_timeout to be configurable

### DIFF
--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -362,6 +362,19 @@
           ],
           "default": null,
           "title": "Read Timeout Seconds",
+          "description": "The timeout in seconds for the session."
+        },
+        "read_transport_sse_timeout_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "title": "Read Transport SSE Timeout Seconds",
           "description": "The timeout in seconds for the server connection."
         },
         "url": {

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -70,6 +70,9 @@ class MCPServerSettings(BaseModel):
     """The arguments for the server command."""
 
     read_timeout_seconds: int | None = None
+    """The timeout in seconds for the session."""
+
+    read_transport_sse_timeout_seconds: int = 300
     """The timeout in seconds for the server connection."""
 
     url: str | None = None

--- a/src/mcp_agent/mcp/mcp_connection_manager.py
+++ b/src/mcp_agent/mcp/mcp_connection_manager.py
@@ -271,7 +271,11 @@ class MCPConnectionManager(ContextDependent):
                 logger.debug(f"{server_name}: Creating stdio client with custom error handler")
                 return stdio_client(server_params, errlog=error_handler)
             elif config.transport == "sse":
-                return sse_client(config.url, config.headers)
+                return sse_client(
+                    config.url,
+                    config.headers,
+                    sse_read_timeout=config.read_transport_sse_timeout_seconds,
+                )
             else:
                 raise ValueError(f"Unsupported transport: {config.transport}")
 

--- a/src/mcp_agent/mcp_server_registry.py
+++ b/src/mcp_agent/mcp_server_registry.py
@@ -152,7 +152,11 @@ class ServerRegistry:
                 raise ValueError(f"URL is required for SSE transport: {server_name}")
 
             # Use sse_client to get the read and write streams
-            async with sse_client(config.url, config.headers) as (read_stream, write_stream):
+            async with sse_client(
+                config.url,
+                config.headers,
+                sse_read_timeout=config.read_transport_sse_timeout_seconds,
+            ) as (read_stream, write_stream):
                 session = client_session_factory(
                     read_stream,
                     write_stream,


### PR DESCRIPTION
Today fast agent is using default timeout for sse_client which happens to be 5 minutes. for production systems this is too low as our observation is that with 5mins of inactivity with an mcp server it becomes unusable.