### PR TITLE
README Update - Incorrect Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Start by installing the [uv package manager](https://docs.astral.sh/uv/) for Pyt
 ```bash
 uv pip install fast-agent-mcp          # install fast-agent!
 fast-agent go                          # start an interactive session
-fast-agent go https://hf.co/mcp        # with a remote MCP
+fast-agent go --url https://hf.co/mcp  # with a remote MCP
 fast-agent go --model=generic.qwen2.5  # use ollama qwen 2.5
 fast-agent setup                       # create an example agent and config files
 uv run agent.py                        # run your first agent


### PR DESCRIPTION
Update README to leverage the correct --url parameter for launch fast-agent from cli with MCP server

Based on the current README example it is stated that the fast-agent server should be started with the following command to connect to an MCP server

```
fast-agent go https://hf.co/mcp
```

This throws an error

```
No such command 'https://hf.co/mcp'.
```


Therefore this appears to no longer be the case based on my testing and the file which contains the arguments for the `go` function here: https://github.com/evalstate/fast-agent/blob/6ee0b2f1adf2f00ee89b950d9225c7c88e006ec9/src/fast_agent/cli/commands/go.py#L293

I have therefore updated the readme to reflect the correct usage as 

```
fast-agent go --url https://hf.co/mcp
```