### PR TITLE
feature: add support for custom model provider

### DIFF
--- a/src/mcp_agent/core/agent_types.py
+++ b/src/mcp_agent/core/agent_types.py
@@ -34,7 +34,7 @@ class AgentConfig:
     default_request_params: RequestParams | None = None
     human_input: bool = False
     agent_type: str = AgentType.BASIC.value
-
+    provider: str | None = None
     def __post_init__(self) -> None:
         """Ensure default_request_params exists with proper history setting"""
 

--- a/src/mcp_agent/core/direct_decorators.py
+++ b/src/mcp_agent/core/direct_decorators.py
@@ -90,6 +90,7 @@ def _decorator_impl(
     use_history: bool = True,
     request_params: RequestParams | None = None,
     human_input: bool = False,
+    provider: Optional[str] = None,
     **extra_kwargs,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
@@ -132,6 +133,7 @@ def _decorator_impl(
             model=model,
             use_history=use_history,
             human_input=human_input,
+            provider=provider,
         )
 
         # Update request params if provided
@@ -174,6 +176,7 @@ def agent(
     use_history: bool = True,
     request_params: RequestParams | None = None,
     human_input: bool = False,
+    provider: Optional[str] = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
     Decorator to create and register a standard agent with type-safe signature.
@@ -203,6 +206,7 @@ def agent(
         use_history=use_history,
         request_params=request_params,
         human_input=human_input,
+        provider=provider,
     )
 
 
@@ -218,6 +222,7 @@ def orchestrator(
     human_input: bool = False,
     plan_type: Literal["full", "iterative"] = "full",
     max_iterations: int = 30,
+    provider: Optional[str] = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedOrchestratorProtocol[P, R]]:
     """
     Decorator to create and register an orchestrator agent with type-safe signature.
@@ -232,7 +237,7 @@ def orchestrator(
         human_input: Whether to enable human input capabilities
         plan_type: Planning approach - "full" or "iterative"
         max_iterations: Maximum number of planning iterations
-
+        provider: Provider name
     Returns:
         A decorator that registers the orchestrator with proper type annotations
     """
@@ -259,6 +264,7 @@ def orchestrator(
             child_agents=agents,
             plan_type=plan_type,
             max_iterations=max_iterations,
+            provider=provider,
         ),
     )
 
@@ -274,6 +280,7 @@ def router(
     use_history: bool = False,
     request_params: RequestParams | None = None,
     human_input: bool = False,
+    provider: Optional[str] = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedRouterProtocol[P, R]]:
     """
     Decorator to create and register a router agent with type-safe signature.
@@ -308,6 +315,7 @@ def router(
             request_params=request_params,
             human_input=human_input,
             router_agents=agents,
+            provider=provider,
         ),
     )
 

--- a/src/mcp_agent/core/fastagent.py
+++ b/src/mcp_agent/core/fastagent.py
@@ -129,6 +129,11 @@ class FastAgent:
             default="0.0.0.0",
             help="Host address to bind to when running as a server with SSE transport",
         )
+        parser.add_argument(
+            "--provider",
+            default=None,
+            help="Provider to use for custom models",
+        )
 
         if ignore_unknown_args:
             known_args, _ = parser.parse_known_args()
@@ -241,12 +246,14 @@ class FastAgent:
                 validate_workflow_references(self.agents)
 
                 # Get a model factory function
-                def model_factory_func(model=None, request_params=None):
+                def model_factory_func(model=None, request_params=None, provider=None):
                     return get_model_factory(
                         self.context,
                         model=model,
+                        provider=provider,
                         request_params=request_params,
                         cli_model=self.args.model if hasattr(self, "args") else None,
+                        cli_provider=self.args.provider if hasattr(self, "args") else None,
                     )
 
                 # Create all agents in dependency order
@@ -445,6 +452,10 @@ class FastAgent:
         self.args.model = None
         if hasattr(original_args, "model"):
             self.args.model = original_args.model
+            
+        self.args.provider = None
+        if hasattr(original_args, "provider"):
+            self.args.provider = original_args.provider
 
         # Run the application, which will detect the server flag and start server mode
         async with self.run():


### PR DESCRIPTION
This change adds a new `provider` parameter to the agent configuration, allowing users to specify custom model providers. This is particularly useful when working with third-party cloud platforms that support OpenAI-compatible APIs but use different model naming conventions.

Key changes:
- Added `provider` parameter to model factory function
- Support provider specification through CLI and agent config
- Enable custom provider override for model selection

This enhancement makes the agent more flexible and compatible with various OpenAI-compatible API providers, such as:
- Third-party cloud platforms
- Self-hosted model services
- Custom model deployments

Example usage:
```python
@agent(model="qwen-vl-max-latest", provider="openai")
async def my_agent():
    # Agent implementation

CLI: uv run web.py --provider openai
```
```