### PR TITLE
Add text navigation mode

### DIFF
--- a/src/fast_agent/ui/elicitation_form.py
+++ b/src/fast_agent/ui/elicitation_form.py
@@ -71,7 +71,7 @@ class SimpleStringValidator(Validator):
         self,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
-        pattern: Optional[str] = None
+        pattern: Optional[str] = None,
     ):
         self.min_length = min_length
         self.max_length = max_length
@@ -399,32 +399,40 @@ class ElicitationForm:
             if hasattr(self, "_toolbar_hidden") and self._toolbar_hidden:
                 return FormattedText([])
 
+            mode_label = "TEXT MODE" if text_navigation_mode else "FIELD MODE"
+            mode_color = "ansired" if text_navigation_mode else "ansigreen"
+
+            arrow_up = "↑"
+            arrow_down = "↓"
+            arrow_left = "←"
+            arrow_right = "→"
+
             if text_navigation_mode:
-                return FormattedText(
-                    [
-                        (
-                            "class:bottom-toolbar.text",
-                            " || TEXT MODE || <CTRL+T> toggle text mode. <TAB> navigate. <ENTER> insert new line.\n",
-                        ),
-                        (
-                            "class:bottom-toolbar.text",
-                            "   <ESC> cancel. <Cancel All> Auto-Cancel further elicitations from this Server.",
-                        ),
-                    ]
+                actions_line = (
+                    "  <ESC> cancel. <Cancel All> Auto-Cancel further elicitations from this Server."
+                )
+                navigation_tail = (
+                    " | <CTRL+T> toggle text mode. <TAB> navigate. <ENTER> insert new line."
                 )
             else:
-                return FormattedText(
-                    [
-                        (
-                            "class:bottom-toolbar.text",
-                            " || FIELD MODE ||  <CTRL+T> toggle text mode. <TAB>/↑↓→← navigate. <Ctrl+J> insert new line.\n",
-                        ),
-                        (
-                            "class:bottom-toolbar.text",
-                            "   <ENTER> submit. <ESC> cancel. <Cancel All> Auto-Cancel further elicitations from this Server.",
-                        ),
-                    ]
+                actions_line = (
+                    "  <ENTER> submit. <ESC> cancel. <Cancel All> Auto-Cancel further elicitations "
+                    "from this Server."
                 )
+                navigation_tail = (
+                    " | <CTRL+T> toggle text mode. "
+                    f"<TAB>/{arrow_up}{arrow_down}{arrow_right}{arrow_left} navigate. "
+                    "<Ctrl+J> insert new line."
+                )
+
+            formatted_segments = [
+                ("class:bottom-toolbar.text", actions_line),
+                ("", "\n"),
+                ("class:bottom-toolbar.text", " | "),
+                (f"fg:{mode_color} bg:ansiblack", f" {mode_label} "),
+                ("class:bottom-toolbar.text", navigation_tail),
+            ]
+            return FormattedText(formatted_segments)
 
         # Store toolbar function reference for later control
         self._get_toolbar = get_toolbar

--- a/src/fast_agent/ui/elicitation_style.py
+++ b/src/fast_agent/ui/elicitation_style.py
@@ -53,7 +53,7 @@ ELICITATION_STYLE = Style.from_dict(
         "completion-menu.meta.completion": "bg:ansiblack fg:ansiblue",
         "completion-menu.meta.completion.current": "bg:ansibrightblack fg:ansiblue",
         # Toolbar - matching enhanced_prompt.py exactly
-        "bottom-toolbar": "fg:ansiblack bg:ansigray",
-        "bottom-toolbar.text": "fg:ansiblack bg:ansigray",
+        "bottom-toolbar": "fg:#ansiblack bg:#ansigray",
+        "bottom-toolbar.text": "fg:#ansiblack bg:#ansigray",
     }
 )


### PR DESCRIPTION
As the navigation in text fields in elicitation forms is difficult, I implemented, similar to multiline mode, a text navigation mode for elicitation forms. With CTRL-T, it's possible to toggle between text navigation and field navigation mode. Field navigation mode represents the already implemented key bindings, text navigation modes allows you to use the arrow keys to navigate inside fields.
The toolbar is quite long now and hasn't a good indicator which mode is currently used. I am open for good ideas.
If you like the idea, you can merge this pull request, else I'm fine with closing it.