### PR TITLE
Refactor Bedrock provider

### DIFF
--- a/examples/bedrock/fast-agent.config.yaml
+++ b/examples/bedrock/fast-agent.config.yaml
@@ -1,6 +1,11 @@
-# Example minimalfast-agent.config.yaml for Bedrock
+# Example minimal fast-agent.config.yaml for Bedrock
 
 # List of supported models: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+# Model string format: bedrock.<model_id>.<reasoning_effort>
+# Examples:
+#   bedrock.amazon.nova-lite-v1:0           # No reasoning
+#   bedrock.claude-sonnet-4-0.high          # High reasoning effort
+#   bedrock.anthropic.claude-3-7-sonnet-20250219-v1:0.medium  # Medium reasoning
 default_model: bedrock.amazon.nova-lite-v1:0
 
 # Bedrock uses the AWS credentials provider chain to authenticate.
@@ -11,3 +16,9 @@ bedrock:
   region: "us-east-1" # required
   profile: "default"  # optional, defaults to "default" - only needed if you have multiple profiles. 
                       # Only needed on local machines, not on AWS.
+  
+  # Default reasoning effort for all Bedrock models (can be overridden in model string)
+  # Options: "minimal" (off), "low" (512 tokens), "medium" (1024 tokens), "high" (2048 tokens)
+  # Note: Only Claude 4, Claude 3.7 Sonnet, and DeepSeek-R1 support reasoning
+  # Other models will automatically fallback to no reasoning if unsupported
+  reasoning_effort: "minimal"  # Default: disabled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,8 @@ markers = [
 
 # Filter out utcnow depreciation warnings from the boto3 library
 filterwarnings = [
-    "ignore:datetime\\.datetime\\.utcnow\\(\\) is deprecated.*:DeprecationWarning:botocore\\.auth"
+    "ignore:datetime\\.datetime\\.utcnow\\(\\) is deprecated.*:DeprecationWarning:botocore\\.auth",
+    "ignore:datetime\\.datetime\\.utcnow\\(\\) is deprecated.*:DeprecationWarning:botocore\\.endpoint$",
 ]
 
 # Other pytest options can go here too

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,12 @@ markers = [
     "integration: marks tests as integration tests",
     "simulated_endpoints: marks tests that use simulated external endpoints"
 ]
+
+# Filter out utcnow depreciation warnings from the boto3 library
+filterwarnings = [
+    "ignore:datetime\\.datetime\\.utcnow\\(\\) is deprecated.*:DeprecationWarning:botocore\\.auth"
+]
+
 # Other pytest options can go here too
 testpaths = ["test", "integration_tests"]
 

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -276,6 +276,9 @@ class BedrockSettings(BaseModel):
     profile: str | None = None
     """AWS profile to use for authentication"""
 
+    reasoning_effort: Literal["minimal", "low", "medium", "high"] = "minimal"
+    """Default reasoning effort for Bedrock models. Can be overridden in model string (e.g., bedrock.claude-sonnet-4-0.high)"""
+
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 

