### PR TITLE
Remove the boilerplate in the `create_agents_in_dependency_order` function

### DIFF
--- a/src/fast_agent/agents/agent_types.py
+++ b/src/fast_agent/agents/agent_types.py
@@ -3,7 +3,7 @@ Type definitions for agents and agent configurations.
 """
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum, auto
 from typing import Dict, List, Optional
 
 from mcp.client.session import ElicitationFnT
@@ -12,18 +12,18 @@ from mcp.client.session import ElicitationFnT
 from fast_agent.types import RequestParams
 
 
-class AgentType(Enum):
+class AgentType(StrEnum):
     """Enumeration of supported agent types."""
 
-    LLM = "llm"  # simple llm delegator
-    BASIC = "agent"
-    CUSTOM = "custom"
-    ORCHESTRATOR = "orchestrator"
-    PARALLEL = "parallel"
-    EVALUATOR_OPTIMIZER = "evaluator_optimizer"
-    ROUTER = "router"
-    CHAIN = "chain"
-    ITERATIVE_PLANNER = "iterative_planner"
+    LLM = auto()
+    BASIC = auto()
+    CUSTOM = auto()
+    ORCHESTRATOR = auto()
+    PARALLEL = auto()
+    EVALUATOR_OPTIMIZER = auto()
+    ROUTER = auto()
+    CHAIN = auto()
+    ITERATIVE_PLANNER = auto()
 
 
 @dataclass

--- a/src/fast_agent/core/agent_app.py
+++ b/src/fast_agent/core/agent_app.py
@@ -34,6 +34,8 @@ class AgentApp:
         Args:
             agents: Dictionary of agent instances keyed by name
         """
+        if len(agents) == 0:
+            raise ValueError("No agents provided!")
         self._agents = agents
 
     def __getitem__(self, key: str) -> AgentProtocol:

--- a/src/fast_agent/core/direct_factory.py
+++ b/src/fast_agent/core/direct_factory.py
@@ -3,7 +3,8 @@ Direct factory functions for creating agent and workflow instances without proxi
 Implements type-safe factories with improved error handling.
 """
 
-from typing import Any, Dict, Optional, Protocol, TypeVar, List
+from functools import partial
+from typing import Any, Dict, List, Optional, Protocol, TypeVar
 
 from fast_agent.agents import McpAgent
 from fast_agent.agents.agent_types import AgentConfig, AgentType
@@ -28,7 +29,6 @@ from fast_agent.interfaces import (
 from fast_agent.llm.model_factory import ModelFactory
 from fast_agent.mcp.ui_agent import McpAgentWithUI
 from fast_agent.types import RequestParams
-from functools import partial
 
 # Type aliases for improved readability and IDE support
 AgentDict = Dict[str, AgentProtocol]

--- a/src/fast_agent/core/direct_factory.py
+++ b/src/fast_agent/core/direct_factory.py
@@ -3,7 +3,7 @@ Direct factory functions for creating agent and workflow instances without proxi
 Implements type-safe factories with improved error handling.
 """
 
-from typing import Any, Dict, Optional, Protocol, TypeVar
+from typing import Any, Dict, Optional, Protocol, TypeVar, List
 
 from fast_agent.agents import McpAgent
 from fast_agent.agents.agent_types import AgentConfig, AgentType
