### PR TITLE
chore: make a check for the length of the agent dict

### DIFF
--- a/src/fast_agent/core/agent_app.py
+++ b/src/fast_agent/core/agent_app.py
@@ -34,6 +34,8 @@ class AgentApp:
         Args:
             agents: Dictionary of agent instances keyed by name
         """
+        if len(agents) == 0:
+            raise ValueError("No agents provided!")
         self._agents = agents
 
     def __getitem__(self, key: str) -> AgentProtocol:


### PR DESCRIPTION
Hi,
I wanted to try-out the commit method you described in [this comment](https://github.com/evalstate/fast-agent/issues/393#issuecomment-3299314847).

This is a trivial check and intent of this PR is much more to familiarize myself with the workflow rather than anything else (but also could mean a fast merge?)

Regards,
Chris

PS: while trivial it actually makes sense to add this because it solves potential bug on line 115 of the same file: `return next(iter(self._agents.values()))` (raises `StopIteration`)