### PR TITLE
Improve elicitation input handling for multiline content

### DIFF
--- a/examples/mcp/elicitations/elicitation_forms_server.py
+++ b/examples/mcp/elicitations/elicitation_forms_server.py
@@ -100,11 +100,25 @@ async def product_review() -> ReadResourceResult:
             },
         )
         review_text: str = Field(
-            description="Tell us about your experience", min_length=10, max_length=1000
+            description="Tell us about your experience",
+            default="""Great product!
+Here's what I loved:
+
+- Excellent build quality
+- Fast shipping
+- Works as advertised
+
+One minor issue:
+- Instructions could be clearer
+
+Overall, highly recommended!""",
+            min_length=10,
+            max_length=1000
         )
 
     result = await mcp.get_context().elicit(
-        "Share your product review - Help others make informed decisions!", schema=ProductReview
+        "Share your product review - Help others make informed decisions!",
+        schema=ProductReview,
     )
 
     match result:


### PR DESCRIPTION
**Key Changes:**
- Select input height based on actual newlines present in default content
- Improve keybindings: Ctrl+J insert new lines, Enter submits
- Adjust input field height dynamicly based on newlines in input

**Demo:** https://asciinema.org/a/lCQtSe9tmN2gQucJcb96p1vbB