--- a/src/mcp_agent/llm/providers/bedrock_utils.py
+++ b/src/mcp_agent/llm/providers/bedrock_utils.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from typing import Collection, Dict, List, Optional, Set, TypedDict, Literal, cast
+
+# Lightweight, runtime-only loader for AWS Bedrock models.
+# - Fetches once per process via boto3 (region from session; env override supported)
+# - Memory cache only; no disk persistence
+# - Provides filtering and optional prefixing (default 'bedrock.') for model IDs
+
+try:
+    import boto3
+except Exception as exc:  # pragma: no cover - import error path
+    boto3 = None  # type: ignore[assignment]
+
+
+Modality = Literal["TEXT", "IMAGE", "VIDEO", "SPEECH", "EMBEDDING"]
+Lifecycle = Literal["ACTIVE", "LEGACY"]
+InferenceType = Literal["ON_DEMAND", "PROVISIONED", "INFERENCE_PROFILE"]
+
+
+class ModelSummary(TypedDict, total=False):
+    modelId: str
+    modelName: str
+    providerName: str
+    inputModalities: List[Modality]
+    outputModalities: List[Modality]
+    responseStreamingSupported: bool
+    customizationsSupported: List[str]
+    inferenceTypesSupported: List[InferenceType]
+    modelLifecycle: Dict[str, Lifecycle]
+
+
+_MODELS_CACHE_BY_REGION: Dict[str, Dict[str, ModelSummary]] = {}
+
+
+def _resolve_region(region: Optional[str]) -> str:
+    if region:
+        return region
+    import os
+
+    env_region = os.getenv("BEDROCK_REGION")
+    if env_region:
+        return env_region
+    if boto3 is None:
+        raise RuntimeError(
+            "boto3 is required to load Bedrock models. Install boto3 or provide a static list."
+        )
+    session = boto3.Session()
+    if not session.region_name:
+        raise RuntimeError(
+            "AWS region could not be resolved. Configure your AWS SSO/profile or set BEDROCK_REGION."
+        )
+    return session.region_name
+
+
+def _strip_prefix(model_id: str, prefix: str) -> str:
+    return model_id[len(prefix) :] if prefix and model_id.startswith(prefix) else model_id
+
+
+def _ensure_loaded(region: Optional[str] = None) -> Dict[str, ModelSummary]:
+    resolved_region = _resolve_region(region)
+    cache = _MODELS_CACHE_BY_REGION.get(resolved_region)
+    if cache is not None:
+        return cache
+
+    if boto3 is None:
+        raise RuntimeError("boto3 is required to load Bedrock models. Install boto3.")
+
+    try:
+        client = boto3.client("bedrock", region_name=resolved_region)
+        resp = client.list_foundation_models()
+        summaries: List[ModelSummary] = resp.get("modelSummaries", [])  # type: ignore[assignment]
+    except Exception as exc:  # keep error simple and actionable
+        raise RuntimeError(
+            f"Failed to list Bedrock foundation models in region '{resolved_region}'. "
+            f"Ensure AWS credentials (SSO) and permissions (bedrock:ListFoundationModels) are configured. "
+            f"Original error: {exc}"
+        )
+
+    cache = {s.get("modelId", ""): s for s in summaries if s.get("modelId")}
+    _MODELS_CACHE_BY_REGION[resolved_region] = cache
+    return cache
+
+
+def refresh_bedrock_models(region: Optional[str] = None) -> None:
+    resolved_region = _resolve_region(region)
+    # drop and reload on next access
+    _MODELS_CACHE_BY_REGION.pop(resolved_region, None)
+    _ensure_loaded(resolved_region)
+
+
+def _matches_modalities(
+    model_modalities: List[Modality], requested: Collection[Modality]
+) -> bool:
+    # include if all requested are present in the model's modalities
+    return set(requested).issubset(set(model_modalities))
+
+
+def all_model_summaries(
+    input_modalities: Optional[Collection[Modality]] = None,
+    output_modalities: Optional[Collection[Modality]] = None,
+    include_legacy: bool = False,
+    providers: Optional[Collection[str]] = None,
+    inference_types: Optional[Collection[InferenceType]] = None,
+    direct_invocation_only: bool = True,
+    region: Optional[str] = None,
+) -> List[ModelSummary]:
+    """Return filtered Bedrock model summaries.
+
+    Defaults: input_modalities={"TEXT"}, output_modalities={"TEXT"}, include_legacy=False,
+    inference_types={"ON_DEMAND"}, direct_invocation_only=True.
+    """
+
+    cache = _ensure_loaded(region)
+    results: List[ModelSummary] = []
+
+    effective_output: Set[Modality] = (
+        set(output_modalities) if output_modalities is not None else {cast(Modality, "TEXT")}
+    )
+    effective_input: Optional[Set[Modality]] = (
+        set(input_modalities) if input_modalities is not None else {cast(Modality, "TEXT")}
+    )
+    provider_filter: Optional[Set[str]] = set(providers) if providers is not None else None
+    effective_inference: Set[InferenceType] = (
+        set(inference_types) if inference_types is not None else {cast(InferenceType, "ON_DEMAND")}
+    )
+
+    for summary in cache.values():
+        lifecycle = (summary.get("modelLifecycle") or {}).get("status")
+        if not include_legacy and lifecycle == "LEGACY":
+            continue
+
+        if provider_filter is not None and summary.get("providerName") not in provider_filter:
+            continue
+
+        # direct invocation only: exclude profile variants like :0:24k or :mm
+        if direct_invocation_only:
+            mid = summary.get("modelId") or ""
+            if mid.count(":") > 1:
+                continue
+
+        # modalities
+        model_inputs: List[Modality] = summary.get("inputModalities", [])  # type: ignore[assignment]
+        model_outputs: List[Modality] = summary.get("outputModalities", [])  # type: ignore[assignment]
+
+        if effective_input is not None and not _matches_modalities(model_inputs, effective_input):
+            continue
+        if effective_output and not _matches_modalities(model_outputs, effective_output):
+            continue
+
+        # inference types
+        model_inference: List[InferenceType] = summary.get("inferenceTypesSupported", [])  # type: ignore[assignment]
+        if effective_inference and not set(effective_inference).issubset(set(model_inference)):
+            continue
+
+        results.append(summary)
+
+    return results
+
+
+def all_bedrock_models(
+    input_modalities: Optional[Collection[Modality]] = None,
+    output_modalities: Optional[Collection[Modality]] = None,
+    include_legacy: bool = False,
+    providers: Optional[Collection[str]] = None,
+    prefix: str = "bedrock.",
+    inference_types: Optional[Collection[InferenceType]] = None,
+    direct_invocation_only: bool = True,
+    region: Optional[str] = None,
+) -> List[str]:
+    """Return model IDs (optionally prefixed) filtered by the given criteria.
+
+    Defaults: output_modalities={"TEXT"}, exclude LEGACY,
+    inference_types={"ON_DEMAND"}, direct_invocation_only=True.
+    """
+
+    summaries = all_model_summaries(
+        input_modalities=input_modalities,
+        output_modalities=output_modalities,
+        include_legacy=include_legacy,
+        providers=providers,
+        inference_types=inference_types,
+        direct_invocation_only=direct_invocation_only,
+        region=region,
+    )
+    ids: List[str] = []
+    for s in summaries:
+        mid = s.get("modelId")
+        if mid:
+            ids.append(mid)
+    if prefix:
+        return [f"{prefix}{mid}" for mid in ids]
+    return ids
+
+
+def get_model_metadata(model_id: str, region: Optional[str] = None) -> Optional[ModelSummary]:
+    cache = _ensure_loaded(region)
+    # Accept either prefixed or plain model IDs
+    plain_id = _strip_prefix(model_id, "bedrock.")
+    return cache.get(plain_id)
+
+
+def list_providers(region: Optional[str] = None) -> List[str]:
+    cache = _ensure_loaded(region)
+    providers = {s.get("providerName") for s in cache.values() if s.get("providerName")}
+    return sorted(providers)  # type: ignore[arg-type]
+
+
+__all__ = [
+    "Modality",
+    "Lifecycle",
+    "ModelSummary",
+    "all_bedrock_models",
+    "all_model_summaries",
+    "get_model_metadata",
+    "list_providers",
+    "refresh_bedrock_models",
+]
+

