### PR TITLE
feat(anthropic): correctly implement prompt caching for messages api

### DIFF
--- a/src/mcp_agent/core/request_params.py
+++ b/src/mcp_agent/core/request_params.py
@@ -52,3 +52,12 @@ class RequestParams(CreateMessageRequestParams):
     """
     Optional dictionary of template variables for dynamic templates. Currently only works for TensorZero inference backend
     """
+
+    prompt_caching: bool = Field(
+        default=False, description="Enable prompt caching for supported LLM providers."
+    )
+    """
+    Enable prompt caching if the underlying LLM provider supports it.
+    For Anthropic, this adds 'cache_control': {'type': 'ephemeral'} to relevant message parts.
+    Behavior for other providers will depend on their specific caching mechanisms.
+    """

--- a/src/mcp_agent/llm/augmented_llm.py
+++ b/src/mcp_agent/llm/augmented_llm.py
@@ -95,8 +95,10 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
     PARAM_USE_HISTORY = "use_history"
     PARAM_MAX_ITERATIONS = "max_iterations"
     PARAM_TEMPLATE_VARS = "template_vars"
+    PARAM_PROMPT_CACHING = "prompt_caching"
+
     # Base set of fields that should always be excluded
-    BASE_EXCLUDE_FIELDS = {PARAM_METADATA}
+    BASE_EXCLUDE_FIELDS = {PARAM_METADATA, PARAM_PROMPT_CACHING}
 
     """
     The basic building block of agentic systems is an LLM enhanced with augmentations
@@ -361,16 +363,28 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
         # Start with base arguments
         arguments = base_args.copy()
 
-        # Use provided exclude_fields or fall back to base exclusions
-        exclude_fields = exclude_fields or self.BASE_EXCLUDE_FIELDS.copy()
+        # Combine base exclusions with provider-specific exclusions
+        final_exclude_fields = self.BASE_EXCLUDE_FIELDS.copy()
+        if exclude_fields:
+            final_exclude_fields.update(exclude_fields)
 
         # Add all fields from params that aren't explicitly excluded
-        params_dict = request_params.model_dump(exclude=exclude_fields)
+        # Ensure model_dump only includes set fields if that's the desired behavior,
+        # or adjust exclude_unset=True/False as needed.
+        # Default Pydantic v2 model_dump is exclude_unset=False
+        params_dict = request_params.model_dump(exclude=final_exclude_fields)
+
         for key, value in params_dict.items():
+            # Only add if not None and not already in base_args (base_args take precedence)
+            # or if None is a valid value for the provider, this logic might need adjustment.
             if value is not None and key not in arguments:
+                arguments[key] = value
+            elif value is not None and key in arguments and arguments[key] is None:
+                # Allow overriding a None in base_args with a set value from params
                 arguments[key] = value
 
         # Finally, add any metadata fields as a last layer of overrides
+        # This ensures metadata can override anything previously set if keys conflict.
         if request_params.metadata:
             arguments.update(request_params.metadata)
 

--- a/src/mcp_agent/llm/augmented_llm_slow.py
+++ b/src/mcp_agent/llm/augmented_llm_slow.py
@@ -1,0 +1,42 @@
+import asyncio
+from typing import Any, List, Optional, Union
+
+from mcp_agent.llm.augmented_llm import (
+    MessageParamT,
+    RequestParams,
+)
+from mcp_agent.llm.augmented_llm_passthrough import PassthroughLLM
+from mcp_agent.llm.provider_types import Provider
+from mcp_agent.mcp.prompt_message_multipart import PromptMessageMultipart
+
+
+class SlowLLM(PassthroughLLM):
+    """
+    A specialized LLM implementation that sleeps for 3 seconds before responding like PassthroughLLM.
+
+    This is useful for testing scenarios where you want to simulate slow responses
+    or for debugging timing-related issues in parallel workflows.
+    """
+
+    def __init__(
+        self, provider=Provider.FAST_AGENT, name: str = "Slow", **kwargs: dict[str, Any]
+    ) -> None:
+        super().__init__(name=name, provider=provider, **kwargs)
+
+    async def generate_str(
+        self,
+        message: Union[str, MessageParamT, List[MessageParamT]],
+        request_params: Optional[RequestParams] = None,
+    ) -> str:
+        """Sleep for 3 seconds then return the input message as a string."""
+        await asyncio.sleep(3)
+        return await super().generate_str(message, request_params)
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: List["PromptMessageMultipart"],
+        request_params: RequestParams | None = None,
+    ) -> PromptMessageMultipart:
+        """Sleep for 3 seconds then apply prompt like PassthroughLLM."""
+        await asyncio.sleep(3)
+        return await super()._apply_prompt_provider_specific(multipart_messages, request_params)

--- a/src/mcp_agent/llm/model_factory.py
+++ b/src/mcp_agent/llm/model_factory.py
@@ -8,6 +8,7 @@ from mcp_agent.core.exceptions import ModelConfigError
 from mcp_agent.core.request_params import RequestParams
 from mcp_agent.llm.augmented_llm_passthrough import PassthroughLLM
 from mcp_agent.llm.augmented_llm_playback import PlaybackLLM
+from mcp_agent.llm.augmented_llm_slow import SlowLLM
 from mcp_agent.llm.provider_types import Provider
 from mcp_agent.llm.providers.augmented_llm_anthropic import AnthropicAugmentedLLM
 from mcp_agent.llm.providers.augmented_llm_azure import AzureOpenAIAugmentedLLM
@@ -29,6 +30,7 @@ LLMClass = Union[
     Type[OpenAIAugmentedLLM],
     Type[PassthroughLLM],
     Type[PlaybackLLM],
+    Type[SlowLLM],
     Type[DeepSeekAugmentedLLM],
     Type[OpenRouterAugmentedLLM],
     Type[TensorZeroAugmentedLLM],
@@ -73,6 +75,7 @@ class ModelFactory:
     DEFAULT_PROVIDERS = {
         "passthrough": Provider.FAST_AGENT,
         "playback": Provider.FAST_AGENT,
+        "slow": Provider.FAST_AGENT,
         "gpt-4o": Provider.OPENAI,
         "gpt-4o-mini": Provider.OPENAI,
         "gpt-4.1": Provider.OPENAI,
@@ -139,6 +142,7 @@ class ModelFactory:
     # This overrides the provider-based class selection
     MODEL_SPECIFIC_CLASSES: Dict[str, LLMClass] = {
         "playback": PlaybackLLM,
+        "slow": SlowLLM,
     }
 
     @classmethod

--- a/tests/integration/sampling/fastagent.config.yaml
+++ b/tests/integration/sampling/fastagent.config.yaml
@@ -23,7 +23,11 @@ mcp:
       args: ["run", "sampling_test_server.py"]
       sampling:
         model: "passthrough"
-    
+    slow_sampling:
+      command: "uv"
+      args: ["run", "sampling_test_server.py"]
+      sampling:
+        model: "slow"
     sampling_test_no_config:
       command: "uv"
       args: ["run", "sampling_test_server.py"]

--- a/tests/integration/sampling/live.py
+++ b/tests/integration/sampling/live.py
@@ -7,11 +7,14 @@ fast = FastAgent("FastAgent Example")
 
 
 # Define the agent
-@fast.agent(servers=["sampling_test"])
+@fast.agent(servers=["sampling_test", "slow_sampling"])
 async def main():
     # use the --model command line switch or agent arguments to change model
     async with fast.run() as agent:
         result = await agent.send('***CALL_TOOL sampling_test-sample {"to_sample": "123foo"}')
+        print(f"RESULT: {result}")
+
+        result = await agent.send('***CALL_TOOL slow_sampling-sample_parallel')
         print(f"RESULT: {result}")
 
 


### PR DESCRIPTION
This PR addresses an issue with Anthropic's prompt caching implementation.

**Changes Made:**

*   Modified `src/mcp_agent/llm/providers/augmented_llm_anthropic.py` to correctly apply the `cache_control` parameter.
*   Previously, `cache_control` was attempted as a top-level parameter or incorrectly added to message objects, leading to API errors.
*   The updated code now adds `cache_control: {"type": "ephemeral"}` to the last content block of the current user's message when the `prompt_caching` flag in `RequestParams` is true.
*   This ensures that the system prompt, any defined tools, and all preceding messages in the conversation are part of the cached prefix, up to and including the marked block, aligning with Anthropic's API documentation.

**Reasoning:**

The Anthropic API expects `cache_control` to be part of a specific content block within the `tools`, `system`, or `messages` arrays to define a cache breakpoint. This change ensures compliance with the API specification, resolving errors like:
    *   `messages.X.cache_control: Extra inputs are not permitted`
    *   `Messages.create() got an unexpected keyword argument 'cache_control'`

This fix enables effective prompt caching for Anthropic models, improving performance and reducing costs for repetitive tasks or prompts with consistent elements.