### PR TITLE
Set Parallel as default multi-model option

### DIFF
--- a/src/fast_agent/cli/commands/go.py
+++ b/src/fast_agent/cli/commands/go.py
@@ -195,6 +195,7 @@ async def _run_agent(
             fan_out=fan_out_agents,
             fan_in="aggregate",
             include_request=True,
+            default=True,
         )
         async def cli_agent():
             async with fast.run() as agent:
@@ -208,7 +209,7 @@ async def _run_agent(
                     display = ConsoleDisplay(config=None)
                     display.show_parallel_results(agent.parallel)
                 else:
-                    await agent.interactive(agent_name="parallel", pretty_print_parallel=True)
+                    await agent.interactive(pretty_print_parallel=True)
     else:
         # Single model - use original behavior
         # Define the agent with specified parameters


### PR DESCRIPTION
When starting fast-agent with multiple models (--model=foo,bar,baz), the Parallel agent is now automatically set as the default. This ensures users don't need to explicitly specify the parallel agent when switching between agents in interactive mode.

Changes:
- Added default=True to @fast.parallel() decorator in go.py
- Removed explicit agent_name="parallel" from interactive() call since it now uses the default agent configuration