--- a/src/mcp_agent/llm/providers/bedrock_utils.py
+++ b/src/mcp_agent/llm/providers/bedrock_utils.py
@@ -89,9 +89,7 @@ def refresh_bedrock_models(region: Optional[str] = None) -> None:
     _ensure_loaded(resolved_region)
 
 
-def _matches_modalities(
-    model_modalities: List[Modality], requested: Collection[Modality]
-) -> bool:
+def _matches_modalities(model_modalities: List[Modality], requested: Collection[Modality]) -> bool:
     # include if all requested are present in the model's modalities
     return set(requested).issubset(set(model_modalities))
 
@@ -216,4 +214,3 @@ __all__ = [
     "list_providers",
     "refresh_bedrock_models",
 ]
-

--- a/tests/e2e/bedrock/bedrock_test_server.py
+++ b/tests/e2e/bedrock/bedrock_test_server.py
@@ -19,11 +19,7 @@ app = FastMCP(name="Bedrock Test Server")
     description="Returns the weather for a specified location.",
 )
 def check_weather(location: str) -> str:
-    # Write the location to a text file (matches main smoke test server)
-    with open("weather_location.txt", "w") as f:
-        f.write(location)
-
-    # Return sunny weather condition (matches main smoke test server)
+    # Return sunny weather condition
     return "It's sunny in " + location
 
 

