### PR TITLE
Review ACP cancellation token implementation

### DIFF
--- a/src/fast_agent/agents/llm_agent.py
+++ b/src/fast_agent/agents/llm_agent.py
@@ -18,7 +18,6 @@ from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.llm_decorator import LlmDecorator, ModelT
 from fast_agent.constants import FAST_AGENT_ERROR_CHANNEL
 from fast_agent.context import Context
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.mcp.helpers.content_helpers import get_text
 from fast_agent.types import PromptMessageExtended, RequestParams
 from fast_agent.types.llm_stop_reason import LlmStopReason
@@ -238,7 +237,6 @@ class LlmAgent(LlmDecorator):
         messages: List[PromptMessageExtended],
         request_params: RequestParams | None = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Enhanced generate implementation that resets tool call tracking.
@@ -272,7 +270,7 @@ class LlmAgent(LlmDecorator):
 
                 try:
                     result, summary = await self._generate_with_summary(
-                        messages, request_params, tools, cancellation_token
+                        messages, request_params, tools
                     )
                 finally:
                     if remove_listener:
@@ -288,7 +286,7 @@ class LlmAgent(LlmDecorator):
             await self.show_assistant_message(result, additional_message=summary_text)
         else:
             result, summary = await self._generate_with_summary(
-                messages, request_params, tools, cancellation_token
+                messages, request_params, tools
             )
 
             summary_text = (

--- a/src/fast_agent/agents/tool_agent.py
+++ b/src/fast_agent/agents/tool_agent.py
@@ -12,7 +12,6 @@ from fast_agent.constants import (
 )
 from fast_agent.context import Context
 from fast_agent.core.logging.logger import get_logger
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.mcp.helpers.content_helpers import text_content
 from fast_agent.tools.elicitation import get_elicitation_fastmcp_tool
 from fast_agent.types import PromptMessageExtended, RequestParams
@@ -80,7 +79,6 @@ class ToolAgent(LlmAgent):
         messages: List[PromptMessageExtended],
         request_params: RequestParams | None = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Generate a response using the LLM, and handle tool calls if necessary.
@@ -97,7 +95,6 @@ class ToolAgent(LlmAgent):
                 messages,
                 request_params=request_params,
                 tools=tools,
-                cancellation_token=cancellation_token,
             )
 
             if LlmStopReason.TOOL_USE == result.stop_reason:

--- a/src/fast_agent/agents/workflow/chain_agent.py
+++ b/src/fast_agent/agents/workflow/chain_agent.py
@@ -15,7 +15,6 @@ from fast_agent.agents.llm_agent import LlmAgent
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
 from fast_agent.interfaces import ModelT
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.types import PromptMessageExtended, RequestParams
 
 logger = get_logger(__name__)
@@ -60,7 +59,6 @@ class ChainAgent(LlmAgent):
         messages: List[PromptMessageExtended],
         request_params: Optional[RequestParams] = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Chain the request through multiple agents in sequence.

--- a/src/fast_agent/agents/workflow/evaluator_optimizer.py
+++ b/src/fast_agent/agents/workflow/evaluator_optimizer.py
@@ -19,7 +19,6 @@ from fast_agent.core.exceptions import AgentConfigError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
 from fast_agent.interfaces import AgentProtocol, ModelT
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.types import PromptMessageExtended, RequestParams
 
 logger = get_logger(__name__)
@@ -109,7 +108,6 @@ class EvaluatorOptimizerAgent(LlmAgent):
         messages: List[PromptMessageExtended],
         request_params: RequestParams | None = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Generate a response through evaluation-guided refinement.

--- a/src/fast_agent/agents/workflow/iterative_planner.py
+++ b/src/fast_agent/agents/workflow/iterative_planner.py
@@ -23,7 +23,6 @@ from fast_agent.core.exceptions import AgentConfigError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
 from fast_agent.interfaces import AgentProtocol, ModelT
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.types import PromptMessageExtended, RequestParams
 
 logger = get_logger(__name__)
@@ -241,7 +240,6 @@ class IterativePlanner(LlmAgent):
         messages: List[PromptMessageExtended],
         request_params: RequestParams | None = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Execute an orchestrated plan to process the input.

--- a/src/fast_agent/agents/workflow/parallel_agent.py
+++ b/src/fast_agent/agents/workflow/parallel_agent.py
@@ -9,7 +9,6 @@ from fast_agent.agents.agent_types import AgentConfig, AgentType
 from fast_agent.agents.llm_agent import LlmAgent
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.interfaces import AgentProtocol, ModelT
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.types import PromptMessageExtended, RequestParams
 
 logger = get_logger(__name__)
