### PR TITLE
Support kwargs for MCPApp

### DIFF
--- a/src/mcp_agent/core/fastagent.py
+++ b/src/mcp_agent/core/fastagent.py
@@ -87,6 +87,7 @@ class FastAgent:
         ignore_unknown_args: bool = False,
         parse_cli_args: bool = True,
         quiet: bool = False,  # Add quiet parameter
+        **kwargs
     ) -> None:
         """
         Initialize the fast-agent application.
@@ -203,6 +204,7 @@ class FastAgent:
             self.app = MCPApp(
                 name=name,
                 settings=config.Settings(**self.config) if hasattr(self, "config") else None,
+                **kwargs
             )
 
             # Stop progress display immediately if quiet mode is requested


### PR DESCRIPTION
As a developer, I should be able to pass low-level configurations to the underlying `MCPApp` while creating my `FastAgent` object.

For eg: `MCPApp` allows custom implementation for `human_input_callback` which the agents within `FastAgent` can use when set with `human_input=True`. This is useful for when we have custom logic to accept user input other than just STDIN.

Similarly, any other configurations that can be set during application creation can be passed via the `kwargs`

