### PR TITLE
Add `api_key` argument to specify API KEY when creating agents

### DIFF
--- a/src/mcp_agent/core/agent_types.py
+++ b/src/mcp_agent/core/agent_types.py
@@ -38,6 +38,7 @@ class AgentConfig:
     agent_type: AgentType = AgentType.BASIC
     default: bool = False
     elicitation_handler: ElicitationFnT | None = None
+    api_key: str | None = None
 
     def __post_init__(self):
         """Ensure default_request_params exists with proper history setting"""

--- a/src/mcp_agent/core/direct_decorators.py
+++ b/src/mcp_agent/core/direct_decorators.py
@@ -138,6 +138,7 @@ def _decorator_impl(
             human_input=human_input,
             default=default,
             elicitation_handler=extra_kwargs.get("elicitation_handler"),
+            api_key=extra_kwargs.get("api_key"),
         )
 
         # Update request params if provided
@@ -182,6 +183,7 @@ def agent(
     human_input: bool = False,
     default: bool = False,
     elicitation_handler: Optional[ElicitationFnT] = None,
+    api_key: str | None = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
     Decorator to create and register a standard agent with type-safe signature.
@@ -215,6 +217,7 @@ def agent(
         human_input=human_input,
         default=default,
         elicitation_handler=elicitation_handler,
+        api_key=api_key,
     )
 
 
@@ -232,6 +235,7 @@ def custom(
     human_input: bool = False,
     default: bool = False,
     elicitation_handler: Optional[ElicitationFnT] = None,
+    api_key: str | None = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
     Decorator to create and register a standard agent with type-safe signature.
@@ -265,6 +269,7 @@ def custom(
         agent_class=cls,
         default=default,
         elicitation_handler=elicitation_handler,
+        api_key=api_key,
     )
 
 
@@ -288,6 +293,7 @@ def orchestrator(
     plan_type: Literal["full", "iterative"] = "full",
     plan_iterations: int = 5,
     default: bool = False,
+    api_key: str | None = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedOrchestratorProtocol[P, R]]:
     """
     Decorator to create and register an orchestrator agent with type-safe signature.
@@ -326,6 +332,7 @@ def orchestrator(
             plan_type=plan_type,
             plan_iterations=plan_iterations,
             default=default,
+            api_key=api_key,
         ),
     )
 
@@ -345,6 +352,7 @@ def router(
     elicitation_handler: Optional[
         ElicitationFnT
     ] = None,  ## exclude from docs, decide whether allowable
+    api_key: str | None = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedRouterProtocol[P, R]]:
     """
     Decorator to create and register a router agent with type-safe signature.
@@ -383,6 +391,7 @@ def router(
             default=default,
             router_agents=agents,
             elicitation_handler=elicitation_handler,
+            api_key=api_key,
         ),
     )
 

--- a/src/mcp_agent/core/direct_factory.py
+++ b/src/mcp_agent/core/direct_factory.py
@@ -150,7 +150,11 @@ async def create_agents_by_type(
 
                 # Attach LLM to the agent
                 llm_factory = model_factory_func(model=config.model)
-                await agent.attach_llm(llm_factory, request_params=config.default_request_params)
+                await agent.attach_llm(
+                    llm_factory,
+                    request_params=config.default_request_params,
+                    api_key=config.api_key
+                )
                 result_agents[name] = agent
 
             elif agent_type == AgentType.CUSTOM:
@@ -165,7 +169,11 @@ async def create_agents_by_type(
 
                 # Attach LLM to the agent
                 llm_factory = model_factory_func(model=config.model)
-                await agent.attach_llm(llm_factory, request_params=config.default_request_params)
+                await agent.attach_llm(
+                    llm_factory,
+                    request_params=config.default_request_params,
+                    api_key=config.api_key
+                )
                 result_agents[name] = agent
 
             elif agent_type == AgentType.ORCHESTRATOR:
@@ -200,7 +208,9 @@ async def create_agents_by_type(
                 # Attach LLM to the orchestrator
                 llm_factory = model_factory_func(model=config.model)
                 await orchestrator.attach_llm(
-                    llm_factory, request_params=config.default_request_params
+                    llm_factory,
+                    request_params=config.default_request_params,
+                    api_key=config.api_key
                 )
 
                 result_agents[name] = orchestrator
@@ -261,7 +271,11 @@ async def create_agents_by_type(
 
                 # Attach LLM to the router
                 llm_factory = model_factory_func(model=config.model)
-                await router.attach_llm(llm_factory, request_params=config.default_request_params)
+                await router.attach_llm(
+                    llm_factory,
+                    request_params=config.default_request_params,
+                    api_key=config.api_key
+                )
                 result_agents[name] = router
 
             elif agent_type == AgentType.CHAIN:

--- a/src/mcp_agent/llm/augmented_llm.py
+++ b/src/mcp_agent/llm/augmented_llm.py
@@ -123,6 +123,7 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
         ] = BasicFormatConverter,
         context: Optional["Context"] = None,
         model: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: dict[str, Any],
     ) -> None:
         """
@@ -172,6 +173,8 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
 
         self.type_converter = type_converter
         self.verb = kwargs.get("verb")
+
+        self._init_api_key = api_key
 
         # Initialize usage tracking
         self.usage_accumulator = UsageAccumulator()
@@ -692,6 +695,9 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
         return self._message_history
 
     def _api_key(self):
+        if self._init_api_key:
+            return self._init_api_key
+
         from mcp_agent.llm.provider_key_manager import ProviderKeyManager
 
         assert self.provider

--- a/src/mcp_agent/mcp/mcp_agent_client_session.py
+++ b/src/mcp_agent/mcp/mcp_agent_client_session.py
@@ -78,6 +78,8 @@ class MCPAgentClientSession(ClientSession, ContextDependent):
         self.agent_model: str | None = kwargs.pop("agent_model", None)
         # Extract agent_name if provided
         self.agent_name: str | None = kwargs.pop("agent_name", None)
+        # Extract api_key if provided
+        self.api_key: str | None = kwargs.pop("api_key", None)
         # Extract custom elicitation handler if provided
         custom_elicitation_handler = kwargs.pop("elicitation_handler", None)
 


### PR DESCRIPTION
This argument allows us to create agents with different API KEYs at runtime. It helps implement workflows that require users to provide an API KEY.