### PR TITLE
Mcp filtering

### DIFF
--- a/examples/mcp/mcp-filtering/fastagent.config.yaml
+++ b/examples/mcp/mcp-filtering/fastagent.config.yaml
@@ -3,4 +3,4 @@ mcp:
     # name used in agent servers array
     creativity:
       command: "uv"
-      args: ["run","mcp_server.py"]y
+      args: ["run", "mcp_server.py"]

--- a/examples/mcp/mcp-filtering/fastagent.config.yaml
+++ b/examples/mcp/mcp-filtering/fastagent.config.yaml
@@ -1,0 +1,6 @@
+mcp:
+  servers:
+    # name used in agent servers array
+    creativity:
+      command: "uv"
+      args: ["run","mcp_server.py"]y

--- a/examples/mcp/mcp-filtering/fastagent.secrets.yaml.example
+++ b/examples/mcp/mcp-filtering/fastagent.secrets.yaml.example
@@ -1,0 +1,16 @@
+# FastAgent Secrets Configuration
+# WARNING: Keep this file secure and never commit to version control
+
+# Alternatively set OPENAI_API_KEY, ANTHROPIC_API_KEY or other environment variables.
+# Keys in the configuration file override environment variables.
+
+openai:
+  api_key: <your-api-key-here>
+anthropic:
+  api_key: <your-api-key-here>
+deepseek:
+  api_key: <your-api-key-here>
+openrouter:
+  api_key: <your-api-key-here>
+
+default_model: <choose a default model for your provider>

--- a/examples/mcp/mcp-filtering/mcp_server.py
+++ b/examples/mcp/mcp-filtering/mcp_server.py
@@ -1,5 +1,6 @@
 import random
 import string
+
 from mcp.server.fastmcp import FastMCP
 
 app = FastMCP(name="Creative Writing Server")

--- a/examples/mcp/mcp-filtering/mcp_server.py
+++ b/examples/mcp/mcp-filtering/mcp_server.py
@@ -1,0 +1,57 @@
+import random
+import string
+from fastmcp import FastMCP # Install fastmcp to use this server
+
+mcp = FastMCP(
+    name="Creative writing tools",
+    instructions="""
+    This is an MCP server with tools for creative writing.
+    """,
+    dependencies=[]
+)
+
+@mcp.tool
+def reverse_string(text: str) -> str:
+    """Reverses a string."""
+    return text[::-1]
+
+@mcp.tool
+def capitalize_string(text: str) -> str:
+    """Capitalizes a string."""
+    return text.upper()
+
+@mcp.tool
+def lowercase_string(text: str) -> str:
+    """Converts a string to lowercase."""
+    return text.lower()
+
+@mcp.tool
+def random_string(length: int) -> str:
+    """Generates a random string of a given length."""
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+@mcp.tool
+def random_case_string(text: str) -> str:
+    """Randomly capitalizes or lowercase each letter in a string."""
+    return ''.join(random.choice([str.upper, str.lower])(c) for c in text)
+
+@mcp.tool
+def coding_camel_case(text: str) -> str:
+    """Converts a string to camel case."""
+    return text.title().replace(" ", "")
+
+@mcp.tool
+def coding_snake_case(text: str) -> str:
+    """Converts a string to snake case."""
+    return text.lower().replace(" ", "_")
+
+@mcp.tool
+def coding_kebab_case(text: str) -> str:
+    """Converts a string to kebab case."""
+    return text.lower().replace(" ", "-")
+
+
+
+if __name__ == "__main__":
+    # Run in stdio mode
+    mcp.run()

--- a/examples/mcp/mcp-filtering/mcp_server.py
+++ b/examples/mcp/mcp-filtering/mcp_server.py
@@ -1,57 +1,126 @@
 import random
 import string
