### PR TITLE
Modify separator to use ':' instead of '-'

### DIFF
--- a/src/mcp_agent/mcp/common.py
+++ b/src/mcp_agent/mcp/common.py
@@ -3,7 +3,7 @@ Common constants and utilities shared between modules to avoid circular imports.
 """
 
 # Constants
-SEP = "-"
+SEP = ":"
 
 
 def create_namespaced_name(server_name: str, resource_name: str) -> str:


### PR DESCRIPTION
'-' is a common symbol used in names. This means that when someone names their mcp server as 'mcp-server', the entire workflow of fastagent fails as it separates the namespaced tools/prompts/resources wrongly. Hence the suggestion to use an uncommon separator such as ':'.