### PR TITLE
Fix recent changes defect

### DIFF
--- a/src/fast_agent/agents/mcp_agent.py
+++ b/src/fast_agent/agents/mcp_agent.py
@@ -43,7 +43,12 @@ from fast_agent.constants import HUMAN_INPUT_TOOL_NAME
 from fast_agent.core.exceptions import PromptExitError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.interfaces import FastAgentLLMProtocol
-from fast_agent.mcp.common import get_resource_name, get_server_name, is_namespaced_name
+from fast_agent.mcp.common import (
+    create_namespaced_name,
+    get_resource_name,
+    get_server_name,
+    is_namespaced_name,
+)
 from fast_agent.mcp.mcp_aggregator import MCPAggregator, NamespacedTool, ServerStatus
 from fast_agent.skills.registry import format_skills_for_prompt
 from fast_agent.tools.elicitation import (
@@ -322,8 +327,8 @@ class McpAgent(ABC, ToolAgent):
             if instructions is None:
                 continue
 
-            # Format tool names with server prefix
-            prefixed_tools = [f"{server_name}-{tool}" for tool in tool_names]
+            # Format tool names with server prefix using the new namespacing convention
+            prefixed_tools = [create_namespaced_name(server_name, tool) for tool in tool_names]
             tools_list = ", ".join(prefixed_tools) if prefixed_tools else "No tools available"
 
             formatted_parts.append(

--- a/src/fast_agent/mcp/mcp_aggregator.py
+++ b/src/fast_agent/mcp/mcp_aggregator.py
@@ -1201,7 +1201,7 @@ class MCPAggregator(ContextDependent):
 
     async def call_tool(self, name: str, arguments: dict | None = None) -> CallToolResult:
         """
-        Call a namespaced tool, e.g., 'server_name-tool_name'.
+        Call a namespaced tool, e.g., 'server_name__tool_name'.
         """
         if not self.initialized:
             await self.load_servers()

--- a/tests/integration/server_instructions/test_server_instructions.py
+++ b/tests/integration/server_instructions/test_server_instructions.py
@@ -49,7 +49,7 @@ Please follow the server-specific instructions above.""",
             # Check that tools are listed
             assert "<tools>" in agent.instruction, \
                 "Tools section not found in XML"
-            assert "instructions_enabled-calculate_sum" in agent.instruction, \
+            assert "instructions_enabled__calculate_sum" in agent.instruction, \
                 "Tool names not properly prefixed in instructions"
 
 
@@ -197,12 +197,12 @@ async def test_tools_list_in_instructions(fast_agent):
 
             # Check that all expected tools are listed
             expected_tools = [
-                "instructions_enabled-calculate_sum",
-                "instructions_enabled-calculate_product",
-                "instructions_enabled-calculate_divide",
-                "instructions_enabled-text_reverse",
-                "instructions_enabled-text_uppercase",
-                "instructions_enabled-text_count"
+                "instructions_enabled__calculate_sum",
+                "instructions_enabled__calculate_product",
+                "instructions_enabled__calculate_divide",
+                "instructions_enabled__text_reverse",
+                "instructions_enabled__text_uppercase",
+                "instructions_enabled__text_count"
             ]
 
             for tool in expected_tools:


### PR DESCRIPTION
The serverInstructions feature was using the old '-' separator to construct namespaced tool names, while the rest of the codebase has been updated to use '__' as the separator (via the common.create_namespaced_name function).

Changes:
- Updated _format_server_instructions in mcp_agent.py to use create_namespaced_name
- Updated docstring in mcp_aggregator.py to reflect new naming convention
- Updated integration tests to expect new __ separator in tool names

This ensures consistency across the codebase for tool namespacing.