### PR TITLE
Add Tool Filtering to Agent Config

### DIFF
--- a/src/mcp_agent/agents/base_agent.py
+++ b/src/mcp_agent/agents/base_agent.py
@@ -82,6 +82,8 @@ class BaseAgent(MCPAggregator, AgentProtocol):
             server_names=self.config.servers,
             connection_persistence=connection_persistence,
             name=self.config.name,
+            include_tools=self.config.include_tools,
+            exclude_tools=self.config.exclude_tools,
             **kwargs,
         )
 

--- a/src/mcp_agent/core/agent_types.py
+++ b/src/mcp_agent/core/agent_types.py
@@ -34,6 +34,8 @@ class AgentConfig:
     default_request_params: RequestParams | None = None
     human_input: bool = False
     agent_type: str = AgentType.BASIC.value
+    include_tools: List[str] = dataclasses.field(default_factory=list)
+    exclude_tools: List[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Ensure default_request_params exists with proper history setting"""

--- a/src/mcp_agent/core/direct_decorators.py
+++ b/src/mcp_agent/core/direct_decorators.py
@@ -90,6 +90,8 @@ def _decorator_impl(
     use_history: bool = True,
     request_params: RequestParams | None = None,
     human_input: bool = False,
+    include_tools: List[str] = [],
+    exclude_tools: List[str] = [],
     **extra_kwargs,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
@@ -104,6 +106,8 @@ def _decorator_impl(
         use_history: Whether to maintain conversation history
         request_params: Additional request parameters for the LLM
         human_input: Whether to enable human input capabilities
+        include_tools: Optional list of tool names. When provided, only the listed tools will be registered. Tool names must be prefixed with the server name: "{server_name}-{tool_name}". Tools in exclude_tools will still be excluded.
+        exclude_tools: Optional list of tool names. When provided, the listed tools will not be registered. Tool names must be prefixed with the server name: "{server_name}-{tool_name}". Excludes any tools also listed in include_tools.
         **extra_kwargs: Additional agent/workflow-specific parameters
     """
 
@@ -132,6 +136,8 @@ def _decorator_impl(
             model=model,
             use_history=use_history,
             human_input=human_input,
+            include_tools=include_tools,
+            exclude_tools=exclude_tools,
         )
 
         # Update request params if provided
@@ -174,6 +180,8 @@ def agent(
     use_history: bool = True,
     request_params: RequestParams | None = None,
     human_input: bool = False,
+    include_tools: List[str] = [],
+    exclude_tools: List[str] = [],
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
     Decorator to create and register a standard agent with type-safe signature.
@@ -187,6 +195,8 @@ def agent(
         use_history: Whether to maintain conversation history
         request_params: Additional request parameters for the LLM
         human_input: Whether to enable human input capabilities
+        include_tools: List of tool names (including server name) to include (if empty, include all tools)
+        exclude_tools: List of tool names (including server name) to exclude (if empty, exclude none)
 
     Returns:
         A decorator that registers the agent with proper type annotations
@@ -203,6 +213,8 @@ def agent(
         use_history=use_history,
         request_params=request_params,
         human_input=human_input,
+        include_tools=include_tools,
+        exclude_tools=exclude_tools,
     )
 
 


### PR DESCRIPTION
This PR adds support for filtering tools available to an agent via `include_tools` and `exclude_tools` parameters.

## Summary

- New `AgentConfig` fields: `include_tools` and `exclude_tools` (lists of `{server}-{tool}` strings)
- Tools are filtered at initialization; exclusion takes precedence over inclusion
- Makes it easy to restrict or customize tool access per agent

## Examples

```python
@agent(
    name="search_agent",
    servers=["search-api"],
    include_tools=["search-api-web_search"]
)
```

```python
@agent(
    name="safe_file_agent",
    servers=["file-system"],
    exclude_tools=["file-system-delete_file"]
)
```

Useful for limiting tool access in multi-agent setups or when integrating with third-party tool servers.