-from fastmcp import FastMCP # Install fastmcp to use this server
+from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP(
-    name="Creative writing tools",
-    instructions="""
-    This is an MCP server with tools for creative writing.
-    """,
-    dependencies=[]
+app = FastMCP(name="Creative Writing Server")
+
+# String manipulation tools
+@app.tool(
+    name="reverse_string",
+    description="Reverses a string",
 )
-
-@mcp.tool
 def reverse_string(text: str) -> str:
-    """Reverses a string."""
     return text[::-1]
 
-@mcp.tool
+@app.tool(
+    name="capitalize_string",
+    description="Capitalizes a string",
+)
 def capitalize_string(text: str) -> str:
-    """Capitalizes a string."""
     return text.upper()
 
-@mcp.tool
+@app.tool(
+    name="lowercase_string",
+    description="Converts a string to lowercase",
+)
 def lowercase_string(text: str) -> str:
-    """Converts a string to lowercase."""
     return text.lower()
 
-@mcp.tool
+@app.tool(
+    name="random_string",
+    description="Generates a random string of a given length",
+)
 def random_string(length: int) -> str:
-    """Generates a random string of a given length."""
     return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
 
-@mcp.tool
+@app.tool(
+    name="random_case_string",
+    description="Randomly capitalizes or lowercase each letter in a string",
+)
 def random_case_string(text: str) -> str:
-    """Randomly capitalizes or lowercase each letter in a string."""
     return ''.join(random.choice([str.upper, str.lower])(c) for c in text)
 
-@mcp.tool
+# Code formatting tools
+@app.tool(
+    name="coding_camel_case",
+    description="Converts a string to camel case",
+)
 def coding_camel_case(text: str) -> str:
-    """Converts a string to camel case."""
     return text.title().replace(" ", "")
 
-@mcp.tool
+@app.tool(
+    name="coding_snake_case",
+    description="Converts a string to snake case",
+)
 def coding_snake_case(text: str) -> str:
-    """Converts a string to snake case."""
     return text.lower().replace(" ", "_")
 
-@mcp.tool
+@app.tool(
+    name="coding_kebab_case",
+    description="Converts a string to kebab case",
+)
 def coding_kebab_case(text: str) -> str:
-    """Converts a string to kebab case."""
     return text.lower().replace(" ", "-")
+
+# Resources
+@app.resource("resource://writing/style_guide")
+def writing_style_guide() -> str:
+    return """Writing Style Guide:
+1. Use active voice when possible
+2. Keep sentences concise and clear
+3. Vary sentence structure for rhythm
+4. Use strong, specific verbs
+5. Avoid excessive adverbs"""
+
+@app.resource("resource://writing/character_names")
+def character_names() -> str:
+    return """Character Name Ideas:
+Fantasy: Eldara, Thorne, Zephyr, Lyanna
+Modern: Alex, Jordan, Riley, Cameron
+Historical: Eleanor, Benedict, Cordelia, Jasper
+Sci-fi: Zara, Kai, Nova, Orion"""
+
+@app.resource("resource://coding/conventions")
+def coding_conventions() -> str:
+    return """Coding Conventions:
+- Variables: snake_case
+- Functions: snake_case
+- Classes: PascalCase
+- Constants: UPPER_CASE
+- Files: lowercase with hyphens"""
+
+@app.resource("resource://creativity/prompts")
+def creativity_prompts() -> str:
+    return """Creative Writing Prompts:
+1. A character discovers they can hear colors
+2. The last person on Earth receives a phone call
+3. A library where books come to life at night
+4. Time moves backwards for one day only
+5. A world where lies become physical objects"""
+
+# Prompts
+@app.prompt("writing_assistant")
+def writing_assistant(genre: str = "general") -> str:
+    """Creative writing assistant for different genres"""
+    return f"I am a creative writing assistant specialized in {genre} writing. I can help you with story structure, character development, dialogue, and prose improvement."
+
+@app.prompt("writing_feedback")
+def writing_feedback(focus: str = "overall") -> str:
+    """Provides feedback on written work"""
+    return f"I am a writing coach focused on {focus} feedback. I'll provide constructive criticism and suggestions to improve your writing."
+
+@app.prompt("coding_helper")
+def coding_helper(language: str = "python") -> str:
+    """Coding assistant for formatting and conventions"""
+    return f"I am a coding assistant specialized in {language}. I can help you with code formatting, naming conventions, and best practices."
+
+@app.prompt("creative_brainstorm")
+def creative_brainstorm(topic: str = "general") -> str:
+    """Brainstorming assistant for creative projects"""
+    return f"I am a creative brainstorming assistant focused on {topic}. I can help you generate ideas, explore concepts, and overcome creative blocks."
 
 
 
 if __name__ == "__main__":
     # Run in stdio mode
-    mcp.run()
+    app.run()

--- a/examples/mcp/mcp-filtering/test_mcp_filtering.py
+++ b/examples/mcp/mcp-filtering/test_mcp_filtering.py
@@ -5,33 +5,80 @@ from mcp_agent.core.fastagent import FastAgent, PromptExitError
 
 
 fast_agent = FastAgent(
-    name="MCP Filtering Tests",
+    name="MCP Filtering Demo",
     parse_cli_args=False,
     quiet=False
 )
 
 @fast_agent.agent(
-    name=f"test-mcp-filtering",    
-    model="gpt-4.1",
-    instruction="You are a creative writer.  You have been supplied with tools to help you with creative tasks.",
+    name="filtered_agent",    
+    model="gpt-4o-mini",
+    instruction="You are a creative writer with filtered access to tools, resources, and prompts.",
     servers=["creativity"],
-    tools={"creativity": ["reverse_string", "code*"]}  # Only supply the reverse string, and the coding tools by wildcard
+    # Tool filtering: only string manipulation tools and coding tools
+    tools={"creativity": ["reverse_string", "capitalize_string", "coding_*"]},
+    # Resource filtering: only writing resources (not coding resources)
+    resources={"creativity": ["resource://writing/*"]},
+    # Prompt filtering: only writing prompts (not coding prompts)
+    prompts={"creativity": ["writing_*"]}
 )
-async def test():
-    return "Debug info printed"
+async def filtered_agent():
+    return "Filtered agent ready"
 
-
+@fast_agent.agent(
+    name="unfiltered_agent",
+    model="gpt-4o-mini", 
+    instruction="You are a creative writer with access to all tools, resources, and prompts.",
+    servers=["creativity"]
+    # No filtering - gets everything
+)
+async def unfiltered_agent():
+    return "Unfiltered agent ready"
 
 async def main():
     try:
         async with fast_agent.run() as agent:
             try:
-                # Debug: Print available tools
-                test_agent = agent._agent("test-mcp-filtering")
-                tools = await test_agent.list_tools()
-                print(f"Available tools: {[tool.name for tool in tools.tools]}")
+                print("🎯 MCP Filtering Demo")
+                print("=" * 50)
                 
-                await agent.interactive(agent_name="test-mcp-filtering")
+                # Show filtered agent capabilities
+                print("\n📦 FILTERED AGENT:")
+                filtered = agent._agent("filtered_agent")
+                
+                tools = await filtered.list_tools()
+                print(f"✅ Available tools ({len(tools.tools)}): {[tool.name for tool in tools.tools]}")
+                
+                resources = await filtered.list_resources()
+                resource_list = resources.get("creativity", [])
+                print(f"📚 Available resources ({len(resource_list)}): {resource_list}")
+                
+                prompts = await filtered.list_prompts()
+                prompt_list = prompts.get("creativity", [])
+                prompt_names = [p.name for p in prompt_list]
+                print(f"💬 Available prompts ({len(prompt_names)}): {prompt_names}")
+                
+                # Show unfiltered agent capabilities
+                print("\n🌐 UNFILTERED AGENT:")
+                unfiltered = agent._agent("unfiltered_agent")
+                
+                tools = await unfiltered.list_tools()
+                print(f"✅ Available tools ({len(tools.tools)}): {[tool.name for tool in tools.tools]}")
+                
+                resources = await unfiltered.list_resources()
+                resource_list = resources.get("creativity", [])
+                print(f"📚 Available resources ({len(resource_list)}): {resource_list}")
+                
+                prompts = await unfiltered.list_prompts()
+                prompt_list = prompts.get("creativity", [])
+                prompt_names = [p.name for p in prompt_list]
+                print(f"💬 Available prompts ({len(prompt_names)}): {prompt_names}")
+                
+                print("\n" + "=" * 50)
+                print("🚀 Starting interactive session with filtered agent...")
+                print("Type 'exit' to quit")
+                
+                await agent.interactive(agent_name="filtered_agent")
 
             except PromptExitError:
                 print("👋 Goodbye!")

--- a/examples/mcp/mcp-filtering/test_mcp_filtering.py
+++ b/examples/mcp/mcp-filtering/test_mcp_filtering.py
@@ -1,0 +1,50 @@
+import asyncio
+import sys
+
+from mcp_agent.core.fastagent import FastAgent, PromptExitError
+
+
+fast_agent = FastAgent(
+    name="MCP Filtering Tests",
+    parse_cli_args=False,
+    quiet=False
+)
+
+@fast_agent.agent(
+    name=f"test-mcp-filtering",    
+    model="gpt-4.1",
+    instruction="You are a creative writer.  You have been supplied with tools to help you with creative tasks.",
+    servers=["creativity"],
+    tools={"creativity": ["reverse_string", "code*"]}  # Only supply the reverse string, and the coding tools by wildcard
+)
+async def test():
+    return "Debug info printed"
+
+
+
+async def main():
+    try:
+        async with fast_agent.run() as agent:
+            try:
+                # Debug: Print available tools
+                test_agent = agent._agent("test-mcp-filtering")
+                tools = await test_agent.list_tools()
+                print(f"Available tools: {[tool.name for tool in tools.tools]}")
+                
+                await agent.interactive(agent_name="test-mcp-filtering")
+
+            except PromptExitError:
+                print("👋 Goodbye!")
+                
+    except KeyboardInterrupt:
+        print("\nExiting...")
+        sys.exit(0)
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/mcp/mcp-filtering/test_mcp_filtering.py
+++ b/examples/mcp/mcp-filtering/test_mcp_filtering.py
@@ -3,7 +3,6 @@ import sys
 
 from mcp_agent.core.fastagent import FastAgent, PromptExitError
 
-
 fast_agent = FastAgent(
     name="MCP Filtering Demo",
     parse_cli_args=False,

--- a/src/mcp_agent/agents/base_agent.py
+++ b/src/mcp_agent/agents/base_agent.py
@@ -7,6 +7,8 @@ and delegates operations to an attached AugmentedLLMProtocol instance.
 
 import asyncio
 import uuid
+import inspect
+import fnmatch
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -18,6 +20,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    Mapping,
 )
 
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill
@@ -30,6 +33,7 @@ from mcp.types import (
     ReadResourceResult,
     TextContent,
     Tool,
+    Prompt,
 )
 from opentelemetry import trace
 from pydantic import BaseModel
@@ -325,9 +329,25 @@ class BaseAgent(MCPAggregator, AgentProtocol):
         self.logger.debug("Received human input signal", data=result)
         return result
 
+    def _matches_pattern(self, name: str, pattern: str, server_name: str) -> bool:
+        """
+        Check if a name matches a pattern for a specific server.
+        
+        Args:
+            name: The full namespaced name (e.g., "mathematics-add")
+            pattern: The pattern to match against (e.g., "add" or "math*")
+            server_name: The server name to prepend to the pattern
+            
+        Returns:
+            True if the name matches the pattern
+        """
+        # Build the full pattern: server_name-pattern
+        full_pattern = f"{server_name}-{pattern}"
+        return fnmatch.fnmatch(name, full_pattern)
+
     async def list_tools(self) -> ListToolsResult:
         """
-        List all tools available to this agent.
+        List all tools available to this agent, filtered by configuration.
 
         Returns:
             ListToolsResult with available tools
@@ -335,7 +355,25 @@ class BaseAgent(MCPAggregator, AgentProtocol):
         if not self.initialized:
             await self.initialize()
 
+        # Get all tools from the parent class
         result = await super().list_tools()
+
+        # Apply filtering if tools are specified in config
+        if self.config.tools is not None:
+            filtered_tools = []
+            for tool in result.tools:
+                # Extract server name from tool name (e.g., "mathematics-add" -> "mathematics")
+                if '-' in tool.name:
+                    server_name = tool.name.split('-', 1)[0]
+                    
+                    # Check if this server has tool filters
+                    if server_name in self.config.tools:
+                        # Check if tool matches any pattern for this server
+                        for pattern in self.config.tools[server_name]:
+                            if self._matches_pattern(tool.name, pattern, server_name):
+                                filtered_tools.append(tool)
+                                break
+            result.tools = filtered_tools
 
         if not self.human_input_callback:
             return result
@@ -634,6 +672,76 @@ class BaseAgent(MCPAggregator, AgentProtocol):
 
         response = await self.generate(prompts, request_params)
         return response.first_text()
+
+    async def list_prompts(self, server_name: str | None = None) -> Mapping[str, List[Prompt]]:
+        """
+        List all prompts available to this agent, filtered by configuration.
+
+        Args:
+            server_name: Optional server name to list prompts from
+
+        Returns:
+            Dictionary mapping server names to lists of Prompt objects
+        """
+        if not self.initialized:
+            await self.initialize()
+
+        # Get all prompts from the parent class
+        result = await super().list_prompts(server_name)
+
+        # Apply filtering if prompts are specified in config
+        if self.config.prompts is not None:
+            filtered_result = {}
+            for server, prompts in result.items():
+                # Check if this server has prompt filters
+                if server in self.config.prompts:
+                    filtered_prompts = []
+                    for prompt in prompts:
+                        # Check if prompt matches any pattern for this server
+                        for pattern in self.config.prompts[server]:
+                            if self._matches_pattern(prompt.name, pattern, server):
+                                filtered_prompts.append(prompt)
+                                break
+                    if filtered_prompts:
+                        filtered_result[server] = filtered_prompts
+            result = filtered_result
+
+        return result
+
+    async def list_resources(self, server_name: str | None = None) -> Dict[str, List[str]]:
+        """
+        List all resources available to this agent, filtered by configuration.
+
+        Args:
+            server_name: Optional server name to list resources from
+
+        Returns:
+            Dictionary mapping server names to lists of resource URIs
+        """
+        if not self.initialized:
+            await self.initialize()
+
+        # Get all resources from the parent class
+        result = await super().list_resources(server_name)
+
+        # Apply filtering if resources are specified in config
+        if self.config.resources is not None:
+            filtered_result = {}
+            for server, resources in result.items():
+                # Check if this server has resource filters
+                if server in self.config.resources:
+                    filtered_resources = []
+                    for resource in resources:
+                        # Check if resource matches any pattern for this server
+                        for pattern in self.config.resources[server]:
+                            if self._matches_pattern(resource, pattern, server):
+                                filtered_resources.append(resource)
+                                break
+                    if filtered_resources:
+                        filtered_result[server] = filtered_resources
+            result = filtered_result
+
+        return result
 
     @property
     def agent_type(self) -> AgentType:

--- a/src/mcp_agent/agents/base_agent.py
+++ b/src/mcp_agent/agents/base_agent.py
@@ -334,16 +334,20 @@ class BaseAgent(MCPAggregator, AgentProtocol):
         Check if a name matches a pattern for a specific server.
         
         Args:
-            name: The full namespaced name (e.g., "mathematics-add")
-            pattern: The pattern to match against (e.g., "add" or "math*")
-            server_name: The server name to prepend to the pattern
+            name: The name to match (could be tool name, resource URI, or prompt name)
+            pattern: The pattern to match against (e.g., "add", "math*", "resource://math/*")
+            server_name: The server name (used for tool name prefixing)
             
         Returns:
             True if the name matches the pattern
         """
-        # Build the full pattern: server_name-pattern
-        full_pattern = f"{server_name}-{pattern}"
-        return fnmatch.fnmatch(name, full_pattern)
+        # For tools, build the full pattern with server prefix: server_name-pattern
+        if name.startswith(f"{server_name}-"):
+            full_pattern = f"{server_name}-{pattern}"
+            return fnmatch.fnmatch(name, full_pattern)
+        
+        # For resources and prompts, match directly against the pattern
+        return fnmatch.fnmatch(name, pattern)
 
     async def list_tools(self) -> ListToolsResult:
         """

--- a/src/mcp_agent/agents/base_agent.py
+++ b/src/mcp_agent/agents/base_agent.py
@@ -6,21 +6,20 @@ and delegates operations to an attached AugmentedLLMProtocol instance.
 """
 
 import asyncio
-import uuid
-import inspect
 import fnmatch
+import uuid
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     List,
+    Mapping,
     Optional,
     Tuple,
     Type,
     TypeVar,
     Union,
-    Mapping,
 )
 
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill
@@ -33,7 +32,6 @@ from mcp.types import (
     ReadResourceResult,
     TextContent,
     Tool,
-    Prompt,
 )
 from opentelemetry import trace
 from pydantic import BaseModel

