### PR TITLE
Add ACP support to fast-agent

### DIFF
--- a/src/fast_agent/acp/server/agent_acp_server.py
+++ b/src/fast_agent/acp/server/agent_acp_server.py
@@ -590,6 +590,11 @@ class AgentACPServer(ACPAgent):
         # Update the session's current agent
         self._session_current_agent[session_id] = mode_id
 
+        # Update the slash command handler's current agent
+        slash_handler = self._session_slash_handlers.get(session_id)
+        if slash_handler:
+            slash_handler.set_current_agent(mode_id)
+
         logger.info(
             "Session mode updated",
             name="acp_set_session_mode_success",


### PR DESCRIPTION
This commit enhances the ACP /status command to be fully mode-aware:

1. Mode-Aware Status Display:
   - /status now shows the currently selected agent/mode
   - Displays all available agents/modes when multiple exist
   - Updates correctly when switching modes via setSessionMode

2. Agent-Specific Status:
   - New syntax: /status <agent_name> shows detailed info for a specific agent
   - Shows agent description, model config, and conversation stats
   - Marks current agent with "(current)" indicator

3. Implementation Details:
   - SlashCommandHandler tracks current agent via _current_agent_name
   - Added set_current_agent() and get_current_agent_name() methods
   - AgentACPServer updates handler when mode changes
   - Helper method _get_agent_instruction() extracts agent descriptions

4. Testing:
   - Added 6 comprehensive integration tests
   - All 17 tests pass (existing + new)
   - Tests cover mode switching, agent argument, and error cases

This resolves the issue where /status always showed the primary agent regardless of which mode was active, making it difficult to understand the current agent context in multi-agent ACP sessions.