@@ -28,6 +28,7 @@ from fast_agent.interfaces import (
 from fast_agent.llm.model_factory import ModelFactory
 from fast_agent.mcp.ui_agent import McpAgentWithUI
 from fast_agent.types import RequestParams
+from functools import partial
 
 # Type aliases for improved readability and IDE support
 AgentDict = Dict[str, AgentProtocol]
@@ -379,6 +380,35 @@ async def create_agents_by_type(
     return result_agents
 
 
+async def active_agents_in_dependency_group(
+    app_instance: Core,
+    agents_dict: AgentConfigDict,
+    model_factory_func: ModelFactoryFunctionProtocol,
+    group: List[str],
+    active_agents: AgentDict,
+):
+    """
+    For each of the possible agent types, create agents and update the active agents dictionary.
+
+    Notice: This function modifies the active_agents dictionary in-place which is a feature (no copies).
+    """
+    type_of_agents = list(map(lambda c: (c, c.value), AgentType))
+    for agent_type, agent_type_value in type_of_agents:
+        agents_dict = {
+            name: agents_dict[name]
+            for name in group
+            if agents_dict[name]["type"] == agent_type_value
+        }
+        agents = await create_agents_by_type(
+            app_instance,
+            agents_dict,
+            agent_type,
+            model_factory_func,
+            active_agents,
+        )
+        active_agents.update(agents)
+
+
 async def create_agents_in_dependency_order(
     app_instance: Core,
     agents_dict: AgentConfigDict,
@@ -403,127 +433,16 @@ async def create_agents_in_dependency_order(
     # Create a dictionary to store all active agents/workflows
     active_agents: AgentDict = {}
 
+    active_agents_in_dependency_group_partial = partial(
+        active_agents_in_dependency_group,
+        app_instance,
+        agents_dict,
+        model_factory_func,
+    )
+
     # Create agent proxies for each group in dependency order
     for group in dependencies:
-        # Create basic agents first
-        # Note: We compare string values from config with the Enum's string value
-        if AgentType.BASIC.value in [agents_dict[name]["type"] for name in group]:
-            basic_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.BASIC.value
-                },
-                AgentType.BASIC,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(basic_agents)
-
-        # Create custom agents first
-        if AgentType.CUSTOM.value in [agents_dict[name]["type"] for name in group]:
-            basic_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.CUSTOM.value
-                },
-                AgentType.CUSTOM,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(basic_agents)
-
-        # Create parallel agents
-        if AgentType.PARALLEL.value in [agents_dict[name]["type"] for name in group]:
-            parallel_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.PARALLEL.value
-                },
-                AgentType.PARALLEL,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(parallel_agents)
-
-        # Create router agents
-        if AgentType.ROUTER.value in [agents_dict[name]["type"] for name in group]:
-            router_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.ROUTER.value
-                },
-                AgentType.ROUTER,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(router_agents)
-
-        # Create chain agents
-        if AgentType.CHAIN.value in [agents_dict[name]["type"] for name in group]:
-            chain_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.CHAIN.value
-                },
-                AgentType.CHAIN,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(chain_agents)
-
-        # Create evaluator-optimizer agents
-        if AgentType.EVALUATOR_OPTIMIZER.value in [agents_dict[name]["type"] for name in group]:
-            evaluator_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.EVALUATOR_OPTIMIZER.value
-                },
-                AgentType.EVALUATOR_OPTIMIZER,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(evaluator_agents)
-
-        if AgentType.ORCHESTRATOR.value in [agents_dict[name]["type"] for name in group]:
-            orchestrator_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.ORCHESTRATOR.value
-                },
-                AgentType.ORCHESTRATOR,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(orchestrator_agents)
-
-        # Create orchestrator2 agents last since they might depend on other agents
-        if AgentType.ITERATIVE_PLANNER.value in [agents_dict[name]["type"] for name in group]:
-            orchestrator2_agents = await create_agents_by_type(
-                app_instance,
-                {
-                    name: agents_dict[name]
-                    for name in group
-                    if agents_dict[name]["type"] == AgentType.ITERATIVE_PLANNER.value
-                },
-                AgentType.ITERATIVE_PLANNER,
-                model_factory_func,
-                active_agents,
-            )
-            active_agents.update(orchestrator2_agents)
+        await active_agents_in_dependency_group_partial(group, active_agents)
 
     return active_agents
 

--- a/src/fast_agent/core/direct_factory.py
+++ b/src/fast_agent/core/direct_factory.py
@@ -394,14 +394,14 @@ async def active_agents_in_dependency_group(
     """
     type_of_agents = list(map(lambda c: (c, c.value), AgentType))
     for agent_type, agent_type_value in type_of_agents:
-        agents_dict = {
+        agents_dict_local = {
             name: agents_dict[name]
             for name in group
             if agents_dict[name]["type"] == agent_type_value
         }
         agents = await create_agents_by_type(
             app_instance,
-            agents_dict,
+            agents_dict_local,
             agent_type,
             model_factory_func,
             active_agents,

--- a/tests/e2e/workflow/test_orchestrator_puzzle.py
+++ b/tests/e2e/workflow/test_orchestrator_puzzle.py
@@ -11,7 +11,7 @@ from fast_agent import FastAgent
 @pytest.mark.parametrize(
     "model_name",
     [
-        "gpt-4.1",
+        "gpt-5.low",
     ],
 )
 async def test_iterative_orchestration(fast_agent, model_name):
@@ -22,25 +22,25 @@ async def test_iterative_orchestration(fast_agent, model_name):
     @fast.agent(
         "first_two",
         instruction="You can provide the first 2 digits of the secret code.",
-        model="gpt-4.1-mini",
+        model="gpt-5-mini.low",
         servers=["puzzle_1"],
     )
     @fast.agent(
         "last_two",
         instruction="You can provide the last 2 digits of the secret code.",
-        model="gpt-4.1-mini",
+        model="gpt-5-mini.low",
         servers=["puzzle_2"],
     )
     @fast.agent(
         "validator",
         instruction="You can validate the 4 digit secret code.",
-        model="gpt-4.1-mini",
+        model="gpt-5-mini.low",
         servers=["puzzle_validator"],
     )
     @fast.iterative_planner(
         "orchestrator",
         agents=["first_two", "last_two", "validator"],
-        model="gpt-4.1",
+        model="gpt-5.low",
     )
     async def agent_function():
         async with fast.run() as agent:


### PR DESCRIPTION
First thing I noticed, looking for the things I could improve upon was this one giant block of repeating code. So I removed it, making sure the order of operations is still the same. 

Also did a small change to the type -> used `StrEnum` + `auto()` just because it results in code that is harder to do typos in (one place for a typo not two).