--- a/tests/e2e/bedrock/bedrock_test_server.py
+++ b/tests/e2e/bedrock/bedrock_test_server.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Bedrock-specific MCP server that matches the main smoke test server functionality.
+"""
+
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Create the FastMCP server
+app = FastMCP(name="Bedrock Test Server")
+
+
+@app.tool(
+    name="check_weather",
+    description="Returns the weather for a specified location.",
+)
+def check_weather(location: str) -> str:
+    # Write the location to a text file (matches main smoke test server)
+    with open("weather_location.txt", "w") as f:
+        f.write(location)
+
+    # Return sunny weather condition (matches main smoke test server)
+    return "It's sunny in " + location
+
+
+@app.tool(name="shirt_colour", description="returns the colour of the shirt being worn")
+def shirt_colour() -> str:
+    return "blue polka dots"
+
+
+if __name__ == "__main__":
+    # Run the server using stdio transport
+    app.run(transport="stdio")

--- a/tests/e2e/bedrock/fastagent.config.yaml
+++ b/tests/e2e/bedrock/fastagent.config.yaml
@@ -1,0 +1,19 @@
+# FastAgent config for Bedrock tools tests
+
+default_model: passthrough
+
+logger:
+  progress_display: true
+  show_chat: true
+  show_tools: true
+  truncate_tools: true
+
+mcp:
+  servers:
+    test_server:
+      command: "uv"
+      args: ["run", "bedrock_test_server.py"]
+    hyphen-name:
+      command: "uv"
+      args: ["run", "bedrock_test_server.py"]
+

--- a/tests/e2e/bedrock/test_dynamic_capabilities.py
+++ b/tests/e2e/bedrock/test_dynamic_capabilities.py
@@ -1,10 +1,20 @@
 import os
+import sys
 from typing import List
 
 import pytest
 
 from mcp_agent.core.prompt import Prompt
 from mcp_agent.llm.providers.bedrock_utils import all_bedrock_models
+from mcp_agent.llm.providers.augmented_llm_bedrock import BedrockAugmentedLLM
+
+
+@pytest.fixture(scope="module", autouse=True)
+def debug_cache_at_end():
+    """Print cache state after all tests in this module complete."""
+    yield
+    sys.stdout.write("\n=== FINAL CACHE STATE (test_dynamic_capabilities.py) ===\n")
+    BedrockAugmentedLLM.debug_cache()
 
 
 def _bedrock_models_for_capability_tests() -> List[str]:

--- a/tests/e2e/bedrock/test_dynamic_capabilities.py
+++ b/tests/e2e/bedrock/test_dynamic_capabilities.py
@@ -1,0 +1,299 @@
+import os
+from typing import List
+
+import pytest
+
+from mcp_agent.core.prompt import Prompt
+from mcp_agent.llm.providers.bedrock_utils import all_bedrock_models
+
+
+def _bedrock_models_for_capability_tests() -> List[str]:
+    """Return the full Bedrock model list for testing dynamic capabilities."""
+    return all_bedrock_models(prefix="")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_system_prompt_fallback(fast_agent, model_name):
+    """Test system prompt fallback: models that don't support system param should inject into first user message."""
+
+    # Mark specific models that don't properly handle system prompts
+    if model_name in ["amazon.titan-text-lite-v1"]:
+        pytest.xfail("This Titan model doesn't properly process injected system prompts")
+
+    fast = fast_agent
+
+    @fast.agent(
+        "system_test",
+        instruction="You are a helpful assistant. Always mention the word 'SYSTEM_WORKING' in your response.",
+        model=f"bedrock.{model_name}",
+    )
+    async def system_test():
+        async with fast.run() as agent:
+            response = await agent.send(Prompt.user("Say hello"))
+            # Verify system prompt was applied (either via system param or injection)
+            assert "SYSTEM_WORKING" in response.upper()
+
+    await system_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_tool_schema_fallback(fast_agent, model_name):
+    """Test tool schema fallback: should try different formats (anthropic/nova/system_prompt) until one works."""
+
+    # Mark Titan text models as expected to fail tool calling
+    if model_name.startswith(("amazon.titan-text", "amazon.titan-tg1")):
+        pytest.xfail("Titan text models don't support native tool calling")
+
+    # Mark models with tool calling issues
+    if model_name.startswith("mistral."):
+        pytest.xfail("Mistral models tend to paraphrase tool responses")
+    if model_name.startswith("ai21."):
+        pytest.xfail("AI21 models may describe tool calls instead of actually calling them")
+
+    fast = fast_agent
+
+    @fast.agent(
+        "tool_test",
+        instruction="You are a helpful assistant. When you call a tool and receive a result, you MUST include the exact tool response text in your final answer without any modification, paraphrasing, or additional commentary.",
+        model=f"bedrock.{model_name}",
+        servers=["test_server"],
+    )
+    async def tool_test():
+        async with fast.run() as agent:
+            response = await agent.send(Prompt.user("What's the weather in Paris? Use tools."))
+            assert isinstance(response, str)
+
+            # Tool should have been called successfully - check for unique response from MCP server
+            assert "sunny" in response.lower() and "paris" in response.lower()
+
+    await tool_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_streaming_with_tools_fallback(fast_agent, model_name):
+    """Test streaming fallback: should detect if streaming+tools fails and fallback to non-streaming."""
+
+    # Mark Titan text models as expected to fail tool calling
+    if model_name.startswith(("amazon.titan-text", "amazon.titan-tg1")):
+        pytest.xfail("Titan text models don't support native tool calling")
+
+    # Mark AI21 models that may describe instead of call tools
+    if model_name.startswith("ai21."):
+        pytest.xfail("AI21 models may describe tool calls instead of actually calling them")
+
+    fast = fast_agent
+
+    @fast.agent(
+        "streaming_test",
+        instruction="You are a helpful assistant. When you receive tool results, include the exact response text without paraphrasing or modifying it.",
+        model=f"bedrock.{model_name}",
+        servers=["test_server"],
+    )
+    async def streaming_test():
+        async with fast.run() as agent:
+            # Test streaming with tools - should fallback to non-streaming if needed
+            response = await agent.send(Prompt.user("What's the weather in Tokyo? Use tools."))
+            assert isinstance(response, str)
+            # Check for unique response from MCP server
+            assert "sunny" in response.lower() and "tokyo" in response.lower()
+
+    await streaming_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_tool_name_policy_fallback(fast_agent, model_name):
+    """Test tool name policy: should detect hyphenated tool names and apply underscore conversion."""
+
+    # Mark Titan text models as expected to fail tool calling
+    if model_name.startswith(("amazon.titan-text", "amazon.titan-tg1")):
+        pytest.xfail("Titan text models don't support native tool calling")
+
+    # Mark specific models that have tool response issues
+    if model_name in ["mistral.mistral-7b-instruct-v0:2"] or model_name.startswith("ai21."):
+        pytest.xfail("These models paraphrase tool responses instead of including exact content")
+
+    fast = fast_agent
+
+    @fast.agent(
+        "name_policy_test",
+        instruction="You are a helpful assistant. When you call a tool and receive a result, you MUST include the exact tool response text in your final answer without any modification, paraphrasing, or additional commentary.",
+        model=f"bedrock.{model_name}",
+        servers=["test_server"],  # This has hyphenated tool names
+    )
+    async def name_policy_test():
+        async with fast.run() as agent:
+            # Single tool call to avoid model confusion from repeated calls
+            response = await agent.send(Prompt.user("What's the weather in London? Use tools."))
+            assert "sunny" in response.lower() and "london" in response.lower()
+
+    await name_policy_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_structured_output_strategy_fallback(fast_agent, model_name):
+    """Test structured output strategy: should try different strategies and retry on failures."""
+
+    # Mark models known to have issues with structured output
+    if model_name.startswith(
+        ("amazon.titan-text", "amazon.titan-tg1", "cohere.", "mistral.", "amazon.nova-")
+    ):
+        pytest.xfail("These models have unreliable structured output support")
+
+    fast = fast_agent
+
+    @fast.agent(
+        "structured_test",
+        instruction="You are a helpful assistant that returns structured data.",
+        model=f"bedrock.{model_name}",
+    )
+    async def structured_test():
+        async with fast.run() as agent:
+            from pydantic import BaseModel
+
+            class WeatherResponse(BaseModel):
+                city: str
+                condition: str
+                temperature: int
+
+            # Use the correct structured() API
+            response, _ = await agent.structured_test.structured(
+                [Prompt.user("What's the weather in Miami? Return structured data.")],
+                model=WeatherResponse,
+            )
+
+            assert isinstance(response, WeatherResponse)
+            assert response.city.lower() == "miami"
+            assert response.condition
+            assert isinstance(response.temperature, int)
+
+    await structured_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_force_non_streaming_structured(fast_agent, model_name):
+    """Test force non-streaming for structured output: should force non-streaming on first structured call."""
+
+    # Mark models known to have issues with structured output
+    if model_name.startswith(
+        ("amazon.titan-text", "amazon.titan-tg1", "cohere.", "mistral.", "amazon.nova-")
+    ):
+        pytest.xfail("These models have unreliable structured output support")
+
+    fast = fast_agent
+
+    @fast.agent(
+        "force_non_streaming_test",
+        instruction="You are a helpful assistant.",
+        model=f"bedrock.{model_name}",
+    )
+    async def force_non_streaming_test():
+        async with fast.run() as agent:
+            from pydantic import BaseModel
+
+            class SimpleResponse(BaseModel):
+                message: str
+                count: int
+
+            # This should trigger _force_non_streaming_once behavior
+            response, _ = await agent.force_non_streaming_test.structured(
+                [Prompt.user("Say hello and count to 3.")], model=SimpleResponse
+            )
+
+            assert isinstance(response, SimpleResponse)
+            assert response.message
+            assert response.count == 3
+
+    await force_non_streaming_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_reasoning_fallback(fast_agent, model_name):
+    """Test reasoning fallback: models that don't support reasoning should fallback gracefully."""
+
+    # Mark models that don't include exact numbers in math responses
+    if model_name.startswith(("mistral.", "amazon.titan-")):
+        pytest.xfail(
+            "These models provide detailed explanations but may not include the exact final number"
+        )
+
+    fast = fast_agent
+
+    @fast.agent(
+        "reasoning_test",
+        instruction="You are a helpful assistant. When solving math problems, always end your response with 'Final answer: [NUMBER]' where NUMBER is the exact integer result.",
+        model=f"bedrock.{model_name}.medium",  # Try medium reasoning effort
+    )
+    async def reasoning_test():
+        async with fast.run() as agent:
+            # Ask for a simple reasoning task
+            response = await agent.reasoning_test.send(
+                "What is 15 + 27? Show your work but make sure to end with 'Final answer: 42'"
+            )
+
+            # Should get a response regardless of reasoning support
+            assert response
+            assert (
+                "42" in response or "final answer: 42" in response.lower()
+            )  # The answer should be 42
+            return response
+
+    await reasoning_test()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_capability_tests())
+async def test_bedrock_temperature_parameter(fast_agent, model_name):
+    """Test temperature parameter: should be applied when reasoning is not enabled."""
+
+    # Mark Titan models as expected to have response formatting issues
+    if model_name.startswith("amazon.titan-"):
+        pytest.xfail(
+            "Titan models have response formatting limitations and may truncate or refuse exact phrases"
+        )
+
+    fast = fast_agent
+
+    @fast.agent(
+        "temperature_test",
+        instruction="You are a helpful assistant. Always respond with the exact text requested without paraphrasing, shortening, or modifying it.",
+        model=f"bedrock.{model_name}",  # No reasoning effort = temperature should work
+    )
+    async def temperature_test():
+        async with fast.run() as agent:
+            from mcp_agent.core.request_params import RequestParams
+
+            # Test with low temperature (should be more deterministic)
+            response = await agent.temperature_test.send(
+                "Say exactly: 'Temperature test successful'",
+                request_params=RequestParams(temperature=0.0),
+            )
+
+            # Should get a response with the temperature parameter applied
+            assert response
+            assert "temperature test successful" in response.lower()
+            return response
+
+    await temperature_test()

