### PR TITLE
Add support for sending MCP metadata

### DIFF
--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar
 from mcp_agent.agents.base_agent import BaseAgent
 from mcp_agent.core.agent_types import AgentConfig
 from mcp_agent.core.interactive_prompt import InteractivePrompt
+from mcp_agent.core.request_params import RequestParams
 from mcp_agent.human_input.types import HumanInputCallback
 from mcp_agent.logging.logger import get_logger
 from mcp_agent.mcp.interfaces import AugmentedLLMProtocol
@@ -51,13 +52,19 @@ class Agent(BaseAgent):
             **kwargs,
         )
 
-    async def prompt(self, default_prompt: str = "", agent_name: Optional[str] = None) -> str:
+    async def prompt(
+        self, 
+        default_prompt: str = "", 
+        agent_name: Optional[str] = None,
+        request_params: RequestParams | None = None
+    ) -> str:
         """
         Start an interactive prompt session with this agent.
 
         Args:
             default: Default message to use when user presses enter
             agent_name: Ignored for single agents, included for API compatibility
+            request_params: Optional request parameters
 
         Returns:
             The result of the interactive session
@@ -66,14 +73,14 @@ class Agent(BaseAgent):
         agent_name_str = str(self.name)
 
         # Create agent_types dictionary with just this agent
-        agent_types = {agent_name_str: self.agent_type.value}
+        agent_types = {agent_name_str: self.agent_type}
 
         # Create the interactive prompt
         prompt = InteractivePrompt(agent_types=agent_types)
 
         # Define wrapper for send function
         async def send_wrapper(message, agent_name):
-            return await self.send(message)
+            return await self.send(message, request_params)
 
         # Start the prompt loop with just this agent
         return await prompt.prompt_loop(

--- a/src/mcp_agent/agents/base_agent.py
+++ b/src/mcp_agent/agents/base_agent.py
@@ -208,7 +208,11 @@ class BaseAgent(MCPAggregator, AgentProtocol):
         result: PromptMessageMultipart = await self.generate([Prompt.user(message)], request_params)
         return result.first_text()
 
-    async def send(self, message: Union[str, PromptMessage, PromptMessageMultipart]) -> str:
+    async def send(
+        self, 
+        message: Union[str, PromptMessage, PromptMessageMultipart],
+        request_params: RequestParams | None = None
+    ) -> str:
         """
         Send a message to the agent and get a response.
 
@@ -217,6 +221,7 @@ class BaseAgent(MCPAggregator, AgentProtocol):
                 - String: Converted to a user PromptMessageMultipart
                 - PromptMessage: Converted to PromptMessageMultipart
                 - PromptMessageMultipart: Used directly
+                - request_params: Optional request parameters
 
         Returns:
             The agent's response as a string
@@ -225,7 +230,7 @@ class BaseAgent(MCPAggregator, AgentProtocol):
         prompt = self._normalize_message_input(message)
 
         # Use the LLM to generate a response
-        response = await self.generate([prompt], None)
+        response = await self.generate([prompt], request_params)
         return response.all_text()
 
     def _normalize_message_input(

--- a/src/mcp_agent/core/request_params.py
+++ b/src/mcp_agent/core/request_params.py
@@ -52,3 +52,8 @@ class RequestParams(CreateMessageRequestParams):
     """
     Optional dictionary of template variables for dynamic templates. Currently only works for TensorZero inference backend
     """
+
+    mcp_metadata: Dict[str, Any] | None = None
+    """
+    Metadata to pass through to MCP tool calls via the _meta field.
+    """


### PR DESCRIPTION
feat: Add per-request metadata support for MCP operations

Use case:
We have a Customers MCP In our organization, each user gets access only to certain customers. Our agents are in a session-managed multi-user environment, so we needed a way to send user details on a per-request basis (Headers are supported globally, but only set at initialization, leaving no way to send different headers with different requests). While it would be possible to send this information as tool call parameters for example, this really would bloat our tool schemas.

Implementation:
- Added RequestParams.mcp_metadata field for passing custom metadata
- Uses contextVar at augmented_llm level to store metadata across async tasks
- Extends agent method signatures to accept RequestParams (send, interactive, prompt, etc.)
- Enhanced MCPAgentClientSession with _meta parameter support for call_tool, read_resource, get_prompt
- Implements safe merging to preserve existing meta fields (e.g. progressToken)
- Metadata flows from RequestParams → Context Variable → MCPAggregator → MCPAgentClientSession → MCP Server

Usage:
```python
request_params = RequestParams(mcp_metadata={"user_id": "123", "auth0_id": "auth0|..."})
await agent.generate("Get customers", request_params)
# MCP server can access via: ctx.request_context.meta.user_id
```

Supports all agent methods and MCP operation types (tools, resources, prompts).

internal ticket: DEV-1888