### PR TITLE
Add MCP SSE server reconnection

### DIFF
--- a/src/mcp_agent/event_progress.py
+++ b/src/mcp_agent/event_progress.py
@@ -25,6 +25,9 @@ class ProgressAction(str, Enum):
     FINISHED = "Finished"
     SHUTDOWN = "Shutdown"
     AGGREGATOR_INITIALIZED = "Running"
+    SERVER_OFFLINE = "Offline"
+    SERVER_RECONNECTING = "Reconnecting"
+    SERVER_ONLINE = "Online"
     FATAL_ERROR = "Error"
 
 

--- a/src/mcp_agent/mcp/mcp_agent_client_session.py
+++ b/src/mcp_agent/mcp/mcp_agent_client_session.py
@@ -180,8 +180,17 @@ class MCPAgentClientSession(ClientSession, ContextDependent):
             )
             return result
         except Exception as e:
-            logger.error(f"send_request failed: {str(e)}")
-            raise
+            # Handle connection errors cleanly
+            from anyio import ClosedResourceError
+            
+            if isinstance(e, ClosedResourceError):
+                # Show clean offline message and convert to ConnectionError
+                from mcp_agent import console
+                console.console.print(f"[dim red]MCP server {self.session_server_name} offline[/dim red]")
+                raise ConnectionError(f"MCP server {self.session_server_name} offline") from e
+            else:
+                logger.error(f"send_request failed: {str(e)}")
+                raise
 
     async def _received_notification(self, notification: ServerNotification) -> None:
         """

--- a/src/mcp_agent/mcp/mcp_aggregator.py
+++ b/src/mcp_agent/mcp/mcp_aggregator.py
@@ -513,7 +513,7 @@ class MCPAggregator(ContextDependent):
                     # The call_tool method signature includes progress_callback parameter
                     return await method(**method_args, progress_callback=progress_callback)
                 else:
-                    return await method(**kwargs)
+                    return await method(**(method_args or {}))
             except ConnectionError:
                 # Let ConnectionError pass through for reconnection logic
                 raise

--- a/src/mcp_agent/mcp/mcp_aggregator.py
+++ b/src/mcp_agent/mcp/mcp_aggregator.py
@@ -513,7 +513,10 @@ class MCPAggregator(ContextDependent):
                     # The call_tool method signature includes progress_callback parameter
                     return await method(**method_args, progress_callback=progress_callback)
                 else:
-                    return await method(**method_args)
+                    return await method(**kwargs)
+            except ConnectionError:
+                # Let ConnectionError pass through for reconnection logic
+                raise
             except Exception as e:
                 error_msg = (
                     f"Failed to {method_name} '{operation_name}' on server '{server_name}': {e}"
@@ -525,33 +528,70 @@ class MCPAggregator(ContextDependent):
                     # Re-raise the original exception to propagate it
                     raise e
 
-        if self.connection_persistence:
-            server_connection = await self._persistent_connection_manager.get_server(
-                server_name, client_session_factory=MCPAgentClientSession
-            )
-            return await try_execute(server_connection.session)
-        else:
-            logger.debug(
-                f"Creating temporary connection to server: {server_name}",
-                data={
-                    "progress_action": ProgressAction.STARTING,
-                    "server_name": server_name,
-                    "agent_name": self.agent_name,
-                },
-            )
-            async with gen_client(
-                server_name, server_registry=self.context.server_registry
-            ) as client:
-                result = await try_execute(client)
+        # Try initial execution
+        try:
+            if self.connection_persistence:
+                server_connection = await self._persistent_connection_manager.get_server(
+                    server_name, client_session_factory=MCPAgentClientSession
+                )
+                return await try_execute(server_connection.session)
+            else:
                 logger.debug(
-                    f"Closing temporary connection to server: {server_name}",
+                    f"Creating temporary connection to server: {server_name}",
                     data={
-                        "progress_action": ProgressAction.SHUTDOWN,
+                        "progress_action": ProgressAction.STARTING,
                         "server_name": server_name,
                         "agent_name": self.agent_name,
                     },
                 )
+                async with gen_client(
+                    server_name, server_registry=self.context.server_registry
+                ) as client:
+                    result = await try_execute(client)
+                    logger.debug(
+                        f"Closing temporary connection to server: {server_name}",
+                        data={
+                            "progress_action": ProgressAction.SHUTDOWN,
+                            "server_name": server_name,
+                            "agent_name": self.agent_name,
+                        },
+                    )
+                    return result
+        except ConnectionError:
+            # Server offline - attempt reconnection
+            from mcp_agent import console
+            console.console.print(f"[dim yellow]MCP server {server_name} reconnecting...[/dim yellow]")
+            
+            try:
+                if self.connection_persistence:
+                    # Force disconnect and create fresh connection
+                    await self._persistent_connection_manager.disconnect_server(server_name)
+                    import asyncio
+                    await asyncio.sleep(0.1)
+                    
+                    server_connection = await self._persistent_connection_manager.get_server(
+                        server_name, client_session_factory=MCPAgentClientSession
+                    )
+                    result = await try_execute(server_connection.session)
+                else:
+                    # For non-persistent connections, just try again
+                    async with gen_client(
+                        server_name, server_registry=self.context.server_registry
+                    ) as client:
+                        result = await try_execute(client)
+                
+                # Success!
+                console.console.print(f"[dim green]MCP server {server_name} online[/dim green]")
                 return result
+                
+            except Exception:
+                # Reconnection failed
+                console.console.print(f"[dim red]MCP server {server_name} offline - failed to reconnect[/dim red]")
+                error_msg = f"MCP server {server_name} offline - failed to reconnect"
+                if error_factory:
+                    return error_factory(error_msg)
+                else:
+                    raise Exception(error_msg)
 
     async def _parse_resource_name(self, name: str, resource_type: str) -> tuple[str, str]:
         """


### PR DESCRIPTION
This change adds a few features:

- supresses mcp sse_reader messages.  Currently, when an SSE MCP server goes offline, pages of stack trace flood the console output.  This is coming from the mcp library.  Added a filter to suppress these errors

- added SSE reconnect logic.  Currently, if an SSE server is down and the agent attempts a tool call, an error is displayed saying that the tool call failed.  Even if the SSE server comes back online, the agent will not be able to call a tool successfully without rebooting the agent.  This changes fixes that, and now a reconnection attempt is made, followed by a successful tool call

This is presented as an alternative to pull request 291 (Dynamic MCP handling)

If accepted, I will do a similar pull request for the HTTP transport