### PR TITLE
Fix base url reads from ENV for Generic and OpenRouter

### DIFF
--- a/src/mcp_agent/llm/providers/augmented_llm_generic.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_generic.py
@@ -40,8 +40,8 @@ class GenericAugmentedLLM(OpenAIAugmentedLLM):
         return api_key or "ollama"
 
     def _base_url(self) -> str:
-        base_url = None
+        base_url = os.getenv("GENERIC_BASE_URL", DEFAULT_OLLAMA_BASE_URL)
         if self.context.config and self.context.config.generic:
             base_url = self.context.config.generic.base_url
 
-        return base_url if base_url else DEFAULT_OLLAMA_BASE_URL
+        return base_url

--- a/src/mcp_agent/llm/providers/augmented_llm_openrouter.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_openrouter.py
@@ -4,7 +4,7 @@ from mcp_agent.core.exceptions import ProviderKeyError
 from mcp_agent.core.request_params import RequestParams
 from mcp_agent.llm.providers.augmented_llm_openai import OpenAIAugmentedLLM
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 # No single default model for OpenRouter, users must specify full path
 DEFAULT_OPENROUTER_MODEL = None 
 
@@ -63,7 +63,7 @@ class OpenRouterAugmentedLLM(OpenAIAugmentedLLM):
 
     def _base_url(self) -> str:
         """Retrieve the OpenRouter base URL from config or use the default."""
-        base_url = OPENROUTER_BASE_URL # Default
+        base_url = os.getenv("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL)  # Default
         config = self.context.config
         
         # Check config file for override


### PR DESCRIPTION
Aligns code with the docs: https://fast-agent.ai/models/llm_providers/#generic-openai-ollama

where GENERIC_BASE_URL and OPENROUTER_BASE_URL can be used to inject base urls