### PR TITLE
Fix: Pass include_request parameter to ParallelAgent constructor

### DIFF
--- a/src/mcp_agent/core/direct_factory.py
+++ b/src/mcp_agent/core/direct_factory.py
@@ -237,6 +237,7 @@ async def create_agents_by_type(
                     context=app_instance.context,
                     fan_in_agent=fan_in_agent,
                     fan_out_agents=fan_out_agents,
+                    include_request=agent_data.get("include_request", True),
                 )
                 await parallel.initialize()
                 result_agents[name] = parallel

--- a/tests/integration/workflow/parallel/test_parallel_agent.py
+++ b/tests/integration/workflow/parallel/test_parallel_agent.py
@@ -63,3 +63,72 @@ foo
             assert expected == await agent.parallel.send("foo")
 
     await agent_function()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_parallel_include_request_false(fast_agent):
+    """Test that include_request=False prevents original request from being sent to fan_in agent."""
+    fast = fast_agent
+
+    @fast.agent(name="fan_out_1")
+    @fast.agent(name="fan_out_2")
+    @fast.agent(name="fan_in")
+    @fast.parallel(
+        name="parallel_no_request",
+        fan_out=["fan_out_1", "fan_out_2"],
+        fan_in="fan_in",
+        include_request=False
+    )
+    async def agent_function():
+        async with fast.run() as agent:
+            # When include_request=False, the fan_in should only receive the responses,
+            # not the original request
+            expected: str = """<fastagent:response agent="fan_out_1">
+foo
+</fastagent:response>
+
+<fastagent:response agent="fan_out_2">
+foo
+</fastagent:response>"""
+            result = await agent.parallel_no_request.send("foo")
+            assert expected == result
+
+    await agent_function()
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_parallel_include_request_true(fast_agent):
+    """Test that include_request=True includes original request in fan_in agent input."""
+    fast = fast_agent
+
+    @fast.agent(name="fan_out_1")
+    @fast.agent(name="fan_out_2")
+    @fast.agent(name="fan_in")
+    @fast.parallel(
+        name="parallel_with_request",
+        fan_out=["fan_out_1", "fan_out_2"],
+        fan_in="fan_in",
+        include_request=True
+    )
+    async def agent_function():
+        async with fast.run() as agent:
+            # When include_request=True, the fan_in should receive both the original request
+            # and the responses from fan_out agents
+            expected: str = """The following request was sent to the agents:
+
+<fastagent:request>
+foo
+</fastagent:request>
+
+<fastagent:response agent="fan_out_1">
+foo
+</fastagent:response>
+
+<fastagent:response agent="fan_out_2">
+foo
+</fastagent:response>"""
+            result = await agent.parallel_with_request.send("foo")
+            assert expected == result
+
+    await agent_function()


### PR DESCRIPTION
The `include_request` parameter from the `@fast.parallel` decorator was not being passed to the `ParallelAgent` constructor, causing it to always default to `True` regardless of the decorator setting.

- Fix: Add missing `include_request` parameter in `direct_factory.py`
- Test: Add tests to verify `include_request` behavior

Fixes issue where setting `include_request=False` had no effect.

Files Changed:
`src/mcp_agent/core/direct_factory.py`
`tests/integration/workflow/parallel/test_parallel_agent.py`