### PR TITLE
Fix ValueError when parsing empty arguments in tool calls

### DIFF
--- a/src/mcp_agent/llm/providers/augmented_llm_openai.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_openai.py
@@ -222,7 +222,7 @@ class OpenAIAugmentedLLM(AugmentedLLM[ChatCompletionMessageParam, ChatCompletion
                         method="tools/call",
                         params=CallToolRequestParams(
                             name=tool_call.function.name,
-                            arguments=from_json(tool_call.function.arguments, allow_partial=True),
+                            arguments={} if not tool_call.function.arguments or tool_call.function.arguments.strip() == '' else from_json(tool_call.function.arguments, allow_partial=True),
                         ),
                     )
                     result = await self.call_tool(tool_call_request, tool_call.id)


### PR DESCRIPTION
## Issue Description

FastAgent crashes with the following error when a tool call contains empty arguments:

```
ValueError: EOF while parsing a value at line 1 column 0
```

The error occurs in the OpenAI completion function when trying to parse empty arguments from a tool call:

```python
arguments=from_json(tool_call.function.arguments, allow_partial=True),
```

When `tool_call.function.arguments` is an empty string, the `from_json` function from `pydantic_core` throws an error because it can't parse an empty string as valid JSON. This is a general issue that can affect any tool call with empty arguments, not just specific tools.



## Fix Implementation

This PR adds a check for empty arguments before calling `from_json`. If the arguments string is empty or contains only whitespace, it returns an empty dictionary `{}` instead of trying to parse it:

```python
arguments={} if not tool_call.function.arguments or tool_call.function.arguments.strip() == '' else from_json(tool_call.function.arguments, allow_partial=True),
```

This ensures that when the model generates a tool call with empty arguments, FastAgent passes an empty dictionary to the MCP server instead of throwing an error.

## Steps to Reproduce

This issue can be reproduced in any scenario where a model might generate a tool call with empty arguments. One specific way to reproduce it is:

1. Set up a FastAgent application with an MCP server that accepts tool calls
2. Create an agent that uses the [Think Tool MCP server](https://github.com/DannyMac180/mcp-think-tool):

```python
@fast.agent(
    instruction="You are a helpful AI Agent.",
    servers=["fetch", "think"])
```
In fastagent.config.yaml:
```yaml
# MCP Servers
mcp:
    servers:
        think:
            command: "python"
            args: ["/path_to/mcp-think-tool"]
```

3. Run the agent and prompt it to use any tool
4. Occasionally, the model will generate a tool call with empty arguments, causing the application to crash

## Steps to Verify

1. Apply the fix to `src/mcp_agent/llm/providers/augmented_llm_openai.py`
2. Run the same agent configuration as above
3. Prompt the agent to use any tool
4. The application should now handle empty arguments gracefully without crashing, even if the model generates a tool call with empty arguments

## Additional Context

This is a defensive programming approach that makes the code more robust by handling edge cases gracefully. It allows tool calls to proceed even when the model generates empty arguments, and then the MCP server can handle the validation of required parameters.

Fixing this in FastAgent rather than in individual MCP servers is a more robust approach because:

1. It addresses the issue at its source in the JSON parsing logic
2. It makes FastAgent resilient to empty arguments for all tool calls, not just specific tools
3. It follows the principle of defensive programming by gracefully handling edge cases
4. It maintains compatibility with all existing MCP server implementations
