### PR TITLE
Fix MCP display showing incorrect instruction status

### DIFF
--- a/src/fast_agent/core/fastagent.py
+++ b/src/fast_agent/core/fastagent.py
@@ -836,9 +836,10 @@ class FastAgent:
 
             agent.instruction = resolved
 
-            config = getattr(agent, "config", None)
-            if config is not None:
-                config.instruction = resolved
+            # Note: We intentionally do NOT modify config.instruction here.
+            # The config should preserve the original template so that
+            # downstream logic (like MCP display) can check for template
+            # variables like {{serverInstructions}}.
 
             request_params = getattr(agent, "_default_request_params", None)
             if request_params is not None:


### PR DESCRIPTION
The MCP display logic checks agent.config.instruction for the presence of {{serverInstructions}} template variable to determine if MCP server instructions should be included in the system prompt.

The recent template resolution changes modified both agent.instruction and agent.config.instruction when resolving environment variables. This caused agent.config.instruction to lose the original template, making it impossible for the display logic to detect if {{serverInstructions}} was present in the original template.

This fix ensures that agent.config.instruction preserves the original template by only modifying agent.instruction during environment variable resolution. This allows the MCP display to correctly detect when server instructions should be included in the system prompt.

Fixes issue where MCP display shows "instr. not in sysprompt" warning even when instructions are correctly included in the system prompt.