--- a/src/mcp_agent/core/agent_types.py
+++ b/src/mcp_agent/core/agent_types.py
@@ -4,7 +4,7 @@ Type definitions for agents and agent configurations.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
+from typing import Dict, List, Optional
 
 from mcp.client.session import ElicitationFnT
 
@@ -31,6 +31,9 @@ class AgentConfig:
     name: str
     instruction: str = "You are a helpful agent."
     servers: List[str] = field(default_factory=list)
+    tools: Optional[Dict[str, List[str]]] = None
+    resources: Optional[Dict[str, List[str]]] = None
+    prompts: Optional[Dict[str, List[str]]] = None
     model: str | None = None
     use_history: bool = True
     default_request_params: RequestParams | None = None

--- a/src/mcp_agent/core/direct_decorators.py
+++ b/src/mcp_agent/core/direct_decorators.py
@@ -246,6 +246,9 @@ def custom(
     *,
     instruction: str = "You are a helpful agent.",
     servers: List[str] = [],
+    tools: Optional[Dict[str, List[str]]] = None,
+    resources: Optional[Dict[str, List[str]]] = None,
+    prompts: Optional[Dict[str, List[str]]] = None,
     model: Optional[str] = None,
     use_history: bool = True,
     request_params: RequestParams | None = None,
@@ -287,6 +290,9 @@ def custom(
         default=default,
         elicitation_handler=elicitation_handler,
         api_key=api_key,
+        tools=tools,
+        resources=resources,
+        prompts=prompts,
     )
 
 
@@ -361,6 +367,9 @@ def router(
     agents: List[str],
     instruction: Optional[str] = None,
     servers: List[str] = [],
+    tools: Optional[Dict[str, List[str]]] = None,
+    resources: Optional[Dict[str, List[str]]] = None,
+    prompts: Optional[Dict[str, List[str]]] = None,
     model: Optional[str] = None,
     use_history: bool = False,
     request_params: RequestParams | None = None,
@@ -409,6 +418,9 @@ def router(
             router_agents=agents,
             elicitation_handler=elicitation_handler,
             api_key=api_key,
+            tools=tools,
+            prompts=prompts,
+            resources=resources,
         ),
     )
 

--- a/src/mcp_agent/core/direct_decorators.py
+++ b/src/mcp_agent/core/direct_decorators.py
@@ -193,6 +193,7 @@ def agent(
     human_input: bool = False,
     default: bool = False,
     elicitation_handler: Optional[ElicitationFnT] = None,
+    api_key: str | None = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
     Decorator to create and register a standard agent with type-safe signature.
@@ -211,6 +212,7 @@ def agent(
         human_input: Whether to enable human input capabilities
         default: Whether to mark this as the default agent
         elicitation_handler: Custom elicitation handler function (ElicitationFnT)
+        api_key: Optional API key for the LLM provider
 
     Returns:
         A decorator that registers the agent with proper type annotations
@@ -232,6 +234,7 @@ def agent(
         tools=tools,
         resources=resources,
         prompts=prompts,
+        api_key=api_key,
     )
 
 

--- a/src/mcp_agent/core/direct_decorators.py
+++ b/src/mcp_agent/core/direct_decorators.py
@@ -9,6 +9,7 @@ from functools import wraps
 from typing import (
     Awaitable,
     Callable,
+    Dict,
     List,
     Literal,
     Optional,
@@ -93,6 +94,9 @@ def _decorator_impl(
     request_params: RequestParams | None = None,
     human_input: bool = False,
     default: bool = False,
+    tools: Optional[Dict[str, List[str]]] = None,
+    resources: Optional[Dict[str, List[str]]] = None,
+    prompts: Optional[Dict[str, List[str]]] = None,
     **extra_kwargs,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
@@ -133,6 +137,9 @@ def _decorator_impl(
             name=name,
             instruction=instruction,
             servers=servers,
+            tools=tools,
+            resources=resources,
+            prompts=prompts,
             model=model,
             use_history=use_history,
             human_input=human_input,
@@ -177,13 +184,15 @@ def agent(
     *,
     instruction: str = "You are a helpful agent.",
     servers: List[str] = [],
+    tools: Optional[Dict[str, List[str]]] = None,
+    resources: Optional[Dict[str, List[str]]] = None,
+    prompts: Optional[Dict[str, List[str]]] = None,
     model: Optional[str] = None,
     use_history: bool = True,
     request_params: RequestParams | None = None,
     human_input: bool = False,
     default: bool = False,
     elicitation_handler: Optional[ElicitationFnT] = None,
-    api_key: str | None = None,
 ) -> Callable[[AgentCallable[P, R]], DecoratedAgentProtocol[P, R]]:
     """
     Decorator to create and register a standard agent with type-safe signature.
@@ -193,6 +202,9 @@ def agent(
         instruction_or_kwarg: Optional positional parameter for instruction
         instruction: Base instruction for the agent (keyword arg)
         servers: List of server names the agent should connect to
+        tools: Optional list of tool names or patterns to include
+        resources: Optional list of resource names or patterns to include
+        prompts: Optional list of prompt names or patterns to include
         model: Model specification string
         use_history: Whether to maintain conversation history
         request_params: Additional request parameters for the LLM
@@ -217,7 +229,9 @@ def agent(
         human_input=human_input,
         default=default,
         elicitation_handler=elicitation_handler,
-        api_key=api_key,
+        tools=tools,
+        resources=resources,
+        prompts=prompts,
     )
 
 

--- a/src/mcp_agent/core/enhanced_prompt.py
+++ b/src/mcp_agent/core/enhanced_prompt.py
@@ -68,6 +68,9 @@ async def _display_agent_info_helper(agent_name: str, agent_provider: object) ->
             len(tools_result.tools) if tools_result and hasattr(tools_result, "tools") else 0
         )
 
+        resources_dict = await agent.list_resources()
+        resource_count = sum(len(resources) for resources in resources_dict.values()) if resources_dict else 0
+
         prompts_dict = await agent.list_prompts()
         prompt_count = sum(len(prompts) for prompts in prompts_dict.values()) if prompts_dict else 0
 
@@ -104,10 +107,11 @@ async def _display_agent_info_helper(agent_name: str, agent_provider: object) ->
                 # Pluralization helpers
                 server_word = "Server" if server_count == 1 else "Servers"
                 tool_word = "tool" if tool_count == 1 else "tools"
+                resource_word = "resource" if resource_count == 1 else "resources"
                 prompt_word = "prompt" if prompt_count == 1 else "prompts"
 
                 rich_print(
-                    f"[dim]Agent [/dim][blue]{agent_name}[/blue][dim]:[/dim] {server_count:,}[dim] MCP {server_word}, [/dim]{tool_count:,}[dim] {tool_word}, [/dim]{prompt_count:,}[dim] {prompt_word} available[/dim]"
+                    f"[dim]Agent [/dim][blue]{agent_name}[/blue][dim]:[/dim] {server_count:,}[dim] MCP {server_word}, [/dim]{tool_count:,}[dim] {tool_word}, [/dim]{resource_count:,}[dim] {resource_word}, [/dim]{prompt_count:,}[dim] {prompt_word} available[/dim]"
                 )
 
         # Mark as shown
@@ -221,6 +225,9 @@ async def _display_child_agent_info(child_agent, prefix: str, agent_provider) ->
             len(tools_result.tools) if tools_result and hasattr(tools_result, "tools") else 0
         )
 
+        resources_dict = await child_agent.list_resources()
+        resource_count = sum(len(resources) for resources in resources_dict.values()) if resources_dict else 0
+
         prompts_dict = await child_agent.list_prompts()
         prompt_count = sum(len(prompts) for prompts in prompts_dict.values()) if prompts_dict else 0
 
@@ -229,10 +236,11 @@ async def _display_child_agent_info(child_agent, prefix: str, agent_provider) ->
             # Pluralization helpers
             server_word = "Server" if server_count == 1 else "Servers"
             tool_word = "tool" if tool_count == 1 else "tools"
+            resource_word = "resource" if resource_count == 1 else "resources"
             prompt_word = "prompt" if prompt_count == 1 else "prompts"
 
             rich_print(
-                f"[dim]  {prefix} [/dim][blue]{child_agent.name}[/blue][dim]:[/dim] {server_count:,}[dim] MCP {server_word}, [/dim]{tool_count:,}[dim] {tool_word}, [/dim]{prompt_count:,}[dim] {prompt_word} available[/dim]"
+                f"[dim]  {prefix} [/dim][blue]{child_agent.name}[/blue][dim]:[/dim] {server_count:,}[dim] MCP {server_word}, [/dim]{tool_count:,}[dim] {tool_word}, [/dim]{resource_count:,}[dim] {resource_word}, [/dim]{prompt_count:,}[dim] {prompt_word} available[/dim]"
             )
         else:
             # Show child even without MCP servers for context

--- a/tests/e2e/mcp_filtering/fastagent.config.yaml
+++ b/tests/e2e/mcp_filtering/fastagent.config.yaml
@@ -1,0 +1,34 @@
+# FastAgent Configuration File
+
+# Default Model Configuration:
+#
+# Takes format:
+#   <provider>.<model_string>.<reasoning_effort?> (e.g. anthropic.claude-3-5-sonnet-20241022 or openai.o3-mini.low)
+# Accepts aliases for Anthropic Models: haiku, haiku3, sonnet, sonnet35, opus, opus3
+# and OpenAI Models: gpt-4o-mini, gpt-4o, o1, o1-mini, o3-mini
+#
+# If not specified, defaults to "haiku".
+# Can be overriden with a command line switch --model=<model>, or within the Agent constructor.
+
+default_model: passthrough
+
+# Logging and Console Configuration:
+logger:
+  # level: "debug" | "info" | "warning" | "error"
+  # type: "none" | "console" | "file" | "http"
+  # path: "/path/to/logfile.jsonl"
+
+  # Switch the progress display on or off
+  progress_display: true
+
+  # Show chat User/Assistant messages on the console
+  show_chat: true
+  # Show tool calls on the console
+  show_tools: true
+  # Truncate long tool responses on the console
+  truncate_tools: true
+mcp:
+  servers:
+    filtering_test_server:
+      command: "uv"
+      args: ["run", "filtering_test_server.py"]

--- a/tests/e2e/mcp_filtering/filtering_test_server.py
+++ b/tests/e2e/mcp_filtering/filtering_test_server.py
@@ -4,6 +4,7 @@ MCP server for testing filtering functionality with multiple tools, resources, a
 """
 
 import logging
+
 from mcp.server.fastmcp import FastMCP
 
 logging.basicConfig(level=logging.INFO)

--- a/tests/e2e/mcp_filtering/filtering_test_server.py
+++ b/tests/e2e/mcp_filtering/filtering_test_server.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+MCP server for testing filtering functionality with multiple tools, resources, and prompts.
+"""
+
+import logging
+from mcp.server.fastmcp import FastMCP
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Create the FastMCP server
+app = FastMCP(name="Filtering Test Server")
+
+# Tools
+@app.tool(
+    name="math_add",
+    description="Add two numbers",
+)
+def math_add(a: int, b: int) -> str:
+    return f"Result: {a + b}"
+
+@app.tool(
+    name="math_subtract", 
+    description="Subtract two numbers",
+)
+def math_subtract(a: int, b: int) -> str:
+    return f"Result: {a - b}"
+
+@app.tool(
+    name="math_multiply",
+    description="Multiply two numbers", 
+)
+def math_multiply(a: int, b: int) -> str:
+    return f"Result: {a * b}"
+
+@app.tool(
+    name="string_upper",
+    description="Convert string to uppercase",
+)
+def string_upper(text: str) -> str:
+    return text.upper()
+
+@app.tool(
+    name="string_lower",
+    description="Convert string to lowercase",
+)
+def string_lower(text: str) -> str:
+    return text.lower()
+
+@app.tool(
+    name="utility_ping",
+    description="Simple ping utility",
+)
+def utility_ping() -> str:
+    return "pong"
+
+@app.tool(
+    name="utility_status",
+    description="Get server status",
+)
+def utility_status() -> str:
+    return "server is running"
+
+# Resources
+@app.resource("resource://math/constants")
+def math_constants() -> str:
+    return "π = 3.14159\ne = 2.71828\nφ = 1.618034"
+
+@app.resource("resource://math/formulas")
+def math_formulas() -> str:
+    return "Area of circle: π × r²\nPythagorean theorem: a² + b² = c²"
+
+@app.resource("resource://string/examples")
+def string_examples() -> str:
+    return "Hello World\nTesting 123\nCase Sensitivity Test"
+
+@app.resource("resource://utility/info")
+def utility_info() -> str:
+    return "Ping: Tests server connectivity\nStatus: Shows server health"
+
+# Prompts
+@app.prompt("math_helper")
+def math_helper_prompt(operation: str = "add") -> str:
+    """Help with mathematical operations"""
+    return f"I am a math helper. Let me help you with {operation} operations."
+
+@app.prompt("math_teacher")
+def math_teacher_prompt(level: str = "basic") -> str:
+    """Math teaching assistant"""
+    return f"I am a math teacher. I can teach {level} level mathematics."
+
+@app.prompt("string_processor")
+def string_processor_prompt(mode: str = "upper") -> str:
+    """String processing assistant"""
+    return f"I am a string processor. I can process strings in {mode} mode."
+
+@app.prompt("utility_assistant")
+def utility_assistant_prompt() -> str:
+    """General utility assistant"""
+    return "I am a utility assistant. I can help with various utility functions."
+
+if __name__ == "__main__":
+    app.run() 

--- a/tests/e2e/mcp_filtering/test_mcp_filtering.py
+++ b/tests/e2e/mcp_filtering/test_mcp_filtering.py
@@ -5,6 +5,7 @@ Tests tool, resource, and prompt filtering across different agent types.
 """
 
 import pytest
+
 from mcp_agent.agents.agent import Agent
 
 

--- a/tests/e2e/mcp_filtering/test_mcp_filtering.py
+++ b/tests/e2e/mcp_filtering/test_mcp_filtering.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+E2E tests for MCP filtering functionality.
+Tests tool, resource, and prompt filtering across different agent types.
+"""
+
+import pytest
+from mcp_agent.agents.agent import Agent
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_tool_filtering_basic_agent(fast_agent):
+    """Test tool filtering with basic agent - no filtering vs with filtering"""
+    fast = fast_agent
+
+    # Test 1: Agent without filtering - should have all tools
+    @fast.agent(
+        name="agent_no_filter",
+        instruction="Agent without tool filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+    )
+    async def agent_no_filter():
+        async with fast.run() as agent_app:
+            tools = await agent_app.agent_no_filter.list_tools()
+            tool_names = [tool.name for tool in tools.tools]
+            
+            # Should have all 7 tools
+            expected_tools = {
+                "filtering_test_server-math_add",
+                "filtering_test_server-math_subtract", 
+                "filtering_test_server-math_multiply",
+                "filtering_test_server-string_upper",
+                "filtering_test_server-string_lower",
+                "filtering_test_server-utility_ping",
+                "filtering_test_server-utility_status"
+            }
+            actual_tools = set(tool_names)
+            assert actual_tools == expected_tools, f"Expected {expected_tools}, got {actual_tools}"
+
+    # Test 2: Agent with filtering - should have only filtered tools
+    @fast.agent(
+        name="agent_with_filter",
+        instruction="Agent with tool filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+        tools={"filtering_test_server": ["math_*", "string_upper"]},  # Only math tools and string_upper
+    )
+    async def agent_with_filter():
+        async with fast.run() as agent_app:
+            tools = await agent_app.agent_with_filter.list_tools()
+            tool_names = [tool.name for tool in tools.tools]
+            
+            # Should have only math tools + string_upper
+            expected_tools = {
+                "filtering_test_server-math_add",
+                "filtering_test_server-math_subtract",
+                "filtering_test_server-math_multiply",
+                "filtering_test_server-string_upper"
+            }
+            actual_tools = set(tool_names)
+            assert actual_tools == expected_tools, f"Expected {expected_tools}, got {actual_tools}"
+            
+            # Should NOT have these tools
+            excluded_tools = {
+                "filtering_test_server-string_lower",
+                "filtering_test_server-utility_ping", 
+                "filtering_test_server-utility_status"
+            }
+            for tool_name in excluded_tools:
+                assert tool_name not in tool_names, f"Tool {tool_name} should have been filtered out"
+
+    await agent_no_filter()
+    await agent_with_filter()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_resource_filtering_basic_agent(fast_agent):
+    """Test resource filtering with basic agent - no filtering vs with filtering"""
+    fast = fast_agent
+
+    # Test 1: Agent without filtering - should have all resources
+    @fast.agent(
+        name="agent_no_filter",
+        instruction="Agent without resource filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+    )
+    async def agent_no_filter():
+        async with fast.run() as agent_app:
+            resources = await agent_app.agent_no_filter.list_resources()
+            resource_uris = resources["filtering_test_server"]  # Already a list of URI strings
+            
+            # Should have all 4 resources
+            expected_resources = {
+                "resource://math/constants",
+                "resource://math/formulas",
+                "resource://string/examples", 
+                "resource://utility/info"
+            }
+            actual_resources = set(resource_uris)
+            assert actual_resources == expected_resources, f"Expected {expected_resources}, got {actual_resources}"
+
+    # Test 2: Agent with filtering - should have only filtered resources
+    @fast.agent(
+        name="agent_with_filter",
+        instruction="Agent with resource filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+        resources={"filtering_test_server": ["resource://math/*", "resource://string/examples"]},
+    )
+    async def agent_with_filter():
+        async with fast.run() as agent_app:
+            resources = await agent_app.agent_with_filter.list_resources()
+            resource_uris = resources.get("filtering_test_server", [])  # Get list or empty list if server not present
+            
+            # Should have only math resources + string examples
+            expected_resources = {
+                "resource://math/constants",
+                "resource://math/formulas",
+                "resource://string/examples"
+            }
+            actual_resources = set(resource_uris)
+            assert actual_resources == expected_resources, f"Expected {expected_resources}, got {actual_resources}"
+            
+            # Should NOT have utility resource
+            excluded_resources = {"resource://utility/info"}
+            for resource_uri in excluded_resources:
+                assert resource_uri not in resource_uris, f"Resource {resource_uri} should have been filtered out"
+
+    await agent_no_filter()
+    await agent_with_filter()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_prompt_filtering_basic_agent(fast_agent):
+    """Test prompt filtering with basic agent - no filtering vs with filtering"""
+    fast = fast_agent
+
+    # Test 1: Agent without filtering - should have all prompts
+    @fast.agent(
+        name="agent_no_filter",
+        instruction="Agent without prompt filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+    )
+    async def agent_no_filter():
+        async with fast.run() as agent_app:
+            prompts = await agent_app.agent_no_filter.list_prompts()
+            prompt_names = [prompt.name for prompt in prompts["filtering_test_server"]]
+            
+            # Should have all 4 prompts
+            expected_prompts = {
+                "math_helper",
+                "math_teacher",
+                "string_processor",
+                "utility_assistant"
+            }
+            actual_prompts = set(prompt_names)
+            assert actual_prompts == expected_prompts, f"Expected {expected_prompts}, got {actual_prompts}"
+
+    # Test 2: Agent with filtering - should have only filtered prompts
+    @fast.agent(
+        name="agent_with_filter",
+        instruction="Agent with prompt filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+        prompts={"filtering_test_server": ["math_*", "utility_assistant"]},
+    )
+    async def agent_with_filter():
+        async with fast.run() as agent_app:
+            prompts = await agent_app.agent_with_filter.list_prompts()
+            prompt_list = prompts.get("filtering_test_server", [])  # Get list or empty list if server not present
+            prompt_names = [prompt.name for prompt in prompt_list]
+            
+            # Should have only math prompts + utility_assistant
+            expected_prompts = {
+                "math_helper",
+                "math_teacher",
+                "utility_assistant"
+            }
+            actual_prompts = set(prompt_names)
+            assert actual_prompts == expected_prompts, f"Expected {expected_prompts}, got {actual_prompts}"
+            
+            # Should NOT have string_processor
+            excluded_prompts = {"string_processor"}
+            for prompt_name in excluded_prompts:
+                assert prompt_name not in prompt_names, f"Prompt {prompt_name} should have been filtered out"
+
+    await agent_no_filter()
+    await agent_with_filter()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_tool_filtering_router_agent(fast_agent):
+    """Test tool filtering with router agent"""
+    fast = fast_agent
+
+    # Create a worker agent for the router
+    @fast.agent(
+        name="math_worker",
+        instruction="Math worker agent",
+        model="passthrough",
+        servers=["filtering_test_server"],
+    )
+    async def math_worker():
+        pass
+
+    # Router agent with filtering
+    @fast.router(
+        name="math_router",
+        agents=["math_worker"],
+        servers=["filtering_test_server"],
+        tools={"filtering_test_server": ["math_*"]},  # Only math tools
+        instruction="Router with tool filtering",
+        model="passthrough",
+    )
+    async def math_router():
+        async with fast.run() as agent_app:
+            tools = await agent_app.math_router.list_tools()
+            tool_names = [tool.name for tool in tools.tools]
+            
+            # Should have only math tools
+            expected_tools = {
+                "filtering_test_server-math_add",
+                "filtering_test_server-math_subtract",
+                "filtering_test_server-math_multiply"
+            }
+            actual_tools = set(tool_names)
+            assert actual_tools == expected_tools, f"Expected {expected_tools}, got {actual_tools}"
+            
+            # Should NOT have string or utility tools
+            excluded_tools = {
+                "filtering_test_server-string_upper",
+                "filtering_test_server-string_lower",
+                "filtering_test_server-utility_ping",
+                "filtering_test_server-utility_status"
+            }
+            for tool_name in excluded_tools:
+                assert tool_name not in tool_names, f"Tool {tool_name} should have been filtered out"
+
+    await math_router()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_tool_filtering_custom_agent(fast_agent):
+    """Test tool filtering with custom agent"""
+    fast = fast_agent
+
+    # Custom agent with filtering
+    @fast.custom(
+        Agent,
+        name="custom_string_agent",
+        instruction="Custom agent with tool filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+        tools={"filtering_test_server": ["string_*"]},  # Only string tools
+    )
+    async def custom_string_agent():
+        async with fast.run() as agent_app:
+            tools = await agent_app.custom_string_agent.list_tools()
+            tool_names = [tool.name for tool in tools.tools]
+            
+            # Should have only string tools
+            expected_tools = {
+                "filtering_test_server-string_upper",
+                "filtering_test_server-string_lower"
+            }
+            actual_tools = set(tool_names)
+            assert actual_tools == expected_tools, f"Expected {expected_tools}, got {actual_tools}"
+            
+            # Should NOT have math or utility tools
+            excluded_tools = {
+                "filtering_test_server-math_add",
+                "filtering_test_server-math_subtract",
+                "filtering_test_server-math_multiply",
+                "filtering_test_server-utility_ping",
+                "filtering_test_server-utility_status"
+            }
+            for tool_name in excluded_tools:
+                assert tool_name not in tool_names, f"Tool {tool_name} should have been filtered out"
+
+    await custom_string_agent()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_combined_filtering(fast_agent):
+    """Test combined tool, resource, and prompt filtering"""
+    fast = fast_agent
+
+    @fast.agent(
+        name="agent_combined_filter",
+        instruction="Agent with combined filtering",
+        model="passthrough",
+        servers=["filtering_test_server"],
+        tools={"filtering_test_server": ["math_*"]},
+        resources={"filtering_test_server": ["resource://math/*"]},
+        prompts={"filtering_test_server": ["math_*"]},
+    )
+    async def agent_combined_filter():
+        async with fast.run() as agent_app:
+            # Test tools
+            tools = await agent_app.agent_combined_filter.list_tools()
+            tool_names = [tool.name for tool in tools.tools]
+            expected_tools = {
+                "filtering_test_server-math_add",
+                "filtering_test_server-math_subtract",
+                "filtering_test_server-math_multiply"
+            }
+            actual_tools = set(tool_names)
+            assert actual_tools == expected_tools, f"Tools - Expected {expected_tools}, got {actual_tools}"
+            
+            # Test resources
+            resources = await agent_app.agent_combined_filter.list_resources()
+            resource_uris = resources.get("filtering_test_server", [])  # Get list or empty list if server not present
+            expected_resources = {
+                "resource://math/constants",
+                "resource://math/formulas"
+            }
+            actual_resources = set(resource_uris)
+            assert actual_resources == expected_resources, f"Resources - Expected {expected_resources}, got {actual_resources}"
+            
+            # Test prompts
+            prompts = await agent_app.agent_combined_filter.list_prompts()
+            prompt_list = prompts.get("filtering_test_server", [])  # Get list or empty list if server not present
+            prompt_names = [prompt.name for prompt in prompt_list]
+            expected_prompts = {
+                "math_helper",
+                "math_teacher"
+            }
+            actual_prompts = set(prompt_names)
+            assert actual_prompts == expected_prompts, f"Prompts - Expected {expected_prompts}, got {actual_prompts}"
+
+    await agent_combined_filter() 


### PR DESCRIPTION
Here is an implementation of agent-level MCP filtering.  This allows filtering of the tools, resources and prompts from the MCP server in the agent decorator configuration.  

This is fully backwards compatible - if no filters are applied, then all tools/resources/prompts are returned.
Includes example and e2e test

refs #280 

if this is something that is considered for inclusion, I can update the docs repo next
