### PR TITLE
Fix syntax errors in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ If the Generator has `use_history` off, the previous iteration is returned when 
 
 ```python
 @fast.evaluator_optimizer(
-  name="researcher"
-  generator="web_searcher"
-  evaluator="quality_assurance"
-  min_rating="EXCELLENT"
+  name="researcher",
+  generator="web_searcher",
+  evaluator="quality_assurance",
+  min_rating="EXCELLENT",
   max_refinements=3
 )
 
@@ -230,8 +230,8 @@ Routers use an LLM to assess a message, and route it to the most appropriate Age
 
 ```python
 @fast.router(
-  name="route"
-  agents["agent1","agent2","agent3"]
+  name="route",
+  agents=["agent1","agent2","agent3"]
 )
 ```
 
@@ -243,7 +243,7 @@ Given a complex task, the Orchestrator uses an LLM to generate a plan to divide 
 
 ```python
 @fast.orchestrator(
-  name="orchestrate"
+  name="orchestrate",
   agents=["task1","task2","task3"]
 )
 ```
@@ -283,7 +283,7 @@ agent["greeter"].send("Good Evening!")          # Dictionary access is supported
   servers=["filesystem"],                # list of MCP Servers for the agent
   model="o3-mini.high",                  # specify a model for the agent
   use_history=True,                      # agent maintains chat history
-  request_params=RequestParams(temperature= 0.7)), # additional parameters for the LLM (or RequestParams())
+  request_params=RequestParams(temperature= 0.7), # additional parameters for the LLM (or RequestParams())
   human_input=True,                      # agent can request human input
 )
 ```
@@ -295,7 +295,7 @@ agent["greeter"].send("Good Evening!")          # Dictionary access is supported
   name="chain",                          # name of the chain
   sequence=["agent1", "agent2", ...],    # list of agents in execution order
   instruction="instruction",             # instruction to describe the chain for other workflows
-  cumulative=False                       # whether to accumulate messages through the chain
+  cumulative=False,                      # whether to accumulate messages through the chain
   continue_with_final=True,              # open chat with agent at end of chain after prompting
 )
 ```


### PR DESCRIPTION
This PR fixes syntax errors in the Python code examples within `README.md`:

- Added missing commas in decorators.
- Fixed incorrect list syntax.
- Corrected misplaced parentheses in the agent definition.

Now the snippets can be directly copied without syntax issues.