@@ -56,7 +55,6 @@ class ParallelAgent(LlmAgent):
         messages: List[PromptMessageExtended],
         request_params: Optional[RequestParams] = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Execute fan-out agents in parallel and aggregate their results with the fan-in agent.

--- a/src/fast_agent/agents/workflow/router_agent.py
+++ b/src/fast_agent/agents/workflow/router_agent.py
@@ -17,7 +17,6 @@ from fast_agent.core.exceptions import AgentConfigError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
 from fast_agent.interfaces import FastAgentLLMProtocol, LLMFactoryProtocol, ModelT
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.types import PromptMessageExtended, RequestParams
 
 if TYPE_CHECKING:
@@ -188,7 +187,6 @@ class RouterAgent(LlmAgent):
         messages: List[PromptMessageExtended],
         request_params: Optional[RequestParams] = None,
         tools: List[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Route the request to the most appropriate agent and return its response.

--- a/src/fast_agent/llm/cancellation.py
+++ b/src/fast_agent/llm/cancellation.py
@@ -1,75 +1,22 @@
 """
 Cancellation support for LLM provider calls.
 
-This module provides a CancellationToken that can be used to cancel
-in-flight LLM requests, particularly useful for:
-- ESC key cancellation in interactive sessions
-- ACP session/cancel protocol support
+This module previously provided a CancellationToken class for cancellation.
+Now cancellation is handled natively through asyncio.Task.cancel() which raises
+asyncio.CancelledError at the next await point.
 
-Note: This module uses asyncio.CancelledError for cancellation exceptions,
-which is the standard Python approach for async cancellation.
+Usage:
+    # Store the task when starting work
+    task = asyncio.current_task()
+
+    # To cancel:
+    task.cancel()  # Raises asyncio.CancelledError in the task
+
+    # In the LLM provider, CancelledError propagates naturally:
+    async for chunk in stream:
+        # task.cancel() will raise CancelledError here
+        process(chunk)
 """
 
-import asyncio
-
-
-class CancellationToken:
-    """
-    A token that can be used to cancel ongoing LLM operations.
-
-    The token uses an asyncio.Event internally to signal cancellation.
-    Once cancelled, it remains in the cancelled state.
-
-    Usage:
-        token = CancellationToken()
-
-        # In the calling code:
-        result = await llm.generate(messages, cancellation_token=token)
-
-        # To cancel (e.g., from ESC key handler or ACP cancel):
-        token.cancel()
-
-        # In the LLM provider:
-        async for chunk in stream:
-            if token.is_cancelled:
-                raise asyncio.CancelledError(token.cancel_reason)
-            # process chunk
-    """
-
-    def __init__(self) -> None:
-        self._event = asyncio.Event()
-        self._cancel_reason: str | None = None
-
-    def cancel(self, reason: str | None = None) -> None:
-        """
-        Signal cancellation.
-
-        Args:
-            reason: Optional reason for cancellation (e.g., "user_cancelled", "timeout")
-        """
-        self._cancel_reason = reason or "cancelled"
-        self._event.set()
-
-    @property
-    def is_cancelled(self) -> bool:
-        """Check if cancellation has been requested."""
-        return self._event.is_set()
-
-    @property
-    def cancel_reason(self) -> str | None:
-        """Get the reason for cancellation, if any."""
-        return self._cancel_reason
-
-    async def wait_for_cancellation(self) -> None:
-        """Wait until cancellation is requested."""
-        await self._event.wait()
-
-    def reset(self) -> None:
-        """
-        Reset the token to non-cancelled state.
-
-        Note: This should be used with caution. Generally, it's better
-        to create a new token for each operation.
-        """
-        self._event.clear()
-        self._cancel_reason = None
+# This module is kept for documentation purposes.
+# All cancellation is now handled via asyncio.Task.cancel()

--- a/src/fast_agent/llm/fastagent_llm.py
+++ b/src/fast_agent/llm/fastagent_llm.py
@@ -36,7 +36,6 @@ from fast_agent.interfaces import (
     FastAgentLLMProtocol,
     ModelT,
 )
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.memory import Memory, SimpleMemory
 from fast_agent.llm.model_database import ModelDatabase
 from fast_agent.llm.provider_types import Provider
@@ -185,7 +184,6 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         messages: list[PromptMessageExtended],
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Generate a completion using normalized message lists.
@@ -197,13 +195,12 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
             messages: List of PromptMessageExtended objects
             request_params: Optional parameters to configure the LLM request
             tools: Optional list of tools available to the LLM
-            cancellation_token: Optional token to cancel the operation
 
         Returns:
             A PromptMessageExtended containing the Assistant response
 
         Raises:
-            asyncio.CancelledError: If the operation is cancelled via the token
+            asyncio.CancelledError: If the operation is cancelled via task.cancel()
         """
         # TODO -- create a "fast-agent" control role rather than magic strings
 
@@ -230,7 +227,7 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         # Track timing for this generation
         start_time = time.perf_counter()
         assistant_response: PromptMessageExtended = await self._apply_prompt_provider_specific(
-            full_history, request_params, tools, cancellation_token=cancellation_token
+            full_history, request_params, tools
         )
         end_time = time.perf_counter()
         duration_ms = round((end_time - start_time) * 1000, 2)
@@ -258,7 +255,6 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
         is_template: bool = False,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Provider-specific implementation of apply_prompt_template.
@@ -271,7 +267,6 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
             request_params: Optional parameters to configure the LLM request
             tools: Optional list of tools available to the LLM
             is_template: Whether this is a template application
-            cancellation_token: Optional token to cancel the operation
 
         Returns:
             String representation of the assistant's response if generated,

--- a/src/fast_agent/llm/internal/passthrough.py
+++ b/src/fast_agent/llm/internal/passthrough.py
@@ -6,7 +6,6 @@ from mcp.types import CallToolRequestParams, PromptMessage
 
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.fastagent_llm import (
     FastAgentLLM,
     RequestParams,
@@ -77,7 +76,6 @@ class PassthroughLLM(FastAgentLLM):
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
         is_template: bool = False,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         # Add messages to history with proper is_prompt flag
         self.history.extend(multipart_messages, is_prompt=is_template)

--- a/src/fast_agent/llm/internal/playback.py
+++ b/src/fast_agent/llm/internal/playback.py
@@ -6,7 +6,6 @@ from mcp.types import PromptMessage
 from fast_agent.core.exceptions import ModelConfigError
 from fast_agent.core.prompt import Prompt
 from fast_agent.interfaces import ModelT
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.internal.passthrough import PassthroughLLM
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.usage_tracking import create_turn_usage_from_messages
@@ -65,7 +64,6 @@ class PlaybackLLM(PassthroughLLM):
         ],
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Handle playback of messages in two modes:

--- a/src/fast_agent/llm/provider/openai/llm_openai.py
+++ b/src/fast_agent/llm/provider/openai/llm_openai.py
@@ -25,7 +25,6 @@ from fast_agent.core.exceptions import ProviderKeyError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
 from fast_agent.event_progress import ProgressAction
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.fastagent_llm import FastAgentLLM, RequestParams
 from fast_agent.llm.model_database import ModelDatabase
 from fast_agent.llm.provider.openai.multipart_converter_openai import OpenAIConverter, OpenAIMessage
@@ -208,7 +207,6 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         self,
         stream,
         model: str,
-        cancellation_token: CancellationToken | None = None,
     ):
         """Process the streaming response and display real-time token usage."""
         # Track estimated output tokens by counting text chunks
@@ -222,7 +220,7 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
             Provider.GOOGLE_OAI,
         ]
         if stream_mode == "manual" or provider_requires_manual:
-            return await self._process_stream_manual(stream, model, cancellation_token)
+            return await self._process_stream_manual(stream, model)
 
         # Use ChatCompletionStreamState helper for accumulation (OpenAI only)
         state = ChatCompletionStreamState()
@@ -233,11 +231,8 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         notified_tool_indices: set[int] = set()
 
         # Process the stream chunks
+        # Cancellation is handled via asyncio.Task.cancel() which raises CancelledError
         async for chunk in stream:
-            # Check for cancellation before processing each chunk
-            if cancellation_token and cancellation_token.is_cancelled:
-                _logger.info("Stream cancelled by user")
-                raise asyncio.CancelledError(cancellation_token.cancel_reason or "cancelled")
 
             # Handle chunk accumulation
             state.handle_chunk(chunk)
@@ -438,7 +433,6 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         self,
         stream,
         model: str,
-        cancellation_token: CancellationToken | None = None,
     ):
         """Manual stream processing for providers like Ollama that may not work with ChatCompletionStreamState."""
 
@@ -461,11 +455,8 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         notified_tool_indices: set[int] = set()
 
         # Process the stream chunks manually
+        # Cancellation is handled via asyncio.Task.cancel() which raises CancelledError
         async for chunk in stream:
-            # Check for cancellation before processing each chunk
-            if cancellation_token and cancellation_token.is_cancelled:
-                self.logger.info("Stream cancelled by user")
-                raise asyncio.CancelledError(cancellation_token.cancel_reason or "cancelled")
 
             # Process streaming events for tool calls
             if chunk.choices:
@@ -702,7 +693,6 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         message: list[OpenAIMessage] | None,
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Process a query using an LLM and available tools.
@@ -760,7 +750,7 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
             async with self._openai_client() as client:
                 stream = await client.chat.completions.create(**arguments)
                 # Process the stream
-                response = await self._process_stream(stream, model_name, cancellation_token)
+                response = await self._process_stream(stream, model_name)
         except asyncio.CancelledError as e:
             reason = str(e) if e.args else "cancelled"
             self.logger.info(f"OpenAI completion cancelled: {reason}")
@@ -918,7 +908,6 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
         is_template: bool = False,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         """
         Provider-specific prompt application.
@@ -938,9 +927,7 @@ class OpenAILLM(FastAgentLLM[ChatCompletionMessageParam, ChatCompletionMessage])
         if not converted_messages:
             converted_messages = [{"role": "user", "content": ""}]
 
-        return await self._openai_completion(
-            converted_messages, req_params, tools, cancellation_token
-        )
+        return await self._openai_completion(converted_messages, req_params, tools)
 
     def _prepare_api_request(
         self, messages, tools: list[ChatCompletionToolParam] | None, request_params: RequestParams

--- a/tests/integration/tool_loop/test_tool_loop.py
+++ b/tests/integration/tool_loop/test_tool_loop.py
@@ -7,7 +7,6 @@ from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.tool_agent import ToolAgent
 from fast_agent.constants import FAST_AGENT_ERROR_CHANNEL
 from fast_agent.core.prompt import Prompt
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.internal.passthrough import PassthroughLLM
 from fast_agent.llm.request_params import RequestParams
 from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
@@ -21,7 +20,6 @@ class ToolGeneratingLlm(PassthroughLLM):
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
         is_template: bool = False,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         tool_calls = {}
         tool_calls["my_id"] = CallToolRequest(
@@ -104,7 +102,6 @@ class PersistentToolGeneratingLlm(PassthroughLLM):
         request_params: RequestParams | None = None,
         tools: list[Tool] | None = None,
         is_template: bool = False,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         self.call_count += 1
         tool_calls = {

--- a/tests/unit/fast_agent/agents/test_agent_history_binding.py
+++ b/tests/unit/fast_agent/agents/test_agent_history_binding.py
@@ -4,7 +4,6 @@ from mcp.types import TextContent
 from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.llm_agent import LlmAgent
 from fast_agent.core.prompt import Prompt
-from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.fastagent_llm import FastAgentLLM
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.request_params import RequestParams
@@ -22,7 +21,6 @@ class FakeLLM(FastAgentLLM[PromptMessageExtended, PromptMessageExtended]):
         request_params: RequestParams | None = None,
         tools=None,
         is_template: bool = False,
-        cancellation_token: CancellationToken | None = None,
     ) -> PromptMessageExtended:
         self.last_messages = list(multipart_messages)
         return Prompt.assistant("ok")

--- a/tests/unit/fast_agent/agents/test_llm_content_filter.py
+++ b/tests/unit/fast_agent/agents/test_llm_content_filter.py
@@ -40,7 +40,7 @@ class RecordingStubLLM(FastAgentLLMProtocol):
     def provider(self) -> Provider:
         return self._provider
 
-    async def generate(self, messages, request_params=None, tools=None, cancellation_token=None):
+    async def generate(self, messages, request_params=None, tools=None):
         self.generated_messages = messages
         self._message_history = messages
         return PromptMessageExtended(

--- a/tests/unit/fast_agent/llm/providers/test_llm_openai_history.py
+++ b/tests/unit/fast_agent/llm/providers/test_llm_openai_history.py
@@ -13,7 +13,7 @@ class CapturingOpenAI(OpenAILLM):
         super().__init__(**kwargs)
         self.captured = None
 
-    async def _openai_completion(self, message, request_params=None, tools=None, cancellation_token=None):
+    async def _openai_completion(self, message, request_params=None, tools=None):
         self.captured = message
         return Prompt.assistant("ok")
 


### PR DESCRIPTION
…ation

- Replace custom CancellationError with asyncio.CancelledError for idiomatic async
- Remove ExtendedAgentSideConnection class (fix non-compliant clients instead)
- Implement task-based cancellation via asyncio.Task.cancel() in ACP server
- Track asyncio tasks per session for proper cancellation support
- Update all LLM providers (Anthropic, OpenAI, Google, Bedrock) to use asyncio.CancelledError
- Add proper CancelledError handling in ACP prompt method

This aligns with Python asyncio best practices and provides more immediate cancellation when LLM providers are blocked on network calls.