### PR TITLE
Added MCP server `cwd` setting

### DIFF
--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -93,6 +93,9 @@ class MCPServerSettings(BaseModel):
     sampling: MCPSamplingSettings | None = None
     """Sampling settings for this Client/Server pair"""
 
+    cwd: str | None = None
+    """Working directory for the executed server command."""
+
 
 class MCPSettings(BaseModel):
     """Configuration for all MCP servers."""

--- a/src/mcp_agent/mcp/mcp_connection_manager.py
+++ b/src/mcp_agent/mcp/mcp_connection_manager.py
@@ -264,6 +264,7 @@ class MCPConnectionManager(ContextDependent):
                     command=config.command,
                     args=config.args if config.args is not None else [],
                     env={**get_default_environment(), **(config.env or {})},
+                    cwd=config.cwd,
                 )
                 # Create custom error handler to ensure all output is captured
                 error_handler = get_stderr_handler(server_name)

--- a/src/mcp_agent/mcp_server_registry.py
+++ b/src/mcp_agent/mcp_server_registry.py
@@ -128,6 +128,7 @@ class ServerRegistry:
                 command=config.command,
                 args=config.args,
                 env={**get_default_environment(), **(config.env or {})},
+                cwd=config.cwd,
             )
 
             # Create a stderr handler that logs to our application logger


### PR DESCRIPTION
Allows MCP server yaml files to specify a `cwd` setting, which is just passed through to the `StdioServerParameters` class.

My specific use case was launching tool servers that exist elsewhere on disk, e.g.,:
1. fast-agent app is in /home/work/app
2. MCP tool server I'm developing is in /home/work/toolbox1
3. Configure fastagent.config.yaml to use my `toolbox1` tools, running from `/home/work/toolbox1`
4. Run fast-agent app
5. Make some edits to toolbox1
6. Goto 4...

Example usage:

fastagent.config.yaml:
```yaml
mcp:
  servers:
    toolbox1:
      command: "node"
      args: ["dist/index.js"]
      cwd: "/home/work/toolbox1"
```