### PR TITLE
Aws Bedrock provider native support

### DIFF
--- a/examples/bedrock/fast-agent.config.yaml
+++ b/examples/bedrock/fast-agent.config.yaml
@@ -1,0 +1,13 @@
+# Example minimalfast-agent.config.yaml for Bedrock
+
+# List of supported models: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+default_model: bedrock.amazon.nova-lite-v1:0
+
+# Bedrock uses the AWS credentials provider chain to authenticate.
+# This can be accomplished with aws sso login on local machines,
+# or by IAM roles within AWS.
+# see https://docs.aws.amazon.com/res/latest/ug/sso-idc.html
+bedrock:
+  region: "us-east-1" # required
+  profile: "default"  # optional, defaults to "default" - only needed if you have multiple profiles. 
+                      # Only needed on local machines, not on AWS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "anthropic>=0.55.0",
     "openai>=1.93.0",
     "azure-identity>=1.14.0",
+    "boto3>=1.35.0",
     "prompt-toolkit>=3.0.50",
     "aiohttp>=3.11.13",
     "opentelemetry-instrumentation-openai>=0.40.14; python_version >= '3.10' and python_version < '4.0'",

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -242,6 +242,20 @@ class TensorZeroSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
+class BedrockSettings(BaseModel):
+    """
+    Settings for using AWS Bedrock models in the fast-agent application.
+    """
+
+    region: str | None = None
+    """AWS region for Bedrock service"""
+
+    profile: str | None = None
+    """AWS profile to use for authentication"""
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+
 class HuggingFaceSettings(BaseModel):
     """
     Settings for HuggingFace authentication (used for MCP connections).
@@ -353,6 +367,9 @@ class Settings(BaseSettings):
 
     aliyun: OpenAISettings | None = None
     """Settings for using Aliyun OpenAI Service in the fast-agent application"""
+
+    bedrock: BedrockSettings | None = None
+    """Settings for using AWS Bedrock models in the fast-agent application"""
 
     huggingface: HuggingFaceSettings | None = None
     """Settings for HuggingFace authentication (used for MCP connections)"""

--- a/src/mcp_agent/llm/model_factory.py
+++ b/src/mcp_agent/llm/model_factory.py
@@ -158,23 +158,6 @@ class ModelFactory:
     }
 
     @classmethod
-    def _is_bedrock_model(cls, model_name: str) -> bool:
-        """Check if a model name matches Bedrock model patterns."""
-        # Bedrock model patterns
-        bedrock_patterns = [
-            r"^amazon\.nova.*",           # Amazon Nova models
-            r"^anthropic\.claude.*",      # Anthropic Claude models
-            r"^meta\.llama.*",            # Meta Llama models
-            r"^mistral\..*",              # Mistral models
-            r"^cohere\..*",               # Cohere models
-            r"^ai21\..*",                 # AI21 models
-            r"^stability\..*",            # Stability AI models
-        ]
-        
-        import re
-        return any(re.match(pattern, model_name) for pattern in bedrock_patterns)
-
-    @classmethod
     def parse_model_string(cls, model_string: str) -> ModelConfig:
         """Parse a model string into a ModelConfig object"""
         model_string = cls.MODEL_ALIASES.get(model_string, model_string)
@@ -220,7 +203,7 @@ class ModelFactory:
             provider = cls.DEFAULT_PROVIDERS.get(model_name_str)
             
             # If still None, try pattern matching for Bedrock models
-            if provider is None and cls._is_bedrock_model(model_name_str):
+            if provider is None and BedrockAugmentedLLM.matches_model_pattern(model_name_str):
                 provider = Provider.BEDROCK
             
             if provider is None:

--- a/src/mcp_agent/llm/provider_types.py
+++ b/src/mcp_agent/llm/provider_types.py
@@ -26,5 +26,5 @@ class Provider(Enum):
     AZURE = ("azure", "Azure")  # Azure OpenAI Service
     ALIYUN = ("aliyun", "Aliyun")  # Aliyun Bailian OpenAI Service
     HUGGINGFACE = ("huggingface", "HuggingFace")  # For HuggingFace MCP connections
-    XAI = (("xai", "XAI"),)  # For xAI Grok models
-    BEDROCK = (("bedrock", "Bedrock")  # For xAI Grok models
+    XAI = ("xai", "XAI")  # For xAI Grok models
+    BEDROCK = ("bedrock", "Bedrock")

--- a/src/mcp_agent/llm/provider_types.py
+++ b/src/mcp_agent/llm/provider_types.py
@@ -19,5 +19,5 @@ class Provider(Enum):
     TENSORZERO = "tensorzero"  # For TensorZero Gateway
     AZURE = "azure"  # Azure OpenAI Service
     ALIYUN = "aliyun"  # Aliyun Bailian OpenAI Service
-    BEDROCK = ("bedrock", "Bedrock")  # AWS Bedrock Service
+    BEDROCK = "bedrock" # AWS Bedrock Service
     HUGGINGFACE = "huggingface"  # For HuggingFace MCP connections

--- a/src/mcp_agent/llm/provider_types.py
+++ b/src/mcp_agent/llm/provider_types.py
@@ -19,5 +19,5 @@ class Provider(Enum):
     TENSORZERO = "tensorzero"  # For TensorZero Gateway
     AZURE = "azure"  # Azure OpenAI Service
     ALIYUN = "aliyun"  # Aliyun Bailian OpenAI Service
-    BEDROCK = "bedrock"  # AWS Bedrock Service
+    BEDROCK = ("bedrock", "Bedrock")  # AWS Bedrock Service
     HUGGINGFACE = "huggingface"  # For HuggingFace MCP connections

--- a/src/mcp_agent/llm/provider_types.py
+++ b/src/mcp_agent/llm/provider_types.py
@@ -19,4 +19,5 @@ class Provider(Enum):
     TENSORZERO = "tensorzero"  # For TensorZero Gateway
     AZURE = "azure"  # Azure OpenAI Service
     ALIYUN = "aliyun"  # Aliyun Bailian OpenAI Service
+    BEDROCK = "bedrock"  # AWS Bedrock Service
     HUGGINGFACE = "huggingface"  # For HuggingFace MCP connections

--- a/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
@@ -885,16 +885,87 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         model: Type[ModelT],
         request_params: RequestParams | None = None,
     ) -> Tuple[ModelT | None, PromptMessageMultipart]:
-        """Apply structured output for Bedrock (not directly supported)."""
-        # Bedrock doesn't have native structured output like OpenAI
-        # We'll need to rely on prompt engineering
+        """Apply structured output for Bedrock using prompt engineering."""
+        # Stage 1: Assume no Bedrock models support native structured output
+        # Generate instructions from the Pydantic model and append to the message
+        
+        # Create a copy of the messages to avoid modifying the original
+        messages_copy = [msg.model_copy(deep=True) for msg in multipart_messages]
+        
+        # Generate structured output instructions from the Pydantic model
+        structured_instructions = self._generate_structured_instructions(model)
+        
+        # Append the instructions to the last message
+        if messages_copy:
+            last_message = messages_copy[-1]
+            last_message.add_text(structured_instructions)
+        
+        # Process the request with the modified messages
         response = await self._apply_prompt_provider_specific(
-            multipart_messages, request_params, is_template=True
+            messages_copy, request_params, is_template=True
         )
         
         # Try to parse the response as structured data
         parsed_model = self._structured_from_multipart(response, model)
         return parsed_model
+
+    def _generate_structured_instructions(self, model: Type[ModelT]) -> str:
+        """
+        Generate structured output instructions from a Pydantic model.
+        
+        This mimics the manual router_instruction wrapper but works for any Pydantic model.
+        """
+        # Get the JSON schema from the Pydantic model
+        schema = model.model_json_schema()
+        
+        # Extract field information
+        properties = schema.get("properties", {})
+        required_fields = schema.get("required", [])
+        
+        # Build the JSON format example
+        json_format = "{\n"
+        field_descriptions = []
+        
+        for field_name, field_info in properties.items():
+            field_type = field_info.get("type", "string")
+            field_desc = field_info.get("description", f"The {field_name} field")
+            
+            # Add to JSON format example
+            if field_type == "string":
+                json_format += f'    "{field_name}": "The {field_name} value",\n'
+            elif field_type == "integer":
+                json_format += f'    "{field_name}": 123,\n'
+            elif field_type == "number":
+                json_format += f'    "{field_name}": 123.45,\n'
+            elif field_type == "boolean":
+                json_format += f'    "{field_name}": true,\n'
+            else:
+                json_format += f'    "{field_name}": "The {field_name} value",\n'
+            
+            # Add field description
+            required_marker = " (required)" if field_name in required_fields else " (optional)"
+            field_descriptions.append(f'    "{field_name}": {field_desc}{required_marker}')
+        
+        json_format = json_format.rstrip(",\n") + "\n}"
+        
+        # Generate the complete instruction
+        instructions = f"""
+The response must be structured in the following format:
+
+<format>
+{json_format}
+</format>
+
+Field descriptions:
+{chr(10).join(field_descriptions)}
+
+IMPORTANT: The response should be raw JSON without any other text or formatting applied. 
+Do not include ```json or ``` or any other markdown formatting - just the raw JSON string only.
+Remember to include all required fields: {', '.join(required_fields)}.
+"""
+        
+        self.logger.debug(f"Generated structured instructions for {model.__name__}: {instructions}")
+        return instructions
 
     @classmethod
     def convert_message_to_message_param(

--- a/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
@@ -61,6 +61,23 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         AugmentedLLM.PARAM_TEMPLATE_VARS,
     }
 
+    @classmethod
+    def matches_model_pattern(cls, model_name: str) -> bool:
+        """Check if a model name matches Bedrock model patterns."""
+        # Bedrock model patterns
+        bedrock_patterns = [
+            r"^amazon\.nova.*",           # Amazon Nova models
+            r"^anthropic\.claude.*",      # Anthropic Claude models
+            r"^meta\.llama.*",            # Meta Llama models
+            r"^mistral\..*",              # Mistral models
+            r"^cohere\..*",               # Cohere models
+            r"^ai21\..*",                 # AI21 models
+            r"^stability\..*",            # Stability AI models
+        ]
+        
+        import re
+        return any(re.match(pattern, model_name) for pattern in bedrock_patterns)
+
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the Bedrock LLM with AWS credentials and region."""
         if boto3 is None:

--- a/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
@@ -16,9 +16,6 @@ from mcp_agent.llm.usage_tracking import TurnUsage
 from mcp_agent.logging.logger import get_logger
 from mcp_agent.mcp.interfaces import ModelT
 from mcp_agent.mcp.prompt_message_multipart import PromptMessageMultipart
-from mcp_agent.llm.providers.multipart_converter_anthropic import (
-    AnthropicConverter,
-)
 
 if TYPE_CHECKING:
     from mcp import ListToolsResult
@@ -51,7 +48,8 @@ BedrockMessageParam = Dict[str, Any]  # Bedrock message parameter format
 
 class ToolSchemaType(Enum):
     """Enum for different tool schema formats used by different model families."""
-    DEFAULT = "default"    # Default toolSpec format used by most models (formerly Nova)
+
+    DEFAULT = "default"  # Default toolSpec format used by most models (formerly Nova)
     SYSTEM_PROMPT = "system_prompt"  # System prompt-based tool calling format
     ANTHROPIC = "anthropic"  # Native Anthropic tool calling format
 
@@ -81,16 +79,17 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         """Check if a model name matches Bedrock model patterns."""
         # Bedrock model patterns
         bedrock_patterns = [
-            r"^amazon\.nova.*",           # Amazon Nova models
-            r"^anthropic\.claude.*",      # Anthropic Claude models
-            r"^meta\.llama.*",            # Meta Llama models
-            r"^mistral\..*",              # Mistral models
-            r"^cohere\..*",               # Cohere models
-            r"^ai21\..*",                 # AI21 models
-            r"^stability\..*",            # Stability AI models
+            r"^amazon\.nova.*",  # Amazon Nova models
+            r"^anthropic\.claude.*",  # Anthropic Claude models
+            r"^meta\.llama.*",  # Meta Llama models
+            r"^mistral\..*",  # Mistral models
+            r"^cohere\..*",  # Cohere models
+            r"^ai21\..*",  # AI21 models
+            r"^stability\..*",  # Stability AI models
         ]
-        
+
         import re
+
         return any(re.match(pattern, model_name) for pattern in bedrock_patterns)
 
     def __init__(self, *args, **kwargs) -> None:
@@ -99,32 +98,34 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             raise ImportError(
                 "boto3 is required for Bedrock support. Install with: pip install boto3"
             )
-        
+
         # Initialize logger
         self.logger = get_logger(__name__)
 
         # Extract AWS configuration from kwargs first
         self.aws_region = kwargs.pop("region", None)
         self.aws_profile = kwargs.pop("profile", None)
-        
+
         super().__init__(*args, provider=Provider.BEDROCK, **kwargs)
-        
+
         # Use config values if not provided in kwargs (after super().__init__)
         if self.context.config and self.context.config.bedrock:
             if not self.aws_region:
                 self.aws_region = self.context.config.bedrock.region
             if not self.aws_profile:
                 self.aws_profile = self.context.config.bedrock.profile
-        
+
         # Final fallback to environment variables
         if not self.aws_region:
             # Support both AWS_REGION and AWS_DEFAULT_REGION
-            self.aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-        
+            self.aws_region = os.environ.get("AWS_REGION") or os.environ.get(
+                "AWS_DEFAULT_REGION", "us-east-1"
+            )
+
         if not self.aws_profile:
             # Support AWS_PROFILE environment variable
             self.aws_profile = os.environ.get("AWS_PROFILE")
-        
+
         # Initialize AWS clients
         self._bedrock_client = None
         self._bedrock_runtime_client = None
@@ -158,7 +159,9 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         if self._bedrock_runtime_client is None:
             try:
                 session = boto3.Session(profile_name=self.aws_profile)
