### PR TITLE
Add support for AWS Bedrock OpenAI OSS models

### DIFF
--- a/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
@@ -86,6 +86,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
             r"^cohere\..*",  # Cohere models
             r"^ai21\..*",  # AI21 models
             r"^stability\..*",  # Stability AI models
+            r"^openai\..*",  # OpenAI models
         ]
 
         import re


### PR DESCRIPTION
On August 5th, AWS announced support for OpenAI's recently released OSS 20b and 120b models.  This adds support for them in the Bedrock augmented LLM provider

internal ref: DEV-1844