### PR TITLE
fix: exclude mcp_metadata from llm args

### DIFF
--- a/src/mcp_agent/llm/augmented_llm.py
+++ b/src/mcp_agent/llm/augmented_llm.py
@@ -101,6 +101,7 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol, Generic[MessageParamT
     PARAM_USE_HISTORY = "use_history"
     PARAM_MAX_ITERATIONS = "max_iterations"
     PARAM_TEMPLATE_VARS = "template_vars"
+    PARAM_MCP_METADATA = "mcp_metadata"
 
     # Base set of fields that should always be excluded
     BASE_EXCLUDE_FIELDS = {PARAM_METADATA}

--- a/src/mcp_agent/llm/providers/augmented_llm_anthropic.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_anthropic.py
@@ -69,6 +69,7 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
         AugmentedLLM.PARAM_MAX_ITERATIONS,
         AugmentedLLM.PARAM_PARALLEL_TOOL_CALLS,
         AugmentedLLM.PARAM_TEMPLATE_VARS,
+        AugmentedLLM.PARAM_MCP_METADATA,
     }
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_bedrock.py
@@ -72,6 +72,7 @@ class BedrockAugmentedLLM(AugmentedLLM[BedrockMessageParam, BedrockMessage]):
         AugmentedLLM.PARAM_MAX_ITERATIONS,
         AugmentedLLM.PARAM_PARALLEL_TOOL_CALLS,
         AugmentedLLM.PARAM_TEMPLATE_VARS,
+        AugmentedLLM.PARAM_MCP_METADATA,
     }
 
     @classmethod

--- a/src/mcp_agent/llm/providers/augmented_llm_google_native.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_google_native.py
@@ -160,6 +160,7 @@ class GoogleNativeAugmentedLLM(AugmentedLLM[types.Content, types.Content]):
         AugmentedLLM.PARAM_USE_HISTORY,  # Handled by AugmentedLLM base / this class's logic
         AugmentedLLM.PARAM_MAX_ITERATIONS,  # Handled by this class's loop
         # Add any other OpenAI-specific params not applicable to google.genai
+        AugmentedLLM.PARAM_MCP_METADATA,
     }.union(AugmentedLLM.BASE_EXCLUDE_FIELDS)
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/mcp_agent/llm/providers/augmented_llm_openai.py
+++ b/src/mcp_agent/llm/providers/augmented_llm_openai.py
@@ -59,6 +59,7 @@ class OpenAIAugmentedLLM(AugmentedLLM[ChatCompletionMessageParam, ChatCompletion
         AugmentedLLM.PARAM_USE_HISTORY,
         AugmentedLLM.PARAM_MAX_ITERATIONS,
         AugmentedLLM.PARAM_TEMPLATE_VARS,
+        AugmentedLLM.PARAM_MCP_METADATA,
     }
 
     def __init__(self, provider: Provider = Provider.OPENAI, *args, **kwargs) -> None:


### PR DESCRIPTION
When using `mcp_metadata` getting error added in this pull request #340 getting error for anthropic llm.

```
File "<localpath>/mcp_agent/llm/providers/augmented_llm_anthropic.py", line 416, in _anthropic_completion
    async with anthropic.messages.stream(**arguments) as stream:
               ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
TypeError: AsyncMessages.stream() got an unexpected keyword argument 'mcp_metadata'
```

Excluding this newly added field from llm args

Sample usage for mcp_metadata
```
request_params = RequestParams(mcp_metadata={"userId": "123"})
await agent.generate("dummy message", request_params)
```