### PR TITLE
Fix - Improve exit command visibility in interactive prompt

### DIFF
--- a/src/mcp_agent/core/enhanced_prompt.py
+++ b/src/mcp_agent/core/enhanced_prompt.py
@@ -585,6 +585,7 @@ async def get_enhanced_input(
             ("Ctrl+Y", "Copy"),
             ("Ctrl+L", "Clear"),
             ("↑/↓", "History"),
+            ("EXIT", "Exit")
         ]
 
         newline = "Ctrl+&lt;Enter&gt;:Submit" if in_multiline_mode else "&lt;Enter&gt;:Submit"


### PR DESCRIPTION
- Surfaces EXIT option directly in toolbar without requiring '/' prefix or remembering how to exit
