### PR TITLE
feat: add multiple MCP server configuration fixtures

### DIFF
--- a/tests/unit/mcp_server/fixtures/backward_compatibility.json
+++ b/tests/unit/mcp_server/fixtures/backward_compatibility.json
@@ -1,0 +1,22 @@
+{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "test-command",
+        "args": [
+          "arg1",
+          "arg2"
+        ],
+        "transport": "stdio"
+      },
+      "another-server": {
+        "command": "another-command",
+        "args": [
+          "--config",
+          "config.json"
+        ],
+        "transport": "stdio"
+      }
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/empty_servers.json
+++ b/tests/unit/mcp_server/fixtures/empty_servers.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/tests/unit/mcp_server/fixtures/environment_variables.json
+++ b/tests/unit/mcp_server/fixtures/environment_variables.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "mcp-github",
+      "args": [
+        "--token",
+        "${GITHUB_TOKEN}"
+      ],
+      "env": {
+        "GITHUB_API_URL": "${GITHUB_API_URL:https://api.github.com}",
+        "DEBUG": "true"
+      }
+    },
+    "fetch": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-fetch"
+      ],
+      "env": {
+        "FETCH_TIMEOUT": "${FETCH_TIMEOUT:30}",
+        "USER_AGENT": "CustomAgent/1.0"
+      }
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/fetch_server.json
+++ b/tests/unit/mcp_server/fixtures/fetch_server.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-fetch"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/fetch_server_docker.json
+++ b/tests/unit/mcp_server/fixtures/fetch_server_docker.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/fetch"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/fetch_server_pip.json
+++ b/tests/unit/mcp_server/fixtures/fetch_server_pip.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "python",
+      "args": [
+        "-m",
+        "mcp_server_fetch"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/filesystem_server.json
+++ b/tests/unit/mcp_server/fixtures/filesystem_server.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop",
+        "/Users/username/Downloads"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/filesystem_server_docker.json
+++ b/tests/unit/mcp_server/fixtures/filesystem_server_docker.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--mount",
+        "type=bind,src=/Users/username/Desktop,dst=/projects/Desktop",
+        "--mount",
+        "type=bind,src=/path/to/other/allowed/dir,dst=/projects/other/allowed/dir,ro",
+        "--mount",
+        "type=bind,src=/path/to/file.txt,dst=/projects/path/to/file.txt",
+        "mcp/filesystem",
+        "/projects"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/git_server.json
+++ b/tests/unit/mcp_server/fixtures/git_server.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "git": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-git",
+        "--repository",
+        "path/to/git/repo"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/git_server_docker.json
+++ b/tests/unit/mcp_server/fixtures/git_server_docker.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "git": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "--mount",
+        "type=bind,src=/Users/username,dst=/Users/username",
+        "mcp/git"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/git_server_pip.json
+++ b/tests/unit/mcp_server/fixtures/git_server_pip.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "git": {
+      "command": "python",
+      "args": [
+        "-m",
+        "mcp_server_git",
+        "--repository",
+        "path/to/git/repo"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/http_transport.json
+++ b/tests/unit/mcp_server/fixtures/http_transport.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "http-server": {
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer ${API_TOKEN}",
+        "Content-Type": "application/json"
+      }
+    },
+    "https-server": {
+      "url": "https://api.example.com/mcp",
+      "headers": {
+        "X-API-Key": "${API_KEY}",
+        "User-Agent": "MCPClient/1.0"
+      }
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/invalid_roots.json
+++ b/tests/unit/mcp_server/fixtures/invalid_roots.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "invalid-server": {
+      "command": "test-command",
+      "roots": [
+        {
+          "uri": "invalid://path",
+          "name": "invalid"
+        },
+        {
+          "uri": "ftp://example.com/files",
+          "name": "ftp"
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/memory_server_custom_path.json
+++ b/tests/unit/mcp_server/fixtures/memory_server_custom_path.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
+      "env": {
+        "MEMORY_FILE_PATH": "/path/to/custom/memory.json"
+      }
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/memory_server_docker.json
+++ b/tests/unit/mcp_server/fixtures/memory_server_docker.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "-v",
+        "claude-memory:/app/dist",
+        "--rm",
+        "mcp/memory"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/multi_server_config.json
+++ b/tests/unit/mcp_server/fixtures/multi_server_config.json
@@ -1,0 +1,38 @@
+{
+  "mcpServers": {
+    "everything": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-everything"
+      ]
+    },
+    "fetch": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-fetch"
+      ]
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop"
+      ]
+    },
+    "git": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-git"
+      ]
+    },
+    "memory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/no_mcp_servers.json
+++ b/tests/unit/mcp_server/fixtures/no_mcp_servers.json
@@ -1,0 +1,4 @@
+{
+  "other_setting": "value",
+  "another_setting": 123
+}

--- a/tests/unit/mcp_server/fixtures/sequential_thinking_server.json
+++ b/tests/unit/mcp_server/fixtures/sequential_thinking_server.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/sequential_thinking_server_docker.json
+++ b/tests/unit/mcp_server/fixtures/sequential_thinking_server_docker.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "sequentialthinking": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "mcp/sequentialthinking"
+      ]
+    }
+  }
+}

--- a/tests/unit/mcp_server/fixtures/with_roots.json
+++ b/tests/unit/mcp_server/fixtures/with_roots.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "filesystem-server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem"
+      ],
+      "roots": [
+        {
+          "uri": "file:///Users/username/Documents",
+          "name": "documents"
+        },
+        {
+          "uri": "file:///Users/username/Downloads",
+          "name": "downloads"
+        },
+        {
+          "uri": "file:///Users/username/Projects",
+          "name": "projects"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Introduced various JSON fixture files for MCP server configurations, including backward compatibility, environment variables, and different server types (fetch, filesystem, git, memory, etc.).
- Added support for Docker and pip commands in server configurations.
- Included examples for handling invalid roots and custom paths for memory servers.
- Created a multi-server configuration example to demonstrate diverse setups.