### PR TITLE
Fix: Handle missing args in MCP server configuration

### DIFF
--- a/src/mcp_agent/mcp/mcp_connection_manager.py
+++ b/src/mcp_agent/mcp/mcp_connection_manager.py
@@ -262,7 +262,7 @@ class MCPConnectionManager(ContextDependent):
             if config.transport == "stdio":
                 server_params = StdioServerParameters(
                     command=config.command,
-                    args=config.args,
+                    args=config.args if config.args is not None else [],
                     env={**get_default_environment(), **(config.env or {})},
                 )
                 # Create custom error handler to ensure all output is captured


### PR DESCRIPTION
## Issue Description

FastAgent crashes with the following validation error when the 'args' component is omitted from the YAML configuration file for an MCP server:

```
1 validation error for StdioServerParameters
args
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/list_type
```

The error occurs in the `mcp_connection_manager.py` file when creating a `StdioServerParameters` object:

```python
server_params = StdioServerParameters(
    command=config.command,
    args=config.args,
    env={**get_default_environment(), **(config.env or {})},
)
```

When the 'args' field is missing in the YAML configuration, `config.args` is `None`, but the `StdioServerParameters` class expects it to be a list. This is causing the validation error and preventing FastAgent from starting up properly.

## Fix Implementation

This PR adds a simple check to provide a default empty list when `config.args` is `None`:

```python
server_params = StdioServerParameters(
    command=config.command,
    args=config.args if config.args is not None else [],
    env={**get_default_environment(), **(config.env or {})},
)
```

This ensures that when the 'args' field is omitted from the YAML configuration, an empty list is passed to `StdioServerParameters` instead of `None`, preventing the validation error.

## Steps to Reproduce

This issue can be reproduced with any FastAgent configuration that omits the 'args' field for an MCP server:

1. Create a FastAgent project with a configuration file (`fastagent.config.yaml`) that omits the 'args' field for an MCP server:

```yaml
mcp:
    servers:
        think:
            command: "/path/to/think-tool"
            # args field is intentionally omitted
```

2. Run the FastAgent application:

```bash
python agent.py
```

3. The application will crash with the validation error mentioned above.

## Steps to Verify

1. Apply the fix to `src/mcp_agent/mcp/mcp_connection_manager.py`
2. Create two test configurations:
   
   a. A configuration with an MCP server that doesn't need arguments:
   ```yaml
   mcp:
       servers:
           think:
               command: "/path/to/standalone-tool"
               # args field is intentionally omitted
   ```
   
   b. A configuration with an MCP server that does need arguments but doesn't have them specified:
   ```yaml
   mcp:
       servers:
           think:
               command: "python"
               # args field is intentionally omitted, but this server needs it
   ```

3. Run the FastAgent application with both configurations:
   - With configuration (a), the application should start up normally and function correctly
   - With configuration (b), the application will start up without a validation error but may hang when trying to use the server, as the server needs arguments to function properly

## Additional Context

This fix follows the principle of defensive programming by gracefully handling the case where the 'args' field is omitted from the YAML configuration. Instead of failing with a validation error, FastAgent now proceeds with an empty list of arguments.

We deliberately chose to allow FastAgent to continue loading even when the 'args' field is missing, rather than throwing a configuration error, because:

1. There are legitimate use cases where an MCP server doesn't need any arguments. For example, standalone executables or scripts that don't require command-line arguments.

2. This approach maintains backward compatibility with existing configurations and allows for more flexibility in server setups.

3. It follows the principle of being "lenient in what you accept, strict in what you produce" - we accept configurations without 'args' but ensure the internal representation is always valid.

During testing, we confirmed that:
- FastAgent works correctly with MCP servers that don't need arguments when the 'args' field is omitted
- FastAgent starts up without errors for servers that do need arguments but don't have them specified, although it will hang when trying to use those servers (which is expected behavior)

This is a minimal, focused change that addresses the specific issue without introducing unnecessary complexity or changing the behavior of well-formed configurations.
