### PR TITLE
LiteLLM+LangFuse Support: Enhancing how request_params are overridden

### DIFF
--- a/src/mcp_agent/llm/augmented_llm.py
+++ b/src/mcp_agent/llm/augmented_llm.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Generic,
     List,
     Optional,
@@ -59,7 +60,36 @@ if TYPE_CHECKING:
 HUMAN_INPUT_TOOL_NAME = "__human_input__"
 
 
-class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT, MessageT]):
+def deep_merge(dict1: Dict[Any, Any], dict2: Dict[Any, Any]) -> Dict[Any, Any]:
+    """
+    Recursively merges `dict2` into `dict1` in place.
+
+    If a key exists in both dictionaries and their values are dictionaries,
+    the function merges them recursively. Otherwise, the value from `dict2`
+    overwrites or is added to `dict1`.
+
+    Args:
+        dict1 (Dict): The dictionary to be updated.
+        dict2 (Dict): The dictionary to merge into `dict1`.
+
+    Returns:
+        Dict: The updated `dict1`.
+    """
+    for key in dict2:
+        if (
+            key in dict1
+            and isinstance(dict1[key], dict)
+            and isinstance(dict2[key], dict)
+        ):
+            deep_merge(dict1[key], dict2[key])
+        else:
+            dict1[key] = dict2[key]
+    return dict1
+
+
+class AugmentedLLM(
+    ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT, MessageT]
+):
     # Common parameter names used across providers
     PARAM_MESSAGES = "messages"
     PARAM_MODEL = "model"
@@ -357,8 +387,10 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
     ) -> RequestParams:
         """Merge default and provided request parameters"""
 
-        merged = default_params.model_dump()
-        merged.update(provided_params.model_dump(exclude_unset=True))
+        merged = deep_merge(
+            default_params.model_dump(),
+            provided_params.model_dump(exclude_unset=True),
+        )
         final_params = RequestParams(**merged)
 
         return final_params


### PR DESCRIPTION
This enhancement performs a recursive merge of ``request_params`` set initially on the agent with parameters passed in during an execution step. Consider the example below that adds a session identifier at runtime to a specific step in the process:

```python
@app.agent(
    name="Generator",
    request_params=RequestParams(
        maxTokens=DEFAULT_MAX_TOKENS,
        use_history=False,
        metadata={
            "metadata": {
                "trace_name": "Novelist",
                "tags": TAGS,
            },
        },
    )
async def main() -> None:
  async with app.run() as agent:
    # ... Do something here
   # Generate a unique session identifier for the next steps...
    session_id = str(uuid4()).replace("-", "")

    # Now pass that session identifier to the agent...
    result = agent.Optimizer.structured(
      prompt,
      SomePydanticObject,
      request_params=RequestParams(
      metadata={"metadata": {"session_id": session_id}}
    )
```

Prior to this update, the inner ``metadata`` would be set to ``{"session_id": session_id}`` and basically would overwrite the default values set above on the agent. With this update ``session_id`` would be merged and the ``metadata`` would get set to:

```python
metadata = {
  "metadata": {
    "trace_name": "Novelist",
    "tags": TAGS,
    "session_id": session_id,
  }
}
```

The specific use case I ran into was that I am using LiteLLM and LangFuse. It is easy enough to set ``metadata`` and pass in the specifics needed for tracing when calling ``@app.agent``. However, there are some situations - like adding a session identifier or other execution specific details - where it isn't feasible to set these globally when initializing the agent decorator, and doing a "deep merge" that overrides the agent defaults is needed.

Note that although this is a small change and likely the behavior most folks would expect, it does introduce a potentially breaking change for any clients that rely on the "shallow" merge.