-                self._bedrock_runtime_client = session.client("bedrock-runtime", region_name=self.aws_region)
+                self._bedrock_runtime_client = session.client(
+                    "bedrock-runtime", region_name=self.aws_region
+                )
             except NoCredentialsError as e:
                 raise ProviderKeyError(
                     "AWS credentials not found",
@@ -169,40 +172,46 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
     def _get_tool_schema_type(self, model_id: str) -> ToolSchemaType:
         """
         Determine which tool schema format to use based on model family.
-        
+
         Args:
             model_id: The model ID (e.g., "bedrock.meta.llama3-1-8b-instruct-v1:0")
-            
+
         Returns:
             ToolSchemaType indicating which format to use
         """
         # Remove any "bedrock." prefix for pattern matching
         clean_model = model_id.replace("bedrock.", "")
-        
+
         # Anthropic models use native Anthropic format
         if re.search(r"anthropic\.claude", clean_model):
-            self.logger.debug(f"Model {model_id} detected as Anthropic - using native Anthropic format")
+            self.logger.debug(
+                f"Model {model_id} detected as Anthropic - using native Anthropic format"
+            )
             return ToolSchemaType.ANTHROPIC
-        
+
         # Scout models use SYSTEM_PROMPT format
         if re.search(r"meta\.llama4-scout", clean_model):
             self.logger.debug(f"Model {model_id} detected as Scout - using SYSTEM_PROMPT format")
             return ToolSchemaType.SYSTEM_PROMPT
-        
+
         # Other Llama 4 models use default toolConfig format
         if re.search(r"meta\.llama4", clean_model):
-            self.logger.debug(f"Model {model_id} detected as Llama 4 (non-Scout) - using default toolConfig format")
+            self.logger.debug(
+                f"Model {model_id} detected as Llama 4 (non-Scout) - using default toolConfig format"
+            )
             return ToolSchemaType.DEFAULT
-        
+
         # Llama 3.x models use system prompt format
         if re.search(r"meta\.llama3", clean_model):
-            self.logger.debug(f"Model {model_id} detected as Llama 3.x - using system prompt format")
+            self.logger.debug(
+                f"Model {model_id} detected as Llama 3.x - using system prompt format"
+            )
             return ToolSchemaType.SYSTEM_PROMPT
-        
+
         # Future: Add other model-specific formats here
         # if re.search(r"mistral\.", clean_model):
         #     return ToolSchemaType.MISTRAL
-        
+
         # Default to default format for all other models
         self.logger.debug(f"Model {model_id} using default tool format")
         return ToolSchemaType.DEFAULT
@@ -210,36 +219,38 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
     def _supports_streaming_with_tools(self, model: str) -> bool:
         """
         Check if a model supports streaming with tools.
-        
+
         Some models (like AI21 Jamba) support tools but not in streaming mode.
         This method uses regex patterns to identify such models.
-        
+
         Args:
             model: The model name (e.g., "ai21.jamba-1-5-mini-v1:0")
-            
+
         Returns:
             False if the model requires non-streaming for tools, True otherwise
         """
         # Remove any "bedrock." prefix for pattern matching
         clean_model = model.replace("bedrock.", "")
-        
+
         # Models that don't support streaming with tools
         non_streaming_patterns = [
-            r"ai21\.jamba",     # All AI21 Jamba models
-            r"meta\.llama",     # All Meta Llama models
-            r"mistral\.",       # All Mistral models
-            r"amazon\.titan",   # All Amazon Titan models
-            r"cohere\.command", # All Cohere Command models
-            r"anthropic\.claude-instant", # Anthropic Claude Instant models
-            r"anthropic\.claude-v2",      # Anthropic Claude v2 models
-            r"deepseek\.",      # All DeepSeek models
+            r"ai21\.jamba",  # All AI21 Jamba models
+            r"meta\.llama",  # All Meta Llama models
+            r"mistral\.",  # All Mistral models
+            r"amazon\.titan",  # All Amazon Titan models
+            r"cohere\.command",  # All Cohere Command models
+            r"anthropic\.claude-instant",  # Anthropic Claude Instant models
+            r"anthropic\.claude-v2",  # Anthropic Claude v2 models
+            r"deepseek\.",  # All DeepSeek models
         ]
-        
+
         for pattern in non_streaming_patterns:
             if re.search(pattern, clean_model, re.IGNORECASE):
-                self.logger.debug(f"Model {model} detected as non-streaming for tools (pattern: {pattern})")
+                self.logger.debug(
+                    f"Model {model} detected as non-streaming for tools (pattern: {pattern})"
+                )
                 return False
-        
+
         return True
 
     def _supports_tool_use(self, model_id: str) -> bool:
@@ -250,69 +261,71 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         """
         # Models that don't support tool use at all
         no_tool_use_patterns = [
-            r"ai21\.jamba-instruct",         # AI21 Jamba-Instruct (but not jamba 1.5)
-            r"ai21\..*jurassic",             # AI21 Labs Jurassic-2 models
-            r"amazon\.titan",                # All Amazon Titan models
-            r"anthropic\.claude-v2",         # Anthropic Claude v2 models
-            r"anthropic\.claude-instant",    # Anthropic Claude Instant models
-            r"cohere\.command(?!-r)",        # Cohere Command (but not Command R/R+)
-            r"cohere\.command-light",        # Cohere Command Light
-            r"deepseek\.",                   # All DeepSeek models
-            r"meta\.llama[23](?![-.])",      # Meta Llama 2 and 3 (but not 3.1+, 3.2+, etc.)
-            r"meta\.llama3-1-8b",            # Meta Llama 3.1 8b - doesn't support tool calls
-            r"meta\.llama3-2-[13]b",         # Meta Llama 3.2 1b and 3b (but not 11b/90b)
-            r"meta\.llama3-2-11b",           # Meta Llama 3.2 11b - doesn't support tool calls
-            r"mistral\..*-instruct",         # Mistral AI Instruct (but not Mistral Large)
+            r"ai21\.jamba-instruct",  # AI21 Jamba-Instruct (but not jamba 1.5)
+            r"ai21\..*jurassic",  # AI21 Labs Jurassic-2 models
+            r"amazon\.titan",  # All Amazon Titan models
+            r"anthropic\.claude-v2",  # Anthropic Claude v2 models
+            r"anthropic\.claude-instant",  # Anthropic Claude Instant models
+            r"cohere\.command(?!-r)",  # Cohere Command (but not Command R/R+)
+            r"cohere\.command-light",  # Cohere Command Light
+            r"deepseek\.",  # All DeepSeek models
+            r"meta\.llama[23](?![-.])",  # Meta Llama 2 and 3 (but not 3.1+, 3.2+, etc.)
+            r"meta\.llama3-1-8b",  # Meta Llama 3.1 8b - doesn't support tool calls
+            r"meta\.llama3-2-[13]b",  # Meta Llama 3.2 1b and 3b (but not 11b/90b)
+            r"meta\.llama3-2-11b",  # Meta Llama 3.2 11b - doesn't support tool calls
+            r"mistral\..*-instruct",  # Mistral AI Instruct (but not Mistral Large)
         ]
-        
+
         for pattern in no_tool_use_patterns:
             if re.search(pattern, model_id):
                 self.logger.info(f"Model {model_id} does not support tool use")
                 return False
-        
+
         return True
 
     def _supports_system_messages(self, model: str) -> bool:
         """
         Check if a model supports system messages.
-        
+
         Some models (like Titan and Cohere embedding models) don't support system messages.
         This method uses regex patterns to identify such models.
-        
+
         Args:
             model: The model name (e.g., "amazon.titan-embed-text-v1")
-            
+
         Returns:
             False if the model doesn't support system messages, True otherwise
         """
         # Remove any "bedrock." prefix for pattern matching
         clean_model = model.replace("bedrock.", "")
-        
+
         # DEBUG: Print the model names for debugging
-        self.logger.info(f"DEBUG: Checking system message support for model='{model}', clean_model='{clean_model}'")
-        
+        self.logger.info(
+            f"DEBUG: Checking system message support for model='{model}', clean_model='{clean_model}'"
+        )
+
         # Models that don't support system messages (reverse logic as suggested)
         no_system_message_patterns = [
-            r"amazon\.titan",            # All Amazon Titan models
-            r"cohere\.command.*-text",   # Cohere command text models (command-text-v14, command-light-text-v14)
-            r"mistral.*mixtral.*8x7b",   # Mistral Mixtral 8x7b models
-            r"mistral.mistral-7b-instruct", # Mistral 7b instruct models
-            r"meta\.llama3-2-11b-instruct", # Specific Meta Llama3 model
+            r"amazon\.titan",  # All Amazon Titan models
+            r"cohere\.command.*-text",  # Cohere command text models (command-text-v14, command-light-text-v14)
+            r"mistral.*mixtral.*8x7b",  # Mistral Mixtral 8x7b models
+            r"mistral.mistral-7b-instruct",  # Mistral 7b instruct models
+            r"meta\.llama3-2-11b-instruct",  # Specific Meta Llama3 model
         ]
-        
+
         for pattern in no_system_message_patterns:
             if re.search(pattern, clean_model, re.IGNORECASE):
-                self.logger.info(f"DEBUG: Model {model} detected as NOT supporting system messages (pattern: {pattern})")
+                self.logger.info(
+                    f"DEBUG: Model {model} detected as NOT supporting system messages (pattern: {pattern})"
+                )
                 return False
-        
+
         self.logger.info(f"DEBUG: Model {model} detected as supporting system messages")
         return True
 
-
-
     def _convert_tools_nova_format(self, tools: "ListToolsResult") -> List[Dict[str, Any]]:
         """Convert MCP tools to Nova-specific toolSpec format.
-        
+
         Note: Nova models have VERY strict JSON schema requirements:
         - Top level schema must be of type Object
         - ONLY three fields are supported: type, properties, required
@@ -321,32 +334,29 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         - Tools with no parameters should have empty properties object
         """
         bedrock_tools = []
-        
+
         # Create mapping from cleaned names to original names for tool execution
         self.tool_name_mapping = {}
-        
+
         self.logger.debug(f"Converting {len(tools.tools)} MCP tools to Nova format")
-        
+
         for tool in tools.tools:
             self.logger.debug(f"Converting MCP tool: {tool.name}")
-            
+
             # Extract and validate the input schema
             input_schema = tool.inputSchema or {}
-            
+
             # Create Nova-compliant schema with ONLY the three allowed fields
             # Always include type and properties (even if empty)
-            nova_schema: Dict[str, Any] = {
-                "type": "object",
-                "properties": {}
-            }
-            
+            nova_schema: Dict[str, Any] = {"type": "object", "properties": {}}
+
             # Properties - clean them strictly
             properties: Dict[str, Any] = {}
             if "properties" in input_schema and isinstance(input_schema["properties"], dict):
                 for prop_name, prop_def in input_schema["properties"].items():
                     # Only include type and description for each property
                     clean_prop: Dict[str, Any] = {}
-                    
+
                     if isinstance(prop_def, dict):
                         # Only include type (required) and description (optional)
                         clean_prop["type"] = prop_def.get("type", "string")
@@ -356,23 +366,27 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                     else:
                         # Handle simple property definitions
                         clean_prop["type"] = "string"
-                    
+
                     properties[prop_name] = clean_prop
-            
+
             # Always set properties (even if empty for parameterless tools)
             nova_schema["properties"] = properties
-                
+
             # Required fields - only add if present and not empty
-            if "required" in input_schema and isinstance(input_schema["required"], list) and input_schema["required"]:
+            if (
+                "required" in input_schema
+                and isinstance(input_schema["required"], list)
+                and input_schema["required"]
+            ):
                 nova_schema["required"] = input_schema["required"]
-            
+
             # IMPORTANT: Nova tool name compatibility fix
-            # Problem: Amazon Nova models fail with "Model produced invalid sequence as part of ToolUse" 
+            # Problem: Amazon Nova models fail with "Model produced invalid sequence as part of ToolUse"
             # when tool names contain hyphens (e.g., "utils-get_current_date_information")
             # Solution: Replace hyphens with underscores for Nova (e.g., "utils_get_current_date_information")
             # Note: Underscores work fine, simple names work fine, but hyphens cause tool calling to fail
             clean_name = tool.name.replace("-", "_")
-            
+
             # Store mapping from cleaned name back to original MCP name
             # This is needed because:
             # 1. Nova receives tools with cleaned names (utils_get_current_date_information)
@@ -380,157 +394,161 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             # 3. But MCP server expects original names (utils-get_current_date_information)
             # 4. So we map back: utils_get_current_date_information -> utils-get_current_date_information
             self.tool_name_mapping[clean_name] = tool.name
-            
+
             bedrock_tool = {
                 "toolSpec": {
                     "name": clean_name,
                     "description": tool.description or f"Tool: {tool.name}",
-                    "inputSchema": {
-                        "json": nova_schema
-                    }
+                    "inputSchema": {"json": nova_schema},
                 }
             }
-            
+
             bedrock_tools.append(bedrock_tool)
-            
+
         self.logger.debug(f"Converted {len(bedrock_tools)} tools for Nova format")
         return bedrock_tools
 
-
-
     def _convert_tools_system_prompt_format(self, tools: "ListToolsResult") -> str:
         """Convert MCP tools to system prompt format.
-        
+
         Uses different formats based on the model:
         - Scout models: Comprehensive system prompt format
         - Other models: Minimal format
         """
         if not tools.tools:
             return ""
-        
+
         # Create mapping from tool names to original names (no cleaning needed for Llama)
         self.tool_name_mapping = {}
-        
-        self.logger.debug(f"Converting {len(tools.tools)} MCP tools to Llama native system prompt format")
-        
+
+        self.logger.debug(
+            f"Converting {len(tools.tools)} MCP tools to Llama native system prompt format"
+        )
+
         # Check if this is a Scout model
         model_id = self.default_request_params.model or DEFAULT_BEDROCK_MODEL
         clean_model = model_id.replace("bedrock.", "")
         is_scout = re.search(r"meta\.llama4-scout", clean_model)
-        
+
         if is_scout:
             # Use comprehensive system prompt format for Scout models
             prompt_parts = [
                 "You are a helpful assistant with access to the following functions. Use them if required:",
-                ""
+                "",
             ]
-            
+
             # Add each tool definition in JSON format
             for tool in tools.tools:
                 self.logger.debug(f"Converting MCP tool: {tool.name}")
-                
+
                 # Use original tool name (no hyphen replacement for Llama)
                 tool_name = tool.name
-                
+
                 # Store mapping (identity mapping since no name cleaning)
                 self.tool_name_mapping[tool_name] = tool.name
-                
+
                 # Create tool definition in the format Llama expects
                 tool_def = {
                     "type": "function",
                     "function": {
                         "name": tool_name,
                         "description": tool.description or f"Tool: {tool.name}",
-                        "parameters": tool.inputSchema or {"type": "object", "properties": {}}
-                    }
+                        "parameters": tool.inputSchema or {"type": "object", "properties": {}},
+                    },
                 }
-                
+
                 prompt_parts.append(json.dumps(tool_def))
-            
+
             # Add comprehensive response format instructions for Scout
-            prompt_parts.extend([
-                "",
-                "## Rules for Function Calling:",
-                "1. When you need to call a function, use the following format:",
-                "   [function_name(arguments)]",
-                "2. You can call multiple functions in a single response if needed",
-                "3. Always provide the function results in your response to the user",
-                "4. If a function call fails, explain the error and try an alternative approach",
-                "5. Only call functions when necessary to answer the user's question",
-                "",
-                "## Response Rules:",
-                "- Always provide a complete answer to the user's question",
-                "- Include function results in your response",
-                "- Be helpful and informative",
-                "- If you cannot answer without calling a function, call the appropriate function first",
-                "",
-                "## Boundaries:",
-                "- Only call functions that are explicitly provided above",
-                "- Do not make up function names or parameters",
-                "- Follow the exact function signature provided",
-                "- Always validate your function calls before making them"
-            ])
+            prompt_parts.extend(
+                [
+                    "",
+                    "## Rules for Function Calling:",
+                    "1. When you need to call a function, use the following format:",
+                    "   [function_name(arguments)]",
+                    "2. You can call multiple functions in a single response if needed",
+                    "3. Always provide the function results in your response to the user",
+                    "4. If a function call fails, explain the error and try an alternative approach",
+                    "5. Only call functions when necessary to answer the user's question",
+                    "",
+                    "## Response Rules:",
+                    "- Always provide a complete answer to the user's question",
+                    "- Include function results in your response",
+                    "- Be helpful and informative",
+                    "- If you cannot answer without calling a function, call the appropriate function first",
+                    "",
+                    "## Boundaries:",
+                    "- Only call functions that are explicitly provided above",
+                    "- Do not make up function names or parameters",
+                    "- Follow the exact function signature provided",
+                    "- Always validate your function calls before making them",
+                ]
+            )
         else:
             # Use minimal format for other Llama models
             prompt_parts = [
                 "You have the following tools available to help answer the user's request. You can call one or more functions at a time. The functions are described here in JSON-schema format:",
-                ""
+                "",
             ]
-            
+
             # Add each tool definition in JSON format
             for tool in tools.tools:
                 self.logger.debug(f"Converting MCP tool: {tool.name}")
-                
+
                 # Use original tool name (no hyphen replacement for Llama)
                 tool_name = tool.name
-                
+
                 # Store mapping (identity mapping since no name cleaning)
                 self.tool_name_mapping[tool_name] = tool.name
-                
+
                 # Create tool definition in the format Llama expects
                 tool_def = {
                     "type": "function",
                     "function": {
                         "name": tool_name,
                         "description": tool.description or f"Tool: {tool.name}",
-                        "parameters": tool.inputSchema or {"type": "object", "properties": {}}
-                    }
+                        "parameters": tool.inputSchema or {"type": "object", "properties": {}},
+                    },
                 }
-                
+
                 prompt_parts.append(json.dumps(tool_def))
-            
+
             # Add the response format instructions based on community best practices
-            prompt_parts.extend([
-                "",
-                "To call one or more tools, provide the tool calls on a new line as a JSON-formatted array. Explain your steps in a neutral tone. Then, only call the tools you can for the first step, then end your turn. If you previously received an error, you can try to call the tool again. Give up after 3 errors.",
-                "",
-                "Conform precisely to the single-line format of this example:",
-                "Tool Call:",
-                '[{"name": "SampleTool", "arguments": {"foo": "bar"}},{"name": "SampleTool", "arguments": {"foo": "other"}}]'
-            ])
-        
+            prompt_parts.extend(
+                [
+                    "",
+                    "To call one or more tools, provide the tool calls on a new line as a JSON-formatted array. Explain your steps in a neutral tone. Then, only call the tools you can for the first step, then end your turn. If you previously received an error, you can try to call the tool again. Give up after 3 errors.",
+                    "",
+                    "Conform precisely to the single-line format of this example:",
+                    "Tool Call:",
+                    '[{"name": "SampleTool", "arguments": {"foo": "bar"}},{"name": "SampleTool", "arguments": {"foo": "other"}}]',
+                ]
+            )
+
         system_prompt = "\n".join(prompt_parts)
         self.logger.debug(f"Generated Llama native system prompt: {system_prompt}")
-        
+
         return system_prompt
 
     def _convert_tools_anthropic_format(self, tools: "ListToolsResult") -> List[Dict[str, Any]]:
         """Convert MCP tools to Anthropic format wrapped in Bedrock toolSpec - preserves raw schema."""
         # No tool name mapping needed for Anthropic (uses original names)
         self.tool_name_mapping = {}
-        
-        self.logger.debug(f"Converting {len(tools.tools)} MCP tools to Anthropic format with toolSpec wrapper")
-        
+
+        self.logger.debug(
+            f"Converting {len(tools.tools)} MCP tools to Anthropic format with toolSpec wrapper"
+        )
+
         bedrock_tools = []
         for tool in tools.tools:
             self.logger.debug(f"Converting MCP tool: {tool.name}")
-            
+
             # Store identity mapping (no name cleaning for Anthropic)
             self.tool_name_mapping[tool.name] = tool.name
-            
+
             # Use raw MCP schema (like native Anthropic provider) - no cleaning
             input_schema = tool.inputSchema or {"type": "object", "properties": {}}
-            
+
             # Wrap in Bedrock toolSpec format but preserve raw Anthropic schema
             bedrock_tool = {
                 "toolSpec": {
@@ -538,19 +556,23 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                     "description": tool.description or f"Tool: {tool.name}",
                     "inputSchema": {
                         "json": input_schema  # Raw MCP schema, not cleaned
-                    }
+                    },
                 }
             }
             bedrock_tools.append(bedrock_tool)
-        
-        self.logger.debug(f"Converted {len(bedrock_tools)} tools to Anthropic format with toolSpec wrapper")
+
+        self.logger.debug(
+            f"Converted {len(bedrock_tools)} tools to Anthropic format with toolSpec wrapper"
+        )
         return bedrock_tools
 
-    def _convert_mcp_tools_to_bedrock(self, tools: "ListToolsResult") -> Union[List[Dict[str, Any]], str]:
+    def _convert_mcp_tools_to_bedrock(
+        self, tools: "ListToolsResult"
+    ) -> Union[List[Dict[str, Any]], str]:
         """Convert MCP tools to appropriate Bedrock format based on model type."""
         model_id = self.default_request_params.model or DEFAULT_BEDROCK_MODEL
         schema_type = self._get_tool_schema_type(model_id)
-        
+
         if schema_type == ToolSchemaType.SYSTEM_PROMPT:
             system_prompt = self._convert_tools_system_prompt_format(tools)
             # Store the system prompt for later use in system message
@@ -561,76 +583,84 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         else:
             return self._convert_tools_nova_format(tools)
 
-    def _add_tools_to_request(self, converse_args: Dict[str, Any], available_tools: Union[List[Dict[str, Any]], str], model_id: str) -> None:
+    def _add_tools_to_request(
+        self,
+        converse_args: Dict[str, Any],
+        available_tools: Union[List[Dict[str, Any]], str],
+        model_id: str,
+    ) -> None:
         """Add tools to the request in the appropriate format based on model type."""
         schema_type = self._get_tool_schema_type(model_id)
-        
+
         if schema_type == ToolSchemaType.SYSTEM_PROMPT:
             # System prompt models expect tools in the system prompt, not as API parameters
             # Tools are already handled in the system prompt generation
-            self.logger.debug(f"System prompt tools handled in system prompt")
+            self.logger.debug("System prompt tools handled in system prompt")
         elif schema_type == ToolSchemaType.ANTHROPIC:
             # Anthropic models expect toolConfig with tools array (like native provider)
-            converse_args["toolConfig"] = {
-                "tools": available_tools
-            }
-            self.logger.debug(f"Added {len(available_tools)} tools to Anthropic request in toolConfig format")
+            converse_args["toolConfig"] = {"tools": available_tools}
+            self.logger.debug(
+                f"Added {len(available_tools)} tools to Anthropic request in toolConfig format"
+            )
         else:
             # Nova models expect toolConfig with toolSpec format
-            converse_args["toolConfig"] = {
-                "tools": available_tools
-            }
-            self.logger.debug(f"Added {len(available_tools)} tools to Nova request in toolConfig format")
+            converse_args["toolConfig"] = {"tools": available_tools}
+            self.logger.debug(
+                f"Added {len(available_tools)} tools to Nova request in toolConfig format"
+            )
 
     def _parse_nova_tool_response(self, processed_response: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Parse Nova-format tool response (toolUse format)."""
         tool_uses = [
-            content_item for content_item in processed_response.get("content", [])
+            content_item
+            for content_item in processed_response.get("content", [])
             if "toolUse" in content_item
         ]
-        
+
         parsed_tools = []
         for tool_use_item in tool_uses:
             tool_use = tool_use_item["toolUse"]
-            parsed_tools.append({
-                "type": "nova",
-                "name": tool_use["name"],
-                "arguments": tool_use["input"],
-                "id": tool_use["toolUseId"]
-            })
-        
+            parsed_tools.append(
+                {
+                    "type": "nova",
+                    "name": tool_use["name"],
+                    "arguments": tool_use["input"],
+                    "id": tool_use["toolUseId"],
+                }
+            )
+
         return parsed_tools
 
-
-
-    def _parse_system_prompt_tool_response(self, processed_response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _parse_system_prompt_tool_response(
+        self, processed_response: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Parse system prompt tool response format: function calls in text."""
         # Extract text content from the response
         text_content = ""
         for content_item in processed_response.get("content", []):
             if isinstance(content_item, dict) and "text" in content_item:
                 text_content += content_item["text"]
-        
+
         if not text_content:
             return []
-        
+
         # Look for different tool call formats
         tool_calls = []
-        
+
         # First try Scout format: [function_name(arguments)]
-        scout_pattern = r'\[([^(]+)\(([^)]*)\)\]'
+        scout_pattern = r"\[([^(]+)\(([^)]*)\)\]"
         scout_matches = re.findall(scout_pattern, text_content)
         if scout_matches:
             for i, (func_name, args_str) in enumerate(scout_matches):
                 func_name = func_name.strip()
                 args_str = args_str.strip()
-                
+
                 # Parse arguments - could be empty, JSON object, or simple values
                 arguments = {}
                 if args_str:
                     try:
                         # Try to parse as JSON object first
-                        if args_str.startswith('{') and args_str.endswith('}'):
+                        if args_str.startswith("{") and args_str.endswith("}"):
                             arguments = json.loads(args_str)
                         else:
                             # For simple values, create a basic structure
@@ -638,19 +668,21 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                     except json.JSONDecodeError:
                         # If JSON parsing fails, treat as string
                         arguments = {"value": args_str}
-                
-                tool_calls.append({
-                    "type": "system_prompt",
-                    "name": func_name,
-                    "arguments": arguments,
-                    "id": f"system_prompt_{func_name}_{i}"
-                })
-            
+
+                tool_calls.append(
+                    {
+                        "type": "system_prompt",
+                        "name": func_name,
+                        "arguments": arguments,
+                        "id": f"system_prompt_{func_name}_{i}",
+                    }
+                )
+
             if tool_calls:
                 return tool_calls
-        
+
         # Second try: find the "Tool Call:" format
-        tool_call_match = re.search(r'Tool Call:\s*(\[.*?\])', text_content, re.DOTALL)
+        tool_call_match = re.search(r"Tool Call:\s*(\[.*?\])", text_content, re.DOTALL)
         if tool_call_match:
             json_str = tool_call_match.group(1)
             try:
@@ -658,18 +690,20 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 if isinstance(parsed_calls, list):
                     for i, call in enumerate(parsed_calls):
                         if isinstance(call, dict) and "name" in call:
-                            tool_calls.append({
-                                "type": "system_prompt",
-                                "name": call["name"],
-                                "arguments": call.get("arguments", {}),
-                                "id": f"system_prompt_{call['name']}_{i}"
-                            })
+                            tool_calls.append(
+                                {
+                                    "type": "system_prompt",
+                                    "name": call["name"],
+                                    "arguments": call.get("arguments", {}),
+                                    "id": f"system_prompt_{call['name']}_{i}",
+                                }
+                            )
                     return tool_calls
             except json.JSONDecodeError as e:
                 self.logger.warning(f"Failed to parse Tool Call JSON array: {json_str} - {e}")
-        
+
         # Fallback: try to parse any JSON array in the text
-        array_match = re.search(r'\[.*?\]', text_content, re.DOTALL)
+        array_match = re.search(r"\[.*?\]", text_content, re.DOTALL)
         if array_match:
             json_str = array_match.group(0)
             try:
@@ -677,76 +711,92 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 if isinstance(parsed_calls, list):
                     for i, call in enumerate(parsed_calls):
                         if isinstance(call, dict) and "name" in call:
-                            tool_calls.append({
-                                "type": "system_prompt",
-                                "name": call["name"],
-                                "arguments": call.get("arguments", {}),
-                                "id": f"system_prompt_{call['name']}_{i}"
-                            })
+                            tool_calls.append(
+                                {
+                                    "type": "system_prompt",
+                                    "name": call["name"],
+                                    "arguments": call.get("arguments", {}),
+                                    "id": f"system_prompt_{call['name']}_{i}",
+                                }
+                            )
                     return tool_calls
             except json.JSONDecodeError as e:
                 self.logger.warning(f"Failed to parse JSON array: {json_str} - {e}")
-        
+
         # Fallback: try to parse as single JSON object (backward compatibility)
         try:
             json_match = re.search(r'\{[^}]*"name"[^}]*"arguments"[^}]*\}', text_content, re.DOTALL)
             if json_match:
                 json_str = json_match.group(0)
                 function_call = json.loads(json_str)
-                
+
                 if "name" in function_call:
-                    return [{
-                        "type": "system_prompt",
-                        "name": function_call["name"],
-                        "arguments": function_call.get("arguments", {}),
-                        "id": f"system_prompt_{function_call['name']}"
-                    }]
-                    
+                    return [
+                        {
+                            "type": "system_prompt",
+                            "name": function_call["name"],
+                            "arguments": function_call.get("arguments", {}),
+                            "id": f"system_prompt_{function_call['name']}",
+                        }
+                    ]
+
         except json.JSONDecodeError as e:
-            self.logger.warning(f"Failed to parse system prompt tool response as JSON: {text_content} - {e}")
-            
+            self.logger.warning(
+                f"Failed to parse system prompt tool response as JSON: {text_content} - {e}"
+            )
+
             # Fallback to old custom tag format in case some models still use it
             function_regex = r"<function=([^>]+)>(.*?)</function>"
             match = re.search(function_regex, text_content)
-            
+
             if match:
                 function_name = match.group(1)
                 function_args_json = match.group(2)
-                
+
                 try:
                     function_args = json.loads(function_args_json)
-                    return [{
-                        "type": "system_prompt",
-                        "name": function_name,
-                        "arguments": function_args,
-                        "id": f"system_prompt_{function_name}"
-                    }]
+                    return [
+                        {
+                            "type": "system_prompt",
+                            "name": function_name,
+                            "arguments": function_args,
+                            "id": f"system_prompt_{function_name}",
+                        }
+                    ]
                 except json.JSONDecodeError:
-                    self.logger.warning(f"Failed to parse fallback custom tag format: {function_args_json}")
-        
+                    self.logger.warning(
+                        f"Failed to parse fallback custom tag format: {function_args_json}"
+                    )
+
         return []
 
-    def _parse_anthropic_tool_response(self, processed_response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _parse_anthropic_tool_response(
+        self, processed_response: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Parse Anthropic tool response format (same as native provider)."""
         tool_uses = []
-        
+
         # Look for toolUse in content items (Bedrock format for Anthropic models)
         for content_item in processed_response.get("content", []):
             if "toolUse" in content_item:
                 tool_use = content_item["toolUse"]
-                tool_uses.append({
-                    "type": "anthropic",
-                    "name": tool_use["name"],
-                    "arguments": tool_use["input"],
-                    "id": tool_use["toolUseId"]
-                })
-        
+                tool_uses.append(
+                    {
+                        "type": "anthropic",
+                        "name": tool_use["name"],
+                        "arguments": tool_use["input"],
+                        "id": tool_use["toolUseId"],
+                    }
+                )
+
         return tool_uses
 
-    def _parse_tool_response(self, processed_response: Dict[str, Any], model_id: str) -> List[Dict[str, Any]]:
+    def _parse_tool_response(
+        self, processed_response: Dict[str, Any], model_id: str
+    ) -> List[Dict[str, Any]]:
         """Parse tool response based on model type."""
         schema_type = self._get_tool_schema_type(model_id)
-        
+
         if schema_type == ToolSchemaType.SYSTEM_PROMPT:
             return self._parse_system_prompt_tool_response(processed_response)
         elif schema_type == ToolSchemaType.ANTHROPIC:
@@ -754,17 +804,16 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         else:
             return self._parse_nova_tool_response(processed_response)
 
-    def _convert_messages_to_bedrock(self, messages: List[BedrockMessageParam]) -> List[Dict[str, Any]]:
+    def _convert_messages_to_bedrock(
+        self, messages: List[BedrockMessageParam]
+    ) -> List[Dict[str, Any]]:
         """Convert message parameters to Bedrock format."""
         bedrock_messages = []
         for message in messages:
-            bedrock_message = {
-                "role": message.get("role", "user"),
-                "content": []
-            }
-            
+            bedrock_message = {"role": message.get("role", "user"), "content": []}
+
             content = message.get("content", [])
-            
+
             if isinstance(content, str):
                 bedrock_message["content"].append({"text": content})
             elif isinstance(content, list):
@@ -773,13 +822,15 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                     if item_type == "text":
                         bedrock_message["content"].append({"text": item.get("text", "")})
                     elif item_type == "tool_use":
-                        bedrock_message["content"].append({
-                            "toolUse": {
-                                "toolUseId": item.get("id", ""),
-                                "name": item.get("name", ""),
-                                "input": item.get("input", {})
+                        bedrock_message["content"].append(
+                            {
+                                "toolUse": {
+                                    "toolUseId": item.get("id", ""),
+                                    "name": item.get("name", ""),
+                                    "input": item.get("input", {}),
+                                }
                             }
-                        })
+                        )
                     elif item_type == "tool_result":
                         tool_use_id = item.get("tool_use_id")
                         raw_content = item.get("content", [])
@@ -791,23 +842,25 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                                 # FIX: The content parts are dicts, not TextContent objects.
                                 if isinstance(part, dict) and "text" in part:
                                     bedrock_content_list.append({"text": part.get("text", "")})
-                        
+
                         # Bedrock requires content for error statuses.
                         if not bedrock_content_list and status == "error":
                             bedrock_content_list.append({"text": "Tool call failed with an error."})
 
-                        bedrock_message["content"].append({
-                            "toolResult": {
-                                "toolUseId": tool_use_id,
-                                "content": bedrock_content_list,
-                                "status": status,
+                        bedrock_message["content"].append(
+                            {
+                                "toolResult": {
+                                    "toolUseId": tool_use_id,
+                                    "content": bedrock_content_list,
+                                    "status": status,
+                                }
                             }
-                        })
-            
+                        )
+
             # Only add the message if it has content
             if bedrock_message["content"]:
                 bedrock_messages.append(bedrock_message)
-            
+
         return bedrock_messages
 
     async def _process_stream(self, stream_response, model: str) -> BedrockMessage:
@@ -830,14 +883,16 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                         # Tool use block started
                         tool_use_start = content_block["start"]["toolUse"]
                         self.logger.debug(f"Tool use block started: {tool_use_start}")
-                        tool_uses.append({
-                            "toolUse": {
-                                "toolUseId": tool_use_start.get("toolUseId"),
-                                "name": tool_use_start.get("name"),
-                                "input": tool_use_start.get("input", {}),
-                                "_input_accumulator": ""  # For accumulating streamed input
+                        tool_uses.append(
+                            {
+                                "toolUse": {
+                                    "toolUseId": tool_use_start.get("toolUseId"),
+                                    "name": tool_use_start.get("name"),
+                                    "input": tool_use_start.get("input", {}),
+                                    "_input_accumulator": "",  # For accumulating streamed input
+                                }
                             }
-                        })
+                        )
                 elif "contentBlockDelta" in event:
                     # Content delta received
                     delta = event["contentBlockDelta"]["delta"]
@@ -845,7 +900,9 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                         text = delta["text"]
                         response_content.append(text)
                         # Update streaming progress
-                        estimated_tokens = self._update_streaming_progress(text, model, estimated_tokens)
+                        estimated_tokens = self._update_streaming_progress(
+                            text, model, estimated_tokens
+                        )
                     elif "toolUse" in delta:
                         # Tool use delta - handle tool call
                         tool_use = delta["toolUse"]
@@ -854,16 +911,20 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                             # Handle input accumulation for streaming tool arguments
                             if "input" in tool_use:
                                 input_data = tool_use["input"]
-                                
+
                                 # If input is a dict, merge it directly
                                 if isinstance(input_data, dict):
                                     tool_uses[-1]["toolUse"]["input"].update(input_data)
                                 # If input is a string, accumulate it for later JSON parsing
                                 elif isinstance(input_data, str):
                                     tool_uses[-1]["toolUse"]["_input_accumulator"] += input_data
-                                    self.logger.debug(f"Accumulated input: {tool_uses[-1]['toolUse']['_input_accumulator']}")
+                                    self.logger.debug(
+                                        f"Accumulated input: {tool_uses[-1]['toolUse']['_input_accumulator']}"
+                                    )
                                 else:
-                                    self.logger.debug(f"Tool use input is unexpected type: {type(input_data)}: {input_data}")
+                                    self.logger.debug(
+                                        f"Tool use input is unexpected type: {type(input_data)}: {input_data}"
+                                    )
                                     # Set the input directly if it's not a dict or string
                                     tool_uses[-1]["toolUse"]["input"] = input_data
                 elif "contentBlockStop" in event:
@@ -873,7 +934,9 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                             if "_input_accumulator" in tool_use["toolUse"]:
                                 accumulated_input = tool_use["toolUse"]["_input_accumulator"]
                                 if accumulated_input:
-                                    self.logger.debug(f"Processing accumulated input: {accumulated_input}")
+                                    self.logger.debug(
+                                        f"Processing accumulated input: {accumulated_input}"
+                                    )
                                     try:
                                         # Try to parse the accumulated input as JSON
                                         parsed_input = json.loads(accumulated_input)
@@ -881,9 +944,13 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                                             tool_use["toolUse"]["input"].update(parsed_input)
                                         else:
                                             tool_use["toolUse"]["input"] = parsed_input
-                                        self.logger.debug(f"Successfully parsed accumulated input: {parsed_input}")
+                                        self.logger.debug(
+                                            f"Successfully parsed accumulated input: {parsed_input}"
+                                        )
                                     except json.JSONDecodeError as e:
-                                        self.logger.warning(f"Failed to parse accumulated input as JSON: {accumulated_input} - {e}")
+                                        self.logger.warning(
+                                            f"Failed to parse accumulated input as JSON: {accumulated_input} - {e}"
+                                        )
                                         # If it's not valid JSON, treat it as a string value
                                         tool_use["toolUse"]["input"] = accumulated_input
                                 # Clean up the accumulator
@@ -934,7 +1001,9 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 if "_input_accumulator" in tool_use["toolUse"]:
                     accumulated_input = tool_use["toolUse"]["_input_accumulator"]
                     if accumulated_input:
-                        self.logger.debug(f"Final processing of accumulated input: {accumulated_input}")
+                        self.logger.debug(
+                            f"Final processing of accumulated input: {accumulated_input}"
+                        )
                         try:
                             # Try to parse the accumulated input as JSON
                             parsed_input = json.loads(accumulated_input)
@@ -942,14 +1011,18 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                                 tool_use["toolUse"]["input"].update(parsed_input)
                             else:
                                 tool_use["toolUse"]["input"] = parsed_input
-                            self.logger.debug(f"Successfully parsed final accumulated input: {parsed_input}")
+                            self.logger.debug(
+                                f"Successfully parsed final accumulated input: {parsed_input}"
+                            )
                         except json.JSONDecodeError as e:
-                            self.logger.warning(f"Failed to parse final accumulated input as JSON: {accumulated_input} - {e}")
+                            self.logger.warning(
+                                f"Failed to parse final accumulated input as JSON: {accumulated_input} - {e}"
+                            )
                             # If it's not valid JSON, treat it as a string value
                             tool_use["toolUse"]["input"] = accumulated_input
                     # Clean up the accumulator
                     del tool_use["toolUse"]["_input_accumulator"]
-            
+
             response["content"].extend(tool_uses)
 
         return response
@@ -957,12 +1030,12 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
     def _process_non_streaming_response(self, response, model: str) -> BedrockMessage:
         """Process non-streaming response from Bedrock."""
         self.logger.debug(f"Processing non-streaming response: {response}")
-        
+
         # Extract response content
         content = response.get("output", {}).get("message", {}).get("content", [])
         usage = response.get("usage", {})
         stop_reason = response.get("stopReason", "end_turn")
-        
+
         # Show progress for non-streaming (single update)
         if usage.get("outputTokens", 0) > 0:
             token_str = str(usage.get("outputTokens", 0)).rjust(5)
@@ -974,7 +1047,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 "details": token_str.strip(),
             }
             self.logger.info("Non-streaming progress", data=data)
-        
+
         # Convert to the same format as streaming response
         processed_response = {
             "content": content,
@@ -986,7 +1059,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             "model": model,
             "role": "assistant",
         }
-        
+
         return processed_response
 
     async def _bedrock_completion(
@@ -998,7 +1071,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         Process a query using Bedrock and available tools.
         """
         client = self._get_bedrock_runtime_client()
-        
+
         try:
             messages: List[BedrockMessageParam] = []
             params = self.get_request_params(request_params)
@@ -1024,23 +1097,28 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         available_tools = []
         tool_list = None
         model_to_check = self.default_request_params.model or DEFAULT_BEDROCK_MODEL
-        
+
         if self._supports_tool_use(model_to_check):
             try:
                 tool_list = await self.aggregator.list_tools()
                 self.logger.debug(f"Found {len(tool_list.tools)} MCP tools")
-                
+
                 available_tools = self._convert_mcp_tools_to_bedrock(tool_list)
-                self.logger.debug(f"Successfully converted {len(available_tools)} tools for Bedrock")
-                
+                self.logger.debug(
+                    f"Successfully converted {len(available_tools)} tools for Bedrock"
+                )
+
             except Exception as e:
                 self.logger.error(f"Error fetching or converting MCP tools: {e}")
                 import traceback
+
                 self.logger.debug(f"Traceback: {traceback.format_exc()}")
                 available_tools = []
                 tool_list = None
         else:
-            self.logger.info(f"Model {model_to_check} does not support tool use - skipping tool preparation")
+            self.logger.info(
+                f"Model {model_to_check} does not support tool use - skipping tool preparation"
+            )
 
         responses: List[TextContent | ImageContent | EmbeddedResource] = []
         model = self.default_request_params.model
@@ -1051,14 +1129,14 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             # Process tools BEFORE message conversion for Llama native format
             model_to_check = model or DEFAULT_BEDROCK_MODEL
             schema_type = self._get_tool_schema_type(model_to_check)
-            
+
             # For Llama native format, we need to store tools before message conversion
             if schema_type == ToolSchemaType.SYSTEM_PROMPT and available_tools:
                 has_tools = bool(available_tools) and (
-                    (isinstance(available_tools, list) and len(available_tools) > 0) or
-                    (isinstance(available_tools, str) and available_tools.strip())
+                    (isinstance(available_tools, list) and len(available_tools) > 0)
+                    or (isinstance(available_tools, str) and available_tools.strip())
                 )
-                
+
                 if has_tools:
                     self._add_tools_to_request({}, available_tools, model_to_check)
                     self.logger.debug("Pre-processed Llama native tools for message injection")
@@ -1074,58 +1152,70 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
 
             # Add system prompt if available and supported by the model
             system_text = self.instruction or params.systemPrompt
-            
+
             # For Llama native format, inject tools into system prompt
-            if schema_type == ToolSchemaType.SYSTEM_PROMPT and hasattr(self, '_system_prompt_tools') and self._system_prompt_tools:
+            if (
+                schema_type == ToolSchemaType.SYSTEM_PROMPT
+                and hasattr(self, "_system_prompt_tools")
+                and self._system_prompt_tools
+            ):
                 # Combine system prompt with tools for Llama native format
                 if system_text:
                     system_text = f"{system_text}\n\n{self._system_prompt_tools}"
                 else:
                     system_text = self._system_prompt_tools
-                self.logger.debug(f"Combined system prompt with system prompt tools")
-            elif hasattr(self, '_system_prompt_tools') and self._system_prompt_tools:
+                self.logger.debug("Combined system prompt with system prompt tools")
+            elif hasattr(self, "_system_prompt_tools") and self._system_prompt_tools:
                 # For other formats, combine system prompt with tools
                 if system_text:
                     system_text = f"{system_text}\n\n{self._system_prompt_tools}"
                 else:
                     system_text = self._system_prompt_tools
-                self.logger.debug(f"Combined system prompt with tools system prompt")
-            
-            self.logger.info(f"DEBUG: BEFORE CHECK - model='{model_to_check}', has_system_text={bool(system_text)}")
-            self.logger.info(f"DEBUG: self.instruction='{self.instruction}', params.systemPrompt='{params.systemPrompt}'")
-            
+                self.logger.debug("Combined system prompt with tools system prompt")
+
+            self.logger.info(
+                f"DEBUG: BEFORE CHECK - model='{model_to_check}', has_system_text={bool(system_text)}"
+            )
+            self.logger.info(
+                f"DEBUG: self.instruction='{self.instruction}', params.systemPrompt='{params.systemPrompt}'"
+            )
+
             supports_system = self._supports_system_messages(model_to_check)
             self.logger.info(f"DEBUG: supports_system={supports_system}")
-            
+
             if system_text and supports_system:
-                converse_args["system"] = [
-                    {"text": system_text}
-                ]
+                converse_args["system"] = [{"text": system_text}]
                 self.logger.info(f"DEBUG: Added system prompt to {model_to_check} request")
             elif system_text:
                 # For models that don't support system messages, inject system prompt into the first user message
-                self.logger.info(f"DEBUG: Injecting system prompt into first user message for {model_to_check} (doesn't support system messages)")
+                self.logger.info(
+                    f"DEBUG: Injecting system prompt into first user message for {model_to_check} (doesn't support system messages)"
+                )
                 if bedrock_messages and bedrock_messages[0].get("role") == "user":
                     first_message = bedrock_messages[0]
                     if first_message.get("content") and len(first_message["content"]) > 0:
                         # Prepend system instruction to the first user message
                         original_text = first_message["content"][0].get("text", "")
-                        first_message["content"][0]["text"] = f"System: {system_text}\n\nUser: {original_text}"
-                        self.logger.info(f"DEBUG: Injected system prompt into first user message")
+                        first_message["content"][0]["text"] = (
+                            f"System: {system_text}\n\nUser: {original_text}"
+                        )
+                        self.logger.info("DEBUG: Injected system prompt into first user message")
             else:
                 self.logger.info(f"DEBUG: No system text provided for {model_to_check}")
 
             # Add tools if available - format depends on model type (skip for Llama native as already processed)
             if schema_type != ToolSchemaType.SYSTEM_PROMPT:
                 has_tools = bool(available_tools) and (
-                    (isinstance(available_tools, list) and len(available_tools) > 0) or
-                    (isinstance(available_tools, str) and available_tools.strip())
+                    (isinstance(available_tools, list) and len(available_tools) > 0)
+                    or (isinstance(available_tools, str) and available_tools.strip())
                 )
-                
+
                 if has_tools:
                     self._add_tools_to_request(converse_args, available_tools, model_to_check)
                 else:
-                    self.logger.debug("No tools available - omitting tool configuration from request")
+                    self.logger.debug(
+                        "No tools available - omitting tool configuration from request"
+                    )
 
             # Add inference configuration
             inference_config = {}
@@ -1133,36 +1223,36 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 inference_config["maxTokens"] = params.maxTokens
             if params.stopSequences:
                 inference_config["stopSequences"] = params.stopSequences
-            
+
             # Nova-specific recommended settings for tool calling
             if model and "nova" in model.lower():
                 inference_config["topP"] = 1.0
                 inference_config["temperature"] = 1.0
                 # Add additionalModelRequestFields for topK
-                converse_args["additionalModelRequestFields"] = {
-                    "inferenceConfig": {"topK": 1}
-                }
-            
+                converse_args["additionalModelRequestFields"] = {"inferenceConfig": {"topK": 1}}
+
             if inference_config:
                 converse_args["inferenceConfig"] = inference_config
 
             self.logger.debug(f"Bedrock converse args: {converse_args}")
-            
+
             # Debug: Print the actual messages being sent to Bedrock for Llama models
             schema_type = self._get_tool_schema_type(model_to_check)
             if schema_type == ToolSchemaType.SYSTEM_PROMPT:
                 self.logger.info("=== SYSTEM PROMPT DEBUG ===")
-                self.logger.info(f"Messages being sent to Bedrock:")
+                self.logger.info("Messages being sent to Bedrock:")
                 for i, msg in enumerate(converse_args.get("messages", [])):
                     self.logger.info(f"Message {i} ({msg.get('role', 'unknown')}):")
                     for j, content in enumerate(msg.get("content", [])):
                         if "text" in content:
                             self.logger.info(f"  Content {j}: {content['text'][:500]}...")
                 self.logger.info("=== END SYSTEM PROMPT DEBUG ===")
-            
+
             # Debug: Print the full tool config being sent
             if "toolConfig" in converse_args:
-                self.logger.debug(f"Tool config being sent to Bedrock: {json.dumps(converse_args['toolConfig'], indent=2)}")
+                self.logger.debug(
+                    f"Tool config being sent to Bedrock: {json.dumps(converse_args['toolConfig'], indent=2)}"
+                )
 
             try:
                 # Choose streaming vs non-streaming based on model capabilities and tool presence
@@ -1171,25 +1261,37 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 #   2. Model doesn't support streaming with tools
                 # Otherwise, always prefer streaming for better UX
                 has_tools = bool(available_tools) and (
-                    (isinstance(available_tools, list) and len(available_tools) > 0) or
-                    (isinstance(available_tools, str) and available_tools.strip())
+                    (isinstance(available_tools, list) and len(available_tools) > 0)
+                    or (isinstance(available_tools, str) and available_tools.strip())
                 )
-                
-                if has_tools and not self._supports_streaming_with_tools(model or DEFAULT_BEDROCK_MODEL):
+
+                if has_tools and not self._supports_streaming_with_tools(
+                    model or DEFAULT_BEDROCK_MODEL
+                ):
                     # Use non-streaming API: model requires it for tool calls
-                    self.logger.debug(f"Using non-streaming API for {model} with tools (model limitation)")
+                    self.logger.debug(
+                        f"Using non-streaming API for {model} with tools (model limitation)"
+                    )
                     response = client.converse(**converse_args)
-                    processed_response = self._process_non_streaming_response(response, model or DEFAULT_BEDROCK_MODEL)
+                    processed_response = self._process_non_streaming_response(
+                        response, model or DEFAULT_BEDROCK_MODEL
+                    )
                 else:
                     # Use streaming API: either no tools OR model supports streaming with tools
-                    streaming_reason = "no tools present" if not has_tools else "model supports streaming with tools"
+                    streaming_reason = (
+                        "no tools present"
+                        if not has_tools
+                        else "model supports streaming with tools"
+                    )
                     self.logger.debug(f"Using streaming API for {model} ({streaming_reason})")
                     response = client.converse_stream(**converse_args)
-                    processed_response = await self._process_stream(response, model or DEFAULT_BEDROCK_MODEL)
+                    processed_response = await self._process_stream(
+                        response, model or DEFAULT_BEDROCK_MODEL
+                    )
             except (ClientError, BotoCoreError) as e:
                 error_msg = str(e)
                 self.logger.error(f"Bedrock API error: {error_msg}")
-                
+
                 # Create error response
                 processed_response = {
                     "content": [{"text": f"Error during generation: {error_msg}"}],
@@ -1211,7 +1313,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                         total_tokens=usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
                         cache_creation_input_tokens=0,
                         cache_read_input_tokens=0,
-                        raw_usage=usage
+                        raw_usage=usage,
                     )
                     self.usage_accumulator.add_turn(turn_usage)
                 except Exception as e:
@@ -1222,7 +1324,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             # Convert response to message param and add to messages
             response_message_param = self.convert_message_to_message_param(processed_response)
             messages.append(response_message_param)
-            
+
             # Extract text content for responses
             if processed_response.get("content"):
                 for content_item in processed_response["content"]:
@@ -1231,24 +1333,28 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
 
             # Handle different stop reasons
             stop_reason = processed_response.get("stop_reason", "end_turn")
-            
+
             # For Llama native format, check for tool calls even if stop_reason is "end_turn"
             schema_type = self._get_tool_schema_type(model or DEFAULT_BEDROCK_MODEL)
             if schema_type == ToolSchemaType.SYSTEM_PROMPT and stop_reason == "end_turn":
                 # Check if there's a tool call in the response
-                parsed_tools = self._parse_tool_response(processed_response, model or DEFAULT_BEDROCK_MODEL)
+                parsed_tools = self._parse_tool_response(
+                    processed_response, model or DEFAULT_BEDROCK_MODEL
+                )
                 if parsed_tools:
                     # Override stop_reason to handle as tool_use
                     stop_reason = "tool_use"
-                    self.logger.debug(f"Detected system prompt tool call, overriding stop_reason to 'tool_use'")
-            
+                    self.logger.debug(
+                        "Detected system prompt tool call, overriding stop_reason to 'tool_use'"
+                    )
+
             if stop_reason == "end_turn":
                 # Extract text for display
                 message_text = ""
                 for content_item in processed_response.get("content", []):
                     if content_item.get("text"):
                         message_text += content_item["text"]
-                
+
                 await self.show_assistant_message(message_text)
                 self.logger.debug(f"Iteration {i}: Stopping because stop_reason is 'end_turn'")
                 break
@@ -1275,12 +1381,14 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 for content_item in processed_response.get("content", []):
                     if content_item.get("text"):
                         message_text += content_item["text"]
-                
+
                 # Parse tool calls using model-specific method
                 self.logger.info(f"DEBUG: About to parse tool response: {processed_response}")
-                parsed_tools = self._parse_tool_response(processed_response, model or DEFAULT_BEDROCK_MODEL)
+                parsed_tools = self._parse_tool_response(
+                    processed_response, model or DEFAULT_BEDROCK_MODEL
+                )
                 self.logger.info(f"DEBUG: Parsed tools: {parsed_tools}")
-                
+
                 if parsed_tools:
                     # We will comment out showing the assistant's intermediate message
                     # to make the output less chatty, as requested by the user.
@@ -1297,25 +1405,27 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                     for tool_idx, parsed_tool in enumerate(parsed_tools):
                         # The original name is needed to call the tool, which is in tool_name_mapping.
                         tool_name_from_model = parsed_tool["name"]
-                        tool_name = self.tool_name_mapping.get(tool_name_from_model, tool_name_from_model)
-                        
+                        tool_name = self.tool_name_mapping.get(
+                            tool_name_from_model, tool_name_from_model
+                        )
+
                         tool_args = parsed_tool["arguments"]
                         tool_use_id = parsed_tool["id"]
-                        
+
                         self.show_tool_call(tool_list.tools, tool_name, tool_args)
-                        
+
                         tool_call_request = CallToolRequest(
                             method="tools/call",
                             params=CallToolRequestParams(name=tool_name, arguments=tool_args),
                         )
-                        
+
                         # Call the tool and get the result
                         result = await self.call_tool(
                             request=tool_call_request, tool_call_id=tool_use_id
                         )
                         # We will also comment out showing the raw tool result to reduce verbosity.
                         # self.show_tool_result(result)
-                        
+
                         # Add each result to our collection
                         tool_results_for_batch.append((tool_use_id, result, tool_name))
                         responses.extend(result.content)
@@ -1334,9 +1444,13 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                         tool_result_parts = []
                         for _, tool_result, tool_name in tool_results_for_batch:
                             result_text = "".join(
-                                [part.text for part in tool_result.content if isinstance(part, TextContent)]
+                                [
+                                    part.text
+                                    for part in tool_result.content
+                                    if isinstance(part, TextContent)
+                                ]
                             )
-                            
+
                             # Create a representation of the tool's output.
                             # Using a JSON-like string is a robust way to present this.
                             result_payload = {
@@ -1345,14 +1459,16 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                                 "result": result_text,
                             }
                             tool_result_parts.append(json.dumps(result_payload))
-                        
+
                         if tool_result_parts:
                             # Combine all tool results into a single text block.
                             full_result_text = f"Tool Results:\n{', '.join(tool_result_parts)}"
-                            messages.append({
-                                "role": "user",
-                                "content": [{"type": "text", "text": full_result_text}],
-                            })
+                            messages.append(
+                                {
+                                    "role": "user",
+                                    "content": [{"type": "text", "text": full_result_text}],
+                                }
+                            )
                     else:
                         # For native tool-using models (Anthropic, Nova), use the structured 'tool_result' format.
                         tool_result_blocks = []
@@ -1366,26 +1482,32 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                                         result_content_blocks.append({"text": part.text})
                                     # Note: This can be extended to handle other content types like images
                                     # For now, we are focusing on making text-based tools work correctly.
-                            
+
                             # If there's no content, provide a default message.
                             if not result_content_blocks:
-                                 result_content_blocks.append({"text": "[No content in tool result]"})
+                                result_content_blocks.append(
+                                    {"text": "[No content in tool result]"}
+                                )
 
                             # This is the format Bedrock expects for tool results in the Converse API
-                            tool_result_blocks.append({
-                                "type": "tool_result",
-                                "tool_use_id": tool_id,
-                                "content": result_content_blocks,
-                                "status": "error" if tool_result.isError else "success",
-                            })
-                        
+                            tool_result_blocks.append(
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": tool_id,
+                                    "content": result_content_blocks,
+                                    "status": "error" if tool_result.isError else "success",
+                                }
+                            )
+
                         if tool_result_blocks:
                             # Append a single user message with all the tool results for this turn
-                            messages.append({
-                                "role": "user",
-                                "content": tool_result_blocks,
-                            })
-                    
+                            messages.append(
+                                {
+                                    "role": "user",
+                                    "content": tool_result_blocks,
+                                }
+                            )
+
                     continue
                 else:
                     # No tool uses but stop_reason was tool_use/tool_calls, treat as end_turn
@@ -1397,12 +1519,12 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                 for content_item in processed_response.get("content", []):
                     if content_item.get("text"):
                         message_text += content_item["text"]
-                
+
                 if message_text:
                     await self.show_assistant_message(message_text)
                 break
 
-        # Update history 
+        # Update history
         if params.use_history:
             # Get current prompt messages
             prompt_messages = self.history.get(include_completion_history=False)
@@ -1417,8 +1539,6 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
 
             self.history.set(new_messages)
 
-
-            
         # Strip leading whitespace from the *last* non-empty text block of the final response
         # to ensure the output is clean.
         if responses:
@@ -1436,13 +1556,13 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
     ) -> PromptMessageMultipart:
         """Generate messages using Bedrock."""
         responses = await self._bedrock_completion(message_param, request_params)
-        
+
         # Convert responses to PromptMessageMultipart
         content_list = []
         for response in responses:
             if isinstance(response, TextContent):
                 content_list.append(response)
-        
+
         return PromptMessageMultipart(role="assistant", content=content_list)
 
     async def _apply_prompt_provider_specific(
@@ -1454,10 +1574,10 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         """Apply Bedrock-specific prompt formatting."""
         if not multipart_messages:
             return PromptMessageMultipart(role="user", content=[])
-        
+
         # Check the last message role
         last_message = multipart_messages[-1]
-        
+
         # Add all previous messages to history (or all messages if last is from assistant)
         # if the last message is a "user" inference is required
         messages_to_add = (
@@ -1466,37 +1586,25 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         converted = []
         for msg in messages_to_add:
             # Convert each message to Bedrock message parameter format
-            bedrock_msg = {
-                "role": msg.role,
-                "content": []
-            }
+            bedrock_msg = {"role": msg.role, "content": []}
             for content_item in msg.content:
                 if isinstance(content_item, TextContent):
-                    bedrock_msg["content"].append({
-                        "type": "text",
-                        "text": content_item.text
-                    })
+                    bedrock_msg["content"].append({"type": "text", "text": content_item.text})
             converted.append(bedrock_msg)
-        
+
         # Add messages to history
         self.history.extend(converted, is_prompt=is_template)
-        
+
         if last_message.role == "assistant":
             # For assistant messages: Return the last message (no completion needed)
             return last_message
-        
+
         # Convert the last user message to Bedrock message parameter format
-        message_param = {
-            "role": last_message.role,
-            "content": []
-        }
+        message_param = {"role": last_message.role, "content": []}
         for content_item in last_message.content:
             if isinstance(content_item, TextContent):
-                message_param["content"].append({
-                    "type": "text",
-                    "text": content_item.text
-                })
-        
+                message_param["content"].append({"type": "text", "text": content_item.text})
+
         # Generate response
         return await self.generate_messages(message_param, request_params)
 
@@ -1506,38 +1614,46 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         def get_field_type_representation(field_type: Any) -> Any:
             """Get a string representation for a field type."""
             # Handle Optional types
-            if hasattr(field_type, '__origin__') and field_type.__origin__ is Union:
+            if hasattr(field_type, "__origin__") and field_type.__origin__ is Union:
                 non_none_types = [t for t in field_type.__args__ if t is not type(None)]
                 if non_none_types:
                     field_type = non_none_types[0]
 
             # Handle basic types
-            if field_type == str:
+            if field_type is str:
                 return "string"
-            elif field_type == int:
+            elif field_type is int:
                 return "integer"
-            elif field_type == float:
+            elif field_type is float:
                 return "float"
-            elif field_type == bool:
+            elif field_type is bool:
                 return "boolean"
 
             # Handle Enum types
-            elif hasattr(field_type, '__bases__') and any(issubclass(base, Enum) for base in field_type.__bases__ if isinstance(base, type)):
+            elif hasattr(field_type, "__bases__") and any(
+                issubclass(base, Enum) for base in field_type.__bases__ if isinstance(base, type)
+            ):
                 enum_values = [f'"{e.value}"' for e in field_type]
                 return f"string (must be one of: {', '.join(enum_values)})"
 
             # Handle List types
-            elif hasattr(field_type, '__origin__') and hasattr(field_type, '__args__') and field_type.__origin__ is list:
+            elif (
+                hasattr(field_type, "__origin__")
+                and hasattr(field_type, "__args__")
+                and field_type.__origin__ is list
+            ):
                 item_type_repr = "any"
                 if field_type.__args__:
                     item_type_repr = get_field_type_representation(field_type.__args__[0])
                 return [item_type_repr]
 
             # Handle nested Pydantic models
-            elif hasattr(field_type, '__bases__') and any(hasattr(base, 'model_fields') for base in field_type.__bases__):
+            elif hasattr(field_type, "__bases__") and any(
+                hasattr(base, "model_fields") for base in field_type.__bases__
+            ):
                 nested_schema = _generate_schema_dict(field_type)
                 return nested_schema
-            
+
             # Default fallback
             else:
                 return "any"
@@ -1545,7 +1661,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         def _generate_schema_dict(model_class: Type) -> Dict[str, Any]:
             """Recursively generate the schema as a dictionary."""
             schema_dict = {}
-            if hasattr(model_class, 'model_fields'):
+            if hasattr(model_class, "model_fields"):
                 for field_name, field_info in model_class.model_fields.items():
                     schema_dict[field_name] = get_field_type_representation(field_info.annotation)
             return schema_dict
@@ -1578,9 +1694,9 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             "- Do not add any extra fields to the JSON response. Only include the fields specified in the schema.",
             "- Valid JSON requires double quotes for all field names and string values. Other types (int, float, boolean, etc.) should not be quoted.",
             "",
-            "Now, generate the valid JSON response for the following request:"
+            "Now, generate the valid JSON response for the following request:",
         ]
-        
+
         # Add the new prompt to the last user message
         multipart_messages[-1].add_text("\n".join(prompt_parts))
 
@@ -1590,69 +1706,61 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             multipart_messages, request_params
         )
         return self._structured_from_multipart(result, model)
-    
+
     def _clean_json_response(self, text: str) -> str:
         """Clean up JSON response by removing text before first { and after last }."""
         if not text:
             return text
-        
+
         # Find the first { and last }
-        first_brace = text.find('{')
-        last_brace = text.rfind('}')
-        
+        first_brace = text.find("{")
+        last_brace = text.rfind("}")
+
         # If we found both braces, extract just the JSON part
         if first_brace != -1 and last_brace != -1 and first_brace < last_brace:
-            return text[first_brace:last_brace + 1]
-        
+            return text[first_brace : last_brace + 1]
+
         # Otherwise return the original text
         return text
-    
+
     def _structured_from_multipart(
         self, message: PromptMessageMultipart, model: Type[ModelT]
     ) -> Tuple[ModelT | None, PromptMessageMultipart]:
         """Override to apply JSON cleaning before parsing."""
         # Get the text from the multipart message
         text = message.all_text()
-        
+
         # Clean the JSON response to remove extra text
         cleaned_text = self._clean_json_response(text)
-        
+
         # If we cleaned the text, create a new multipart with the cleaned text
         if cleaned_text != text:
             from mcp.types import TextContent
+
             cleaned_multipart = PromptMessageMultipart(
-                role=message.role,
-                content=[TextContent(type="text", text=cleaned_text)]
+                role=message.role, content=[TextContent(type="text", text=cleaned_text)]
             )
         else:
             cleaned_multipart = message
-        
+
         # Use the parent class method with the cleaned multipart
         return super()._structured_from_multipart(cleaned_multipart, model)
-
-
 
     @classmethod
     def convert_message_to_message_param(
         cls, message: BedrockMessage, **kwargs
     ) -> BedrockMessageParam:
         """Convert a Bedrock message to message parameter format."""
-        message_param = {
-            "role": message.get("role", "assistant"),
-            "content": []
-        }
-        
+        message_param = {"role": message.get("role", "assistant"), "content": []}
+
         for content_item in message.get("content", []):
             if isinstance(content_item, dict):
                 if "text" in content_item:
-                    message_param["content"].append({
-                        "type": "text",
-                        "text": content_item["text"]
-                    })
+                    message_param["content"].append({"type": "text", "text": content_item["text"]})
                 elif "toolUse" in content_item:
                     tool_use = content_item["toolUse"]
                     tool_input = tool_use.get("input", {})
-                    
+
                     # Ensure tool_input is a dictionary
                     if not isinstance(tool_input, dict):
                         if isinstance(tool_input, str):
@@ -1662,16 +1770,18 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
                                 tool_input = {}
                         else:
                             tool_input = {}
-                    
-                    message_param["content"].append({
-                        "type": "tool_use",
-                        "id": tool_use.get("toolUseId", ""),
-                        "name": tool_use.get("name", ""),
-                        "input": tool_input
-                    })
-        
+
+                    message_param["content"].append(
+                        {
+                            "type": "tool_use",
+                            "id": tool_use.get("toolUseId", ""),
+                            "name": tool_use.get("name", ""),
+                            "input": tool_input,
+                        }
+                    )
+
         return message_param
 
     def _api_key(self) -> str:
         """Bedrock doesn't use API keys, returns empty string."""
-        return "" 
+        return ""

--- a/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
@@ -1,0 +1,898 @@
+import json
+import os
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
+
+from mcp.types import EmbeddedResource, ImageContent, TextContent
+from rich.text import Text
+
+from mcp_agent.core.exceptions import ProviderKeyError
+from mcp_agent.core.prompt import Prompt
+from mcp_agent.core.request_params import RequestParams
+from mcp_agent.event_progress import ProgressAction
+from mcp_agent.llm.augmented_llm import AugmentedLLM
+from mcp_agent.llm.provider_types import Provider
+from mcp_agent.llm.usage_tracking import TurnUsage
+from mcp_agent.logging.logger import get_logger
+from mcp_agent.mcp.interfaces import ModelT
+from mcp_agent.mcp.prompt_message_multipart import PromptMessageMultipart
+
+if TYPE_CHECKING:
+    from mcp import ListToolsResult
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+except ImportError:
+    boto3 = None
+    BotoCoreError = Exception
+    ClientError = Exception
+    NoCredentialsError = Exception
+
+from mcp.types import (
+    CallToolRequest,
+    CallToolRequestParams,
+)
+
+DEFAULT_BEDROCK_MODEL = "amazon.nova-lite-v1:0"
+
+# Bedrock message format types
+BedrockMessage = Dict[str, Any]  # Bedrock message format
+BedrockMessageParam = Dict[str, Any]  # Bedrock message parameter format
+
+
+class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
+    """
+    AWS Bedrock implementation of AugmentedLLM using the Converse API.
+    Supports all Bedrock models including Nova, Claude, Meta, etc.
+    """
+
+    # Bedrock-specific parameter exclusions
+    BEDROCK_EXCLUDE_FIELDS = {
+        AugmentedLLM.PARAM_MESSAGES,
+        AugmentedLLM.PARAM_MODEL,
+        AugmentedLLM.PARAM_SYSTEM_PROMPT,
+        AugmentedLLM.PARAM_STOP_SEQUENCES,
+        AugmentedLLM.PARAM_MAX_TOKENS,
+        AugmentedLLM.PARAM_METADATA,
+        AugmentedLLM.PARAM_USE_HISTORY,
+        AugmentedLLM.PARAM_MAX_ITERATIONS,
+        AugmentedLLM.PARAM_PARALLEL_TOOL_CALLS,
+        AugmentedLLM.PARAM_TEMPLATE_VARS,
+    }
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize the Bedrock LLM with AWS credentials and region."""
+        if boto3 is None:
+            raise ImportError(
+                "boto3 is required for Bedrock support. Install with: pip install boto3"
+            )
+        
+        # Initialize logger
+        self.logger = get_logger(__name__)
+
+        # Extract AWS configuration from kwargs first
+        self.aws_region = kwargs.pop("region", None)
+        self.aws_profile = kwargs.pop("profile", None)
+        
+        super().__init__(*args, provider=Provider.BEDROCK, **kwargs)
+        
+        # Use config values if not provided in kwargs (after super().__init__)
+        if self.context.config and self.context.config.bedrock:
+            if not self.aws_region:
+                self.aws_region = self.context.config.bedrock.region
+            if not self.aws_profile:
+                self.aws_profile = self.context.config.bedrock.profile
+        
+        # Final fallback to environment variables
+        if not self.aws_region:
+            self.aws_region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+        
+        # Initialize AWS clients
+        self._bedrock_client = None
+        self._bedrock_runtime_client = None
+
+    def _initialize_default_params(self, kwargs: dict) -> RequestParams:
+        """Initialize Bedrock-specific default parameters"""
+        # Get base defaults from parent (includes ModelDatabase lookup)
+        base_params = super()._initialize_default_params(kwargs)
+
+        # Override with Bedrock-specific settings
+        chosen_model = kwargs.get("model", DEFAULT_BEDROCK_MODEL)
+        base_params.model = chosen_model
+
+        return base_params
+
+    def _get_bedrock_client(self):
+        """Get or create Bedrock client."""
+        if self._bedrock_client is None:
+            try:
+                session = boto3.Session(profile_name=self.aws_profile)
+                self._bedrock_client = session.client("bedrock", region_name=self.aws_region)
+            except NoCredentialsError as e:
+                raise ProviderKeyError(
+                    "AWS credentials not found",
+                    "Please configure AWS credentials using AWS CLI, environment variables, or IAM roles.",
+                ) from e
+        return self._bedrock_client
+
+    def _get_bedrock_runtime_client(self):
+        """Get or create Bedrock Runtime client."""
+        if self._bedrock_runtime_client is None:
+            try:
+                session = boto3.Session(profile_name=self.aws_profile)
+                self._bedrock_runtime_client = session.client("bedrock-runtime", region_name=self.aws_region)
+            except NoCredentialsError as e:
+                raise ProviderKeyError(
+                    "AWS credentials not found",
+                    "Please configure AWS credentials using AWS CLI, environment variables, or IAM roles.",
+                ) from e
+        return self._bedrock_runtime_client
+
+    def _supports_streaming_with_tools(self, model: str) -> bool:
+        """
+        Check if a model supports streaming with tools.
+        
+        Some models (like AI21 Jamba) support tools but not in streaming mode.
+        This method uses regex patterns to identify such models.
+        
+        Args:
+            model: The model name (e.g., "ai21.jamba-1-5-mini-v1:0")
+            
+        Returns:
+            False if the model requires non-streaming for tools, True otherwise
+        """
+        # Remove any "bedrock." prefix for pattern matching
+        clean_model = model.replace("bedrock.", "")
+        
+        # Models that don't support streaming with tools
+        non_streaming_patterns = [
+            r"ai21\.jamba",     # All AI21 Jamba models
+            r"meta\.llama",     # All Meta Llama models
+            r"mistral\.",       # All Mistral models
+        ]
+        
+        for pattern in non_streaming_patterns:
+            if re.search(pattern, clean_model, re.IGNORECASE):
+                self.logger.debug(f"Model {model} detected as non-streaming for tools (pattern: {pattern})")
+                return False
+        
+        return True
+
+    def _convert_mcp_tools_to_bedrock(self, tools: "ListToolsResult") -> List[Dict[str, Any]]:
+        """Convert MCP tools to Bedrock tool format.
+        
+        Note: Nova models have VERY strict JSON schema requirements:
+        - Top level schema must be of type Object
+        - ONLY three fields are supported: type, properties, required
+        - NO other fields like $schema, description, title, additionalProperties
+        - Properties can only have type and description
+        - Tools with no parameters should have empty properties object
+        """
+        bedrock_tools = []
+        
+        # Create mapping from cleaned names to original names for tool execution
+        self.tool_name_mapping = {}
+        
+        self.logger.debug(f"Converting {len(tools.tools)} MCP tools to Bedrock format")
+        
+        for tool in tools.tools:
+            self.logger.debug(f"Converting MCP tool: {tool.name}")
+            
+            # Extract and validate the input schema
+            input_schema = tool.inputSchema or {}
+            
+            # Create Nova-compliant schema with ONLY the three allowed fields
+            # Always include type and properties (even if empty)
+            nova_schema: Dict[str, Any] = {
+                "type": "object",
+                "properties": {}
+            }
+            
+            # Properties - clean them strictly
+            properties: Dict[str, Any] = {}
+            if "properties" in input_schema and isinstance(input_schema["properties"], dict):
+                for prop_name, prop_def in input_schema["properties"].items():
+                    # Only include type and description for each property
+                    clean_prop: Dict[str, Any] = {}
+                    
+                    if isinstance(prop_def, dict):
+                        # Only include type (required) and description (optional)
+                        clean_prop["type"] = prop_def.get("type", "string")
+                        # Nova allows description in properties
+                        if "description" in prop_def:
+                            clean_prop["description"] = prop_def["description"]
+                    else:
+                        # Handle simple property definitions
+                        clean_prop["type"] = "string"
+                    
+                    properties[prop_name] = clean_prop
+            
+            # Always set properties (even if empty for parameterless tools)
+            nova_schema["properties"] = properties
+                
+            # Required fields - only add if present and not empty
+            if "required" in input_schema and isinstance(input_schema["required"], list) and input_schema["required"]:
+                nova_schema["required"] = input_schema["required"]
+            
+            # IMPORTANT: Nova tool name compatibility fix
+            # Problem: Amazon Nova models fail with "Model produced invalid sequence as part of ToolUse" 
+            # when tool names contain hyphens (e.g., "utils-get_current_date_information")
+            # Solution: Replace hyphens with underscores for Nova (e.g., "utils_get_current_date_information")
+            # Note: Underscores work fine, simple names work fine, but hyphens cause tool calling to fail
+            clean_name = tool.name.replace("-", "_")
+            
+            # Store mapping from cleaned name back to original MCP name
+            # This is needed because:
+            # 1. Nova receives tools with cleaned names (utils_get_current_date_information)
+            # 2. Nova calls tools using cleaned names
+            # 3. But MCP server expects original names (utils-get_current_date_information)
+            # 4. So we map back: utils_get_current_date_information -> utils-get_current_date_information
+            self.tool_name_mapping[clean_name] = tool.name
+            
+            bedrock_tool = {
+                "toolSpec": {
+                    "name": clean_name,
+                    "description": tool.description or f"Tool: {tool.name}",
+                    "inputSchema": {
+                        "json": nova_schema
+                    }
+                }
+            }
+            
+            bedrock_tools.append(bedrock_tool)
+            
+        self.logger.debug(f"Converted {len(bedrock_tools)} tools for Bedrock")
+        return bedrock_tools
+
+    def _convert_messages_to_bedrock(self, messages: List[BedrockMessageParam]) -> List[Dict[str, Any]]:
+        """Convert message parameters to Bedrock format."""
+        bedrock_messages = []
+        for message in messages:
+            bedrock_message = {
+                "role": message.get("role", "user"),
+                "content": []
+            }
+            
+            # Handle different content types
+            content = message.get("content", [])
+            if isinstance(content, str):
+                bedrock_message["content"] = [{"text": content}]
+            elif isinstance(content, list):
+                for item in content:
+                    if isinstance(item, str):
+                        bedrock_message["content"].append({"text": item})
+                    elif isinstance(item, dict):
+                        if item.get("type") == "text":
+                            bedrock_message["content"].append({"text": item.get("text", "")})
+                        elif item.get("type") == "tool_use":
+                            bedrock_message["content"].append({
+                                "toolUse": {
+                                    "toolUseId": item.get("id", ""),
+                                    "name": item.get("name", ""),
+                                    "input": item.get("input", {})
+                                }
+                            })
+                        elif item.get("type") == "tool_result":
+                            # Nova-specific tool result format
+                            tool_result_content = item.get("content", "")
+                            
+                            # Try to parse as JSON for structured data
+                            try:
+                                # If content is already a dict, use it directly
+                                if isinstance(tool_result_content, dict):
+                                    json_content = tool_result_content
+                                else:
+                                    # Try to parse as JSON string
+                                    parsed_content = json.loads(tool_result_content)
+                                    
+                                    # Nova requires JSON content to be an object, not a primitive
+                                    # If we got a primitive value, wrap it in an object
+                                    if isinstance(parsed_content, (str, int, float, bool, list)):
+                                        json_content = {"result": parsed_content}
+                                    else:
+                                        json_content = parsed_content
+                                
+                                bedrock_message["content"].append({
+                                    "toolResult": {
+                                        "toolUseId": item.get("tool_call_id", ""),
+                                        "content": [{"json": json_content}],
+                                        "status": "success"
+                                    }
+                                })
+                            except (json.JSONDecodeError, TypeError):
+                                # Fall back to text format for non-JSON content
+                                bedrock_message["content"].append({
+                                    "toolResult": {
+                                        "toolUseId": item.get("tool_call_id", ""),
+                                        "content": [{"text": str(tool_result_content)}],
+                                        "status": "success"
+                                    }
+                                })
+            
+            bedrock_messages.append(bedrock_message)
+        
+        return bedrock_messages
+
+    async def _process_stream(self, stream_response, model: str) -> BedrockMessage:
+        """Process streaming response from Bedrock."""
+        estimated_tokens = 0
+        response_content = []
+        tool_uses = []
+        stop_reason = None
+        usage = {"input_tokens": 0, "output_tokens": 0}
+
+        try:
+            for event in stream_response["stream"]:
+                if "messageStart" in event:
+                    # Message started
+                    continue
+                elif "contentBlockStart" in event:
+                    # Content block started
+                    content_block = event["contentBlockStart"]
+                    if "start" in content_block and "toolUse" in content_block["start"]:
+                        # Tool use block started
+                        tool_use_start = content_block["start"]["toolUse"]
+                        self.logger.debug(f"Tool use block started: {tool_use_start}")
+                        tool_uses.append({
+                            "toolUse": {
+                                "toolUseId": tool_use_start.get("toolUseId"),
+                                "name": tool_use_start.get("name"),
+                                "input": tool_use_start.get("input", {}),
+                                "_input_accumulator": ""  # For accumulating streamed input
+                            }
+                        })
+                elif "contentBlockDelta" in event:
+                    # Content delta received
+                    delta = event["contentBlockDelta"]["delta"]
+                    if "text" in delta:
+                        text = delta["text"]
+                        response_content.append(text)
+                        # Update streaming progress
+                        estimated_tokens = self._update_streaming_progress(text, model, estimated_tokens)
+                    elif "toolUse" in delta:
+                        # Tool use delta - handle tool call
+                        tool_use = delta["toolUse"]
+                        self.logger.debug(f"Tool use delta: {tool_use}")
+                        if tool_use and tool_uses:
+                            # Handle input accumulation for streaming tool arguments
+                            if "input" in tool_use:
+                                input_data = tool_use["input"]
+                                
+                                # If input is a dict, merge it directly
+                                if isinstance(input_data, dict):
+                                    tool_uses[-1]["toolUse"]["input"].update(input_data)
+                                # If input is a string, accumulate it for later JSON parsing
+                                elif isinstance(input_data, str):
+                                    tool_uses[-1]["toolUse"]["_input_accumulator"] += input_data
+                                    self.logger.debug(f"Accumulated input: {tool_uses[-1]['toolUse']['_input_accumulator']}")
+                                else:
+                                    self.logger.debug(f"Tool use input is unexpected type: {type(input_data)}: {input_data}")
+                                    # Set the input directly if it's not a dict or string
+                                    tool_uses[-1]["toolUse"]["input"] = input_data
+                elif "contentBlockStop" in event:
+                    # Content block stopped - finalize any accumulated tool input
+                    if tool_uses:
+                        for tool_use in tool_uses:
+                            if "_input_accumulator" in tool_use["toolUse"]:
+                                accumulated_input = tool_use["toolUse"]["_input_accumulator"]
+                                if accumulated_input:
+                                    self.logger.debug(f"Processing accumulated input: {accumulated_input}")
+                                    try:
+                                        # Try to parse the accumulated input as JSON
+                                        parsed_input = json.loads(accumulated_input)
+                                        if isinstance(parsed_input, dict):
+                                            tool_use["toolUse"]["input"].update(parsed_input)
+                                        else:
+                                            tool_use["toolUse"]["input"] = parsed_input
+                                        self.logger.debug(f"Successfully parsed accumulated input: {parsed_input}")
+                                    except json.JSONDecodeError as e:
+                                        self.logger.warning(f"Failed to parse accumulated input as JSON: {accumulated_input} - {e}")
+                                        # If it's not valid JSON, treat it as a string value
+                                        tool_use["toolUse"]["input"] = accumulated_input
+                                # Clean up the accumulator
+                                del tool_use["toolUse"]["_input_accumulator"]
+                    continue
+                elif "messageStop" in event:
+                    # Message stopped
+                    if "stopReason" in event["messageStop"]:
+                        stop_reason = event["messageStop"]["stopReason"]
+                elif "metadata" in event:
+                    # Usage metadata
+                    metadata = event["metadata"]
+                    if "usage" in metadata:
+                        usage = metadata["usage"]
+                        actual_tokens = usage.get("outputTokens", 0)
+                        if actual_tokens > 0:
+                            # Emit final progress with actual token count
+                            token_str = str(actual_tokens).rjust(5)
+                            data = {
+                                "progress_action": ProgressAction.STREAMING,
+                                "model": model,
+                                "agent_name": self.name,
+                                "chat_turn": self.chat_turn(),
+                                "details": token_str.strip(),
+                            }
+                            self.logger.info("Streaming progress", data=data)
+        except Exception as e:
+            self.logger.error(f"Error processing stream: {e}")
+            raise
+
+        # Construct the response message
+        full_text = "".join(response_content)
+        response = {
+            "content": [{"text": full_text}] if full_text else [],
+            "stop_reason": stop_reason or "end_turn",
+            "usage": {
+                "input_tokens": usage.get("inputTokens", 0),
+                "output_tokens": usage.get("outputTokens", 0),
+            },
+            "model": model,
+            "role": "assistant",
+        }
+
+        # Add tool uses if any
+        if tool_uses:
+            # Clean up any remaining accumulators before adding to response
+            for tool_use in tool_uses:
+                if "_input_accumulator" in tool_use["toolUse"]:
+                    accumulated_input = tool_use["toolUse"]["_input_accumulator"]
+                    if accumulated_input:
+                        self.logger.debug(f"Final processing of accumulated input: {accumulated_input}")
+                        try:
+                            # Try to parse the accumulated input as JSON
+                            parsed_input = json.loads(accumulated_input)
+                            if isinstance(parsed_input, dict):
+                                tool_use["toolUse"]["input"].update(parsed_input)
+                            else:
+                                tool_use["toolUse"]["input"] = parsed_input
+                            self.logger.debug(f"Successfully parsed final accumulated input: {parsed_input}")
+                        except json.JSONDecodeError as e:
+                            self.logger.warning(f"Failed to parse final accumulated input as JSON: {accumulated_input} - {e}")
+                            # If it's not valid JSON, treat it as a string value
+                            tool_use["toolUse"]["input"] = accumulated_input
+                    # Clean up the accumulator
+                    del tool_use["toolUse"]["_input_accumulator"]
+            
+            response["content"].extend(tool_uses)
+
+        return response
+
+    def _process_non_streaming_response(self, response, model: str) -> BedrockMessage:
+        """Process non-streaming response from Bedrock."""
+        self.logger.debug(f"Processing non-streaming response: {response}")
+        
+        # Extract response content
+        content = response.get("output", {}).get("message", {}).get("content", [])
+        usage = response.get("usage", {})
+        stop_reason = response.get("stopReason", "end_turn")
+        
+        # Show progress for non-streaming (single update)
+        if usage.get("outputTokens", 0) > 0:
+            token_str = str(usage.get("outputTokens", 0)).rjust(5)
+            data = {
+                "progress_action": ProgressAction.STREAMING,
+                "model": model,
+                "agent_name": self.name,
+                "chat_turn": self.chat_turn(),
+                "details": token_str.strip(),
+            }
+            self.logger.info("Non-streaming progress", data=data)
+        
+        # Convert to the same format as streaming response
+        processed_response = {
+            "content": content,
+            "stop_reason": stop_reason,
+            "usage": {
+                "input_tokens": usage.get("inputTokens", 0),
+                "output_tokens": usage.get("outputTokens", 0),
+            },
+            "model": model,
+            "role": "assistant",
+        }
+        
+        return processed_response
+
+    async def _bedrock_completion(
+        self,
+        message_param: BedrockMessageParam,
+        request_params: RequestParams | None = None,
+    ) -> List[TextContent | ImageContent | EmbeddedResource]:
+        """
+        Process a query using Bedrock and available tools.
+        """
+        client = self._get_bedrock_runtime_client()
+        
+        try:
+            messages: List[BedrockMessageParam] = []
+            params = self.get_request_params(request_params)
+        except (ClientError, BotoCoreError) as e:
+            error_msg = str(e)
+            if "UnauthorizedOperation" in error_msg or "AccessDenied" in error_msg:
+                raise ProviderKeyError(
+                    "AWS Bedrock access denied",
+                    "Please check your AWS credentials and IAM permissions for Bedrock.",
+                ) from e
+            else:
+                raise ProviderKeyError(
+                    "AWS Bedrock error",
+                    f"Error accessing Bedrock: {error_msg}",
+                ) from e
+
+        # Always include prompt messages, but only include conversation history
+        # if use_history is True
+        messages.extend(self.history.get(include_completion_history=params.use_history))
+        messages.append(message_param)
+
+        # Get available tools
+        available_tools = []
+        tool_list = None
+        try:
+            tool_list = await self.aggregator.list_tools()
+            self.logger.debug(f"Found {len(tool_list.tools)} MCP tools")
+            
+            available_tools = self._convert_mcp_tools_to_bedrock(tool_list)
+            self.logger.debug(f"Successfully converted {len(available_tools)} tools for Bedrock")
+            
+        except Exception as e:
+            self.logger.error(f"Error fetching or converting MCP tools: {e}")
+            import traceback
+            self.logger.debug(f"Traceback: {traceback.format_exc()}")
+            available_tools = []
+            tool_list = None
+
+        responses: List[TextContent | ImageContent | EmbeddedResource] = []
+        model = self.default_request_params.model
+
+        for i in range(params.max_iterations):
+            self._log_chat_progress(self.chat_turn(), model=model)
+
+            # Convert messages to Bedrock format
+            bedrock_messages = self._convert_messages_to_bedrock(messages)
+
+            # Prepare Bedrock Converse API arguments
+            converse_args = {
+                "modelId": model,
+                "messages": bedrock_messages,
+            }
+
+            # Add system prompt if available
+            if self.instruction or params.systemPrompt:
+                converse_args["system"] = [
+                    {"text": self.instruction or params.systemPrompt}
+                ]
+
+            # Add tools if available - Nova requires at least one tool if toolConfig is provided
+            if available_tools and len(available_tools) > 0:
+                converse_args["toolConfig"] = {
+                    "tools": available_tools
+                }
+                self.logger.debug(f"Added {len(available_tools)} tools to Nova request")
+            else:
+                self.logger.debug("No tools available - omitting toolConfig from Nova request")
+
+            # Add inference configuration
+            inference_config = {}
+            if params.maxTokens is not None:
+                inference_config["maxTokens"] = params.maxTokens
+            if params.stopSequences:
+                inference_config["stopSequences"] = params.stopSequences
+            
+            # Nova-specific recommended settings for tool calling
+            if model and "nova" in model.lower():
+                inference_config["topP"] = 1.0
+                inference_config["temperature"] = 1.0
+                # Add additionalModelRequestFields for topK
+                converse_args["additionalModelRequestFields"] = {
+                    "inferenceConfig": {"topK": 1}
+                }
+            
+            if inference_config:
+                converse_args["inferenceConfig"] = inference_config
+
+            self.logger.debug(f"Bedrock converse args: {converse_args}")
+            
+            # Debug: Print the full tool config being sent
+            if "toolConfig" in converse_args:
+                self.logger.debug(f"Tool config being sent to Bedrock: {json.dumps(converse_args['toolConfig'], indent=2)}")
+
+            try:
+                # Choose streaming vs non-streaming based on model capabilities and tool presence
+                # Logic: Only use non-streaming when BOTH conditions are true:
+                #   1. Tools are available (available_tools is not empty)
+                #   2. Model doesn't support streaming with tools
+                # Otherwise, always prefer streaming for better UX
+                if available_tools and not self._supports_streaming_with_tools(model or DEFAULT_BEDROCK_MODEL):
+                    # Use non-streaming API: model requires it for tool calls
+                    self.logger.debug(f"Using non-streaming API for {model} with tools (model limitation)")
+                    response = client.converse(**converse_args)
+                    processed_response = self._process_non_streaming_response(response, model or DEFAULT_BEDROCK_MODEL)
+                else:
+                    # Use streaming API: either no tools OR model supports streaming with tools
+                    streaming_reason = "no tools present" if not available_tools else "model supports streaming with tools"
+                    self.logger.debug(f"Using streaming API for {model} ({streaming_reason})")
+                    response = client.converse_stream(**converse_args)
+                    processed_response = await self._process_stream(response, model or DEFAULT_BEDROCK_MODEL)
+            except (ClientError, BotoCoreError) as e:
+                error_msg = str(e)
+                self.logger.error(f"Bedrock API error: {error_msg}")
+                
+                # Create error response
+                processed_response = {
+                    "content": [{"text": f"Error during generation: {error_msg}"}],
+                    "stop_reason": "error",
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                    "model": model,
+                    "role": "assistant",
+                }
+
+            # Track usage
+            if processed_response.get("usage"):
+                try:
+                    usage = processed_response["usage"]
+                    turn_usage = TurnUsage(
+                        provider=Provider.BEDROCK.value,
+                        model=model,
+                        input_tokens=usage.get("input_tokens", 0),
+                        output_tokens=usage.get("output_tokens", 0),
+                        total_tokens=usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+                        cache_creation_input_tokens=0,
+                        cache_read_input_tokens=0,
+                        raw_usage=usage
+                    )
+                    self.usage_accumulator.add_turn(turn_usage)
+                except Exception as e:
+                    self.logger.warning(f"Failed to track usage: {e}")
+
+            self.logger.debug(f"{model} response:", data=processed_response)
+
+            # Convert response to message param and add to messages
+            response_message_param = self.convert_message_to_message_param(processed_response)
+            messages.append(response_message_param)
+            
+            # Extract text content for responses
+            if processed_response.get("content"):
+                for content_item in processed_response["content"]:
+                    if content_item.get("text"):
+                        responses.append(TextContent(type="text", text=content_item["text"]))
+
+            # Handle different stop reasons
+            stop_reason = processed_response.get("stop_reason", "end_turn")
+            
+            if stop_reason == "end_turn":
+                # Extract text for display
+                message_text = ""
+                for content_item in processed_response.get("content", []):
+                    if content_item.get("text"):
+                        message_text += content_item["text"]
+                
+                await self.show_assistant_message(message_text)
+                self.logger.debug(f"Iteration {i}: Stopping because stop_reason is 'end_turn'")
+                break
+            elif stop_reason == "stop_sequence":
+                self.logger.debug(f"Iteration {i}: Stopping because stop_reason is 'stop_sequence'")
+                break
+            elif stop_reason == "max_tokens":
+                self.logger.debug(f"Iteration {i}: Stopping because stop_reason is 'max_tokens'")
+                if params.maxTokens is not None:
+                    message_text = Text(
+                        f"the assistant has reached the maximum token limit ({params.maxTokens})",
+                        style="dim green italic",
+                    )
+                else:
+                    message_text = Text(
+                        "the assistant has reached the maximum token limit",
+                        style="dim green italic",
+                    )
+                await self.show_assistant_message(message_text)
+                break
+            elif stop_reason == "tool_use":
+                # Handle tool use
+                message_text = ""
+                for content_item in processed_response.get("content", []):
+                    if content_item.get("text"):
+                        message_text += content_item["text"]
+                
+                # Collect tool uses
+                tool_uses = [
+                    content_item for content_item in processed_response.get("content", [])
+                    if "toolUse" in content_item
+                ]
+                
+                if tool_uses:
+                    if not message_text:
+                        message_text = Text(
+                            "the assistant requested tool calls",
+                            style="dim green italic",
+                        )
+                    
+                    # Process tool calls
+                    tool_results = []
+                    for tool_idx, tool_use_item in enumerate(tool_uses):
+                        self.logger.debug(f"Processing tool use item: {tool_use_item}")
+                        tool_use = tool_use_item["toolUse"]
+                        self.logger.debug(f"Tool use object: {tool_use}")
+                        tool_name = tool_use["name"]
+                        tool_args = tool_use["input"]
+                        tool_use_id = tool_use["toolUseId"]
+                        
+                        # Ensure tool_args is a dictionary
+                        if not isinstance(tool_args, dict):
+                            self.logger.debug(f"Converting tool_args from {type(tool_args)} to dict: {tool_args}")
+                            if tool_args == "":
+                                tool_args = {}
+                            elif isinstance(tool_args, str):
+                                try:
+                                    # Try to parse as JSON
+                                    tool_args = json.loads(tool_args)
+                                except json.JSONDecodeError:
+                                    self.logger.warning(f"Failed to parse tool_args as JSON: {tool_args}")
+                                    tool_args = {}
+                            else:
+                                tool_args = {}
+                        
+                        if tool_idx == 0:  # Only show message for first tool use
+                            await self.show_assistant_message(message_text, tool_name)
+                        
+                        # Show tool call with available tools
+                        if tool_list and tool_list.tools:
+                            self.show_tool_call(tool_list.tools, tool_name, tool_args)
+                        else:
+                            self.logger.warning(f"Tool list not available for displaying tool call: {tool_name}")
+                        
+                        # Map the tool name back to original MCP name if needed
+                        original_tool_name = getattr(self, 'tool_name_mapping', {}).get(tool_name, tool_name)
+                        self.logger.debug(f"Mapping tool name '{tool_name}' to '{original_tool_name}'")
+                        
+                        # Create tool call request
+                        tool_call_request = CallToolRequest(
+                            method="tools/call",
+                            params=CallToolRequestParams(
+                                name=original_tool_name,
+                                arguments=tool_args,
+                            ),
+                        )
+                        
+                        # Execute tool call
+                        tool_result = await self.call_tool(tool_call_request, tool_use_id)
+                        tool_results.append(tool_result)
+                        
+                        # Add tool result to messages
+                        tool_result_content = tool_result.content[0].text if tool_result.content else ""
+                        
+                        # Format tool result for Nova compatibility
+                        tool_result_message = {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_call_id": tool_use_id,
+                                    "content": tool_result_content,
+                                }
+                            ],
+                        }
+                        messages.append(tool_result_message)
+                    
+                    continue  # Continue to next iteration for tool use
+                else:
+                    # No tool uses but stop_reason was tool_use, treat as end_turn
+                    await self.show_assistant_message(message_text)
+                    break
+            else:
+                # Unknown stop reason, continue or break based on content
+                message_text = ""
+                for content_item in processed_response.get("content", []):
+                    if content_item.get("text"):
+                        message_text += content_item["text"]
+                
+                if message_text:
+                    await self.show_assistant_message(message_text)
+                break
+
+        return responses
+
+    async def generate_messages(
+        self,
+        message_param: BedrockMessageParam,
+        request_params: RequestParams | None = None,
+    ) -> PromptMessageMultipart:
+        """Generate messages using Bedrock."""
+        responses = await self._bedrock_completion(message_param, request_params)
+        
+        # Convert responses to PromptMessageMultipart
+        content_list = []
+        for response in responses:
+            if isinstance(response, TextContent):
+                content_list.append(response)
+        
+        return PromptMessageMultipart(role="assistant", content=content_list)
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: List[PromptMessageMultipart],
+        request_params: RequestParams | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageMultipart:
+        """Apply Bedrock-specific prompt formatting."""
+        if not multipart_messages:
+            return PromptMessageMultipart(role="user", content=[])
+        
+        # Use the last message as the user message
+        last_message = multipart_messages[-1]
+        
+        # Convert to Bedrock message parameter format
+        message_param = {
+            "role": last_message.role,
+            "content": []
+        }
+        
+        for content_item in last_message.content:
+            if isinstance(content_item, TextContent):
+                message_param["content"].append({
+                    "type": "text",
+                    "text": content_item.text
+                })
+        
+        # Generate response
+        return await self.generate_messages(message_param, request_params)
+
+    async def _apply_prompt_provider_specific_structured(
+        self,
+        multipart_messages: List[PromptMessageMultipart],
+        model: Type[ModelT],
+        request_params: RequestParams | None = None,
+    ) -> Tuple[ModelT | None, PromptMessageMultipart]:
+        """Apply structured output for Bedrock (not directly supported)."""
+        # Bedrock doesn't have native structured output like OpenAI
+        # We'll need to rely on prompt engineering
+        response = await self._apply_prompt_provider_specific(
+            multipart_messages, request_params, is_template=True
+        )
+        
+        # Try to parse the response as structured data
+        parsed_model = self._structured_from_multipart(response, model)
+        return parsed_model
+
+    @classmethod
+    def convert_message_to_message_param(
+        cls, message: BedrockMessage, **kwargs
+    ) -> BedrockMessageParam:
+        """Convert a Bedrock message to message parameter format."""
+        message_param = {
+            "role": message.get("role", "assistant"),
+            "content": []
+        }
+        
+        for content_item in message.get("content", []):
+            if isinstance(content_item, dict):
+                if "text" in content_item:
+                    message_param["content"].append({
+                        "type": "text",
+                        "text": content_item["text"]
+                    })
+                elif "toolUse" in content_item:
+                    tool_use = content_item["toolUse"]
+                    tool_input = tool_use.get("input", {})
+                    
+                    # Ensure tool_input is a dictionary
+                    if not isinstance(tool_input, dict):
+                        if isinstance(tool_input, str):
+                            try:
+                                tool_input = json.loads(tool_input) if tool_input else {}
+                            except json.JSONDecodeError:
+                                tool_input = {}
+                        else:
+                            tool_input = {}
+                    
+                    message_param["content"].append({
+                        "type": "tool_use",
+                        "id": tool_use.get("toolUseId", ""),
+                        "name": tool_use.get("name", ""),
+                        "input": tool_input
+                    })
+        
+        return message_param
+
+    def _api_key(self) -> str:
+        """Bedrock doesn't use API keys, returns empty string."""
+        return "" 

--- a/src/mcp_agent/logging/logger.py
+++ b/src/mcp_agent/logging/logger.py
@@ -8,6 +8,7 @@ Logger module for the MCP Agent, which provides:
 """
 
 import asyncio
+import logging
 import threading
 import time
 from contextlib import asynccontextmanager, contextmanager
@@ -205,6 +206,12 @@ class LoggingConfig:
         """
         if cls._initialized:
             return
+
+        # Suppress boto3/botocore logging to prevent flooding
+        logging.getLogger('boto3').setLevel(logging.WARNING)
+        logging.getLogger('botocore').setLevel(logging.WARNING)
+        logging.getLogger('urllib3').setLevel(logging.WARNING)
+        logging.getLogger('s3transfer').setLevel(logging.WARNING)
 
         bus = AsyncEventBus.get(transport=transport)
 

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.39.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1f/b7510dcd26eb14735d6f4b2904e219b825660425a0cf0b6f35b84c7249b0/boto3-1.39.4.tar.gz", hash = "sha256:6c955729a1d70181bc8368e02a7d3f350884290def63815ebca8408ee6d47571", size = 111829, upload-time = "2025-07-09T19:23:01.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/5c/93292e4d8c809950c13950b3168e0eabdac828629c21047959251ad3f28c/boto3-1.39.4-py3-none-any.whl", hash = "sha256:f8e9534b429121aa5c5b7c685c6a94dd33edf14f87926e9a182d5b50220ba284", size = 139908, upload-time = "2025-07-09T19:22:59.808Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.39.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/9f/21c823ea2fae3fa5a6c9e8caaa1f858acd55018e6d317505a4f14c5bb999/botocore-1.39.4.tar.gz", hash = "sha256:e662ac35c681f7942a93f2ec7b4cde8f8b56dd399da47a79fa3e370338521a56", size = 14136116, upload-time = "2025-07-09T19:22:49.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/44/f120319e0a9afface645e99f300175b9b308e4724cb400b32e1bd6eb3060/botocore-1.39.4-py3-none-any.whl", hash = "sha256:c41e167ce01cfd1973c3fa9856ef5244a51ddf9c82cb131120d8617913b6812a", size = 13795516, upload-time = "2025-07-09T19:22:44.446Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -463,6 +491,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "azure-identity" },
+    { name = "boto3" },
     { name = "deprecated" },
     { name = "email-validator" },
     { name = "fastapi" },
@@ -471,10 +500,10 @@ dependencies = [
     { name = "openai" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-anthropic", marker = "python_full_version < '4.0'" },
+    { name = "opentelemetry-instrumentation-anthropic", marker = "python_full_version < '4'" },
     { name = "opentelemetry-instrumentation-google-genai" },
-    { name = "opentelemetry-instrumentation-mcp", marker = "python_full_version < '4.0'" },
-    { name = "opentelemetry-instrumentation-openai", marker = "python_full_version < '4.0'" },
+    { name = "opentelemetry-instrumentation-mcp", marker = "python_full_version < '4'" },
+    { name = "opentelemetry-instrumentation-openai", marker = "python_full_version < '4'" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -525,6 +554,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.42.0" },
     { name = "azure-identity", specifier = ">=1.14.0" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.14.0" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "deprecated", specifier = ">=1.2.18" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.115.6" },
@@ -534,10 +564,10 @@ requires-dist = [
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.58.1" },
     { name = "opentelemetry-distro", specifier = ">=0.50b0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
-    { name = "opentelemetry-instrumentation-anthropic", marker = "python_full_version >= '3.10' and python_full_version < '4.0'", specifier = ">=0.40.14" },
+    { name = "opentelemetry-instrumentation-anthropic", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=0.40.14" },
     { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.2b0" },
-    { name = "opentelemetry-instrumentation-mcp", marker = "python_full_version >= '3.10' and python_full_version < '4.0'", specifier = ">=0.40.14" },
-    { name = "opentelemetry-instrumentation-openai", marker = "python_full_version >= '3.10' and python_full_version < '4.0'", specifier = ">=0.40.14" },
+    { name = "opentelemetry-instrumentation-mcp", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=0.40.14" },
+    { name = "opentelemetry-instrumentation-openai", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=0.40.14" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.50" },
     { name = "pydantic", specifier = ">=2.10.4" },
@@ -976,6 +1006,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/b3/2bd02071c5a2430d0b70403a34411fc519c2f227da7b03da9ba6a956f931/jiter-0.10.0-cp314-cp314-win32.whl", hash = "sha256:ac509f7eccca54b2a29daeb516fb95b6f0bd0d0d8084efaf8ed5dfc7b9f0b357", size = 210127, upload-time = "2025-05-18T19:04:38.837Z" },
     { url = "https://files.pythonhosted.org/packages/03/0c/5fe86614ea050c3ecd728ab4035534387cd41e7c1855ef6c031f1ca93e3f/jiter-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ed975b83a2b8639356151cef5c0d597c68376fc4922b45d0eb384ac058cfa00", size = 318527, upload-time = "2025-05-18T19:04:40.612Z" },
     { url = "https://files.pythonhosted.org/packages/b3/4a/4175a563579e884192ba6e81725fc0448b042024419be8d83aa8a80a3f44/jiter-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aa96f2abba33dc77f79b4cf791840230375f9534e5fac927ccceb58c5e604a5", size = 354213, upload-time = "2025-05-18T19:04:41.894Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
 ]
 
 [[package]]
@@ -1696,6 +1735,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1903,6 +1954,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944, upload-time = "2025-06-05T21:00:08.459Z" },
     { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669, upload-time = "2025-06-05T21:00:11.147Z" },
     { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928, upload-time = "2025-06-05T21:00:13.758Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/5d/9dcc100abc6711e8247af5aa561fc07c4a046f72f659c3adea9a449e191a/s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177", size = 150232, upload-time = "2025-05-22T19:24:50.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/17/22bf8155aa0ea2305eefa3a6402e040df7ebe512d1310165eda1e233c3f8/s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be", size = 85152, upload-time = "2025-05-22T19:24:48.703Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is a proper AWS Bedrock provider for full support of all AWS Bedrock models

features:
- streaming responses for all providers
- tool use for all providers
- streaming responses during tool use for models that support it; non-streaming response during tool use otherwise
- uses the AWS SDK directly, eliminating the need for proxy gateways such as Bedrock Access Gateway, LiteLLM, TensorZero, etc.
- Tool information is supplied to the various models in the proper format for that model

I tried using Bedrock with fast-agent via:
**Bedrock Access Gateway** - chat worked, but tool support was broken
**LiteLLM proxy**: chat worked, but tool support also broken
**TensorZero gateway**: chat worked, but tool support also broken.  Additionally, there was a lot of complexity setting up the TOML file - literally every single model AND every single tool call had to be manually set up in the TOML config.

I spent a lot of time trying to get Bedrock models working in fast-agent via these types of proxies, but the problem was consistent - whether setting up a model as "custom" or "openai" - it would send the tool schema in the openai format always, which the models rejected.  Since Bedrock aggregates many different models from different places, each model must receive the tool information in the schema that particular model understands, and the proxy layers (and fast-agent) were unable to provide this tool data in the correct format.  These issues would cascade throughout fast-agent; for example, workflow agents (routers, etc) would not work due to the broken tool calls.

This pull request fixes all of the above by implementing a native Bedrock provider using the AWS SDK (boto3 library).  This  has been thoroughly tested and is perfectly stable.  