--- a/tests/e2e/bedrock/test_e2e_smoke_bedrock.py
+++ b/tests/e2e/bedrock/test_e2e_smoke_bedrock.py
@@ -151,11 +151,6 @@ async def test_bedrock_basic_tool_calling(fast_agent, model_name):
     )
     async def weather_forecast():
         async with fast.run() as agent:
-            # ensure file is absent
-            if os.path.exists("weather_location.txt"):
-                os.remove("weather_location.txt")
-            assert not os.path.exists("weather_location.txt")
-
             # Expected outliers for tool-calling via Bedrock Converse
             if model_name.startswith("ai21."):
                 pytest.xfail(
@@ -185,9 +180,6 @@ async def test_bedrock_basic_tool_calling(fast_agent, model_name):
 
             # Check for expected response from tool (matches main smoke test server)
             assert "sunny" in response.lower()
-
-            # tool side-effect (matches main smoke test server)
-            assert os.path.exists("weather_location.txt")
 
     await weather_forecast()
 

--- a/tests/e2e/bedrock/test_e2e_smoke_bedrock.py
+++ b/tests/e2e/bedrock/test_e2e_smoke_bedrock.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import List, Annotated
 
 import pytest
@@ -8,6 +9,15 @@ from mcp_agent.core.request_params import RequestParams
 from mcp_agent.mcp.helpers.content_helpers import split_thinking_content
 from pydantic import BaseModel, Field
 from mcp_agent.llm.providers.bedrock_utils import all_bedrock_models
+from mcp_agent.llm.providers.augmented_llm_bedrock import BedrockAugmentedLLM
+
+
+@pytest.fixture(scope="module", autouse=True)
+def debug_cache_at_end():
+    """Print cache state after all tests in this module complete."""
+    yield
+    sys.stdout.write("\n=== FINAL CACHE STATE (test_e2e_smoke_bedrock.py) ===\n")
+    BedrockAugmentedLLM.debug_cache()
 
 
 def _bedrock_models_for_smoke() -> List[str]:

--- a/tests/e2e/bedrock/test_e2e_smoke_bedrock.py
+++ b/tests/e2e/bedrock/test_e2e_smoke_bedrock.py
@@ -1,0 +1,380 @@
+import os
+from typing import List, Annotated
+
+import pytest
+
+from mcp_agent.core.prompt import Prompt
+from mcp_agent.core.request_params import RequestParams
+from mcp_agent.mcp.helpers.content_helpers import split_thinking_content
+from pydantic import BaseModel, Field
+from mcp_agent.llm.providers.bedrock_utils import all_bedrock_models
+
+
+def _bedrock_models_for_smoke() -> List[str]:
+    """Return the full Bedrock model list for exhaustive smoke reporting."""
+    return all_bedrock_models(prefix="")
+
+
+# ---------------- Structured output smoke tests (Bedrock) ----------------
+
+
+class FormattedResponse(BaseModel):
+    thinking: Annotated[
+        str, Field(description="Your reflection on the conversation that is not seen by the user.")
+    ]
+    message: str
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("model_name", _bedrock_models_for_smoke())
+async def test_bedrock_basic_textual_prompting(fast_agent, model_name):
+    """Bedrock-specific smoke test: simple textual generation."""
+    fast = fast_agent
+
+    # These models are expected to fail
+    if model_name.startswith("amazon.titan-text-") or model_name.startswith("amazon.titan-tg1"):
+        pytest.xfail("Titan text inconsistent for this test")
+    if model_name.startswith("anthropic.claude-3-haiku-"):
+        pytest.xfail("Claude 3 Haiku often too short for this test")
+
+    @fast.agent(
+        "agent",
+        instruction="You are a helpful AI Agent",
+        model=f"bedrock.{model_name}",
+    )
+    async def agent_function():
+        async with fast.run() as agent:
+            response = await agent.send(
+                Prompt.user(
+                    "write a short 40-60 word story about cats. No preamble; output only the story."
+                )
+            )
+            response_text = response.strip()
+            words = response_text.split()
+            assert 30 <= len(words) <= 80
+
+    await agent_function()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_open_ai_history_compat(fast_agent, model_name):
+    """Bedrock models should maintain provider history with system prompt preserved."""
+    fast = fast_agent
+
+    @fast.agent(
+        "agent",
+        instruction="SYSTEM PROMPT",
+        model=f"bedrock.{model_name}",
+    )
+    async def agent_function():
+        async with fast.run() as agent:
+            await agent.send("MESSAGE ONE")
+            await agent.send("MESSAGE TWO")
+
+            provider_history = agent.agent._llm.history
+            multipart_history = agent.agent.message_history
+
+            assert 4 == len(provider_history.get())
+            assert 4 == len(multipart_history)
+
+    await agent_function()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_multiple_text_blocks_prompting(fast_agent, model_name):
+    fast = fast_agent
+
+    # Per-test expected behavior
+    if model_name.startswith(("amazon.titan-text-", "amazon.titan-tg1")):
+        pytest.xfail("Titan text inconsistent for this test")
+
+    @fast.agent(
+        instruction="You are a helpful AI Agent",
+        model=f"bedrock.{model_name}",
+    )
+    async def agent_function():
+        async with fast.run() as agent:
+            response = await agent.default.generate(
+                [Prompt.user("write a 50-80 word story", "about cats - include the word 'cat'")]
+            )
+            response_text = response.all_text()
+            words = response_text.split()
+            assert 32 <= len(words) <= 100
+            assert "cat" in response_text.lower()
+
+            response = await agent.default.generate(
+                [Prompt.user("write a 50-80 word story"), Prompt.user("about cats - include 'cat'")]
+            )
+            response_text = response.all_text()
+            words = response_text.split()
+            assert 32 <= len(words) <= 100
+            assert "cat" in response_text.lower()
+
+    await agent_function()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_basic_tool_calling(fast_agent, model_name):
+    """Bedrock tool calling smoke: simple end-to-end tool invocation.
+
+    Uses 'test_server' tools from the existing E2E environment.
+    """
+    fast = fast_agent
+
+    @fast.agent(
+        "weatherforecast",
+        instruction=(
+            "You are a helpful assistant. Use tools when needed. When you receive a tool result, return the tool result text EXACTLY with no preamble, explanation, or modifications."
+        ),
+        model=f"bedrock.{model_name}",
+        servers=["test_server"],
+    )
+    async def weather_forecast():
+        async with fast.run() as agent:
+            # ensure file is absent
+            if os.path.exists("weather_location.txt"):
+                os.remove("weather_location.txt")
+            assert not os.path.exists("weather_location.txt")
+
+            # Expected outliers for tool-calling via Bedrock Converse
+            if model_name.startswith("ai21."):
+                pytest.xfail(
+                    "AI21 Jamba models do not reliably invoke tools through Bedrock Converse"
+                )
+            if model_name in [
+                "amazon.titan-text-lite-v1",
+                "amazon.titan-text-express-v1",
+                "amazon.titan-tg1-large",
+            ]:
+                pytest.xfail(
+                    "Titan text models either do not tool-call or do not return raw tool result"
+                )
+            if model_name == "mistral.mistral-7b-instruct-v0:2":
+                pytest.xfail("Mistral 7B occasionally calls the wrong tool or paraphrases output")
+            if model_name == "mistral.mistral-small-2402-v1:0":
+                pytest.xfail(
+                    "Mistral Small occasionally emits tool call JSON instead of tool result"
+                )
+
+            response = await agent.send(
+                Prompt.user(
+                    "Use the check_weather tool to get London's weather. Do NOT answer from your own knowledge. After the tool returns, respond with ONLY the tool's raw text output, exactly as returned. No preamble, no extra words."
+                )
+            )
+            assert isinstance(response, str)
+
+            # Check for expected response from tool (matches main smoke test server)
+            assert "sunny" in response.lower()
+
+            # tool side-effect (matches main smoke test server)
+            assert os.path.exists("weather_location.txt")
+
+    await weather_forecast()
+
+
+def _bedrock_models_for_structured() -> List[str]:
+    """Return Bedrock models suitable for structured-output tests.
+
+    Prefer Nova and Claude 3.x families.
+    """
+    candidates = all_bedrock_models(prefix="")
+    filtered = [
+        m for m in candidates if m.startswith("amazon.nova-") or m.startswith("anthropic.claude-3")
+    ]
+    return filtered
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_structured_output_auto_format(fast_agent, model_name):
+    fast = fast_agent
+
+    # Skip families unreliable for structured outputs
+    if model_name.startswith(("amazon.nova-micro-", "amazon.titan-", "meta.llama3-", "mistral.")):
+        pytest.skip("Skipping structured-output test for this model family")
+
+    @fast.agent(
+        "chat",
+        instruction="You are a helpful assistant.",
+        model=f"bedrock.{model_name}",
+    )
+    async def create_structured():
+        async with fast.run() as agent:
+            thinking, response = await agent.chat.structured(
+                [Prompt.user("Let's talk about guitars.")],
+                model=FormattedResponse,
+            )
+            assert isinstance(thinking, FormattedResponse)
+            _, json_part = split_thinking_content(response.first_text())
+            assert FormattedResponse.model_validate_json(json_part)
+            assert "guitar" in thinking.message.lower()
+
+    await create_structured()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_structured_output_parses_assistant_message_if_last(fast_agent, model_name):
+    fast = fast_agent
+
+    @fast.agent(
+        "chat",
+        instruction="You are a helpful assistant.",
+        model=f"bedrock.{model_name}",
+    )
+    async def create_structured():
+        async with fast.run() as agent:
+            thinking, response = await agent.chat.structured(
+                [
+                    Prompt.user("Let's talk about guitars."),
+                    Prompt.assistant(
+                        '{"thinking":"The user wants to have a conversation about guitars, which are a broad...","message":"Sure! I love talking about guitars."}'
+                    ),
+                ],
+                model=FormattedResponse,
+            )
+            assert thinking.thinking.startswith(
+                "The user wants to have a conversation about guitars"
+            )
+
+    await create_structured()
+
+
+response_format = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "formatted_response",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "thinking": {
+                    "type": "string",
+                    "description": "Your reflection on the conversation that is not seen by the user.",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Your message to the user.",
+                },
+            },
+            "required": ["thinking", "message"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_structured_output_with_response_format_override(fast_agent, model_name):
+    fast = fast_agent
+
+    # Skip families unreliable for structured outputs
+    if model_name.startswith(("amazon.nova-micro-", "amazon.titan-", "meta.llama3-", "mistral.")):
+        pytest.skip("Skipping structured-output test for this model family")
+
+    @fast.agent(
+        "chat",
+        instruction="You are a helpful assistant.",
+        model=f"bedrock.{model_name}",
+    )
+    async def create_structured():
+        async with fast.run() as agent:
+            thinking, response = await agent.chat.structured(
+                [Prompt.user("Let's talk about guitars.")],
+                model=FormattedResponse,
+                request_params=RequestParams(response_format=response_format),
+            )
+            assert thinking is not None
+            assert "guitar" in thinking.message.lower()
+
+    await create_structured()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "model_name",
+    _bedrock_models_for_smoke(),
+)
+async def test_bedrock_history_management_with_structured(fast_agent, model_name):
+    fast = fast_agent
+
+    # Skip families unreliable for structured outputs
+    # if model_name.startswith(("amazon.nova-micro-", "amazon.titan-", "meta.llama3-", "mistral.")):
+    #     pytest.skip("Skipping structured-output test for this model family")
+
+    # Known unreliable for structured/history: xfail Titans
+    if model_name.startswith("amazon.titan-"):
+        pytest.xfail("Titan models are unreliable for structured outputs with history")
+    # Known intermittent failure for Mistral 7B on this structured/history task
+    if model_name == "mistral.mistral-7b-instruct-v0:2":
+        pytest.xfail("Mistral 7B occasionally ignores topic in structured history JSON")
+
+    @fast.agent(
+        "chat",
+        instruction=(
+            "You are a helpful assistant. The user may request structured outputs. When asked to return structured JSON, respond with ONLY valid JSON conforming to the schema, no prose or preambles."
+        ),
+        model=f"bedrock.{model_name}",
+    )
+    async def create_structured():
+        async with fast.run() as agent:
+            await agent.chat.send("good morning")
+            thinking, response = await agent.chat.structured(
+                [Prompt.user("Let's talk about guitars.")],
+                model=FormattedResponse,
+            )
+            assert "guitar" in thinking.message.lower()
+
+            thinking, response = await agent.chat.structured(
+                [Prompt.user("Let's talk about pianos.")],
+                model=FormattedResponse,
+            )
+            assert "piano" in thinking.message.lower()
+
+            response = await agent.chat.send(
+                "Based ONLY on this conversation so far, did we talk about space travel? Respond EXACTLY YES or NO in uppercase, with no punctuation or explanations. If not discussed, respond NO."
+            )
+            assert "no" in response.lower()
+
+            assert 8 == len(agent.chat.message_history)
+            assert len(agent.chat._llm.history.get()) > 7
+
+    await create_structured()


### PR DESCRIPTION
Large refactor and cleanup of the Bedrock provider.
The biggest change is auto capability discovery.  Individual models can now determine their own capabilities (supporting system prompts, supporting tool calls, tool call format, etc) via a fallback and cache system.  On first use, capabilities start high and continue to fallback until a working solution is found.  That solution is then cached for subsequent calls.
Tons of other improvements
- temperature support
- reasoning support
- proper enums instead of string literals
- complete e2e tests
- Provider is much more maintainable now.  There are no more look-up tables for capabilities, and no list of supported models, as the supported models list now comes directly from Bedrock.  This means that updated model offerings should just work automatically