### PR TITLE
ElicitationForm: Add support for pattern matching in string fields

### DIFF
--- a/src/fast_agent/human_input/form_fields.py
+++ b/src/fast_agent/human_input/form_fields.py
@@ -29,6 +29,8 @@ class StringField:
             schema["minLength"] = self.min_length
         if self.max_length is not None:
             schema["maxLength"] = self.max_length
+        if self.pattern is not None:
+            schema["pattern"] = self.pattern
         if self.format:
             schema["format"] = self.format
 
@@ -178,10 +180,11 @@ def string(
     default: Optional[str] = None,
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
     format: Optional[str] = None,
 ) -> StringField:
     """Create a string field."""
-    return StringField(title, description, default, min_length, max_length, format)
+    return StringField(title, description, default, min_length, max_length, pattern, format)
 
 
 def email(


### PR DESCRIPTION
Hi,
I implemented the argument `pattern` from pydantic.Field as it is useful to define valid input strings for a field.
Unfortunately, I wasn't able to implement a wrapping or truncation of the pattern string if it is too long. So that's something another person has to implement as pattterns can be long.