### PR TITLE
Review ACP cancellation implementation in Python SDK

### DIFF
--- a/src/fast_agent/llm/cancellation.py
+++ b/src/fast_agent/llm/cancellation.py
@@ -5,6 +5,9 @@ This module provides a CancellationToken that can be used to cancel
 in-flight LLM requests, particularly useful for:
 - ESC key cancellation in interactive sessions
 - ACP session/cancel protocol support
+
+When cancellation is detected, raise asyncio.CancelledError for proper
+asyncio integration.
 """
 
 import asyncio
@@ -73,14 +76,6 @@ class CancellationToken:
         self._cancel_reason = None
 
 
-class CancellationError(Exception):
-    """
-    Exception raised when an operation is cancelled.
-
-    This is not an error condition - it indicates intentional cancellation
-    by the user or system.
-    """
-
-    def __init__(self, reason: str = "Operation cancelled"):
-        self.reason = reason
-        super().__init__(reason)
+# Deprecated: Use asyncio.CancelledError instead
+# Kept for backward compatibility during transition
+CancellationError = asyncio.CancelledError

--- a/src/fast_agent/llm/provider/anthropic/llm_anthropic.py
+++ b/src/fast_agent/llm/provider/anthropic/llm_anthropic.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Type, Union, cast
 
@@ -28,7 +29,7 @@ from fast_agent.core.logging.logger import get_logger
 from fast_agent.core.prompt import Prompt
 from fast_agent.event_progress import ProgressAction
 from fast_agent.interfaces import ModelT
-from fast_agent.llm.cancellation import CancellationError, CancellationToken
+from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.fastagent_llm import (
     FastAgentLLM,
     RequestParams,
@@ -251,7 +252,7 @@ class AnthropicLLM(FastAgentLLM[MessageParam, Message]):
                 # Check for cancellation before processing each event
                 if cancellation_token and cancellation_token.is_cancelled:
                     logger.info("Stream cancelled by user")
-                    raise CancellationError(cancellation_token.cancel_reason or "cancelled")
+                    raise asyncio.CancelledError()
                 if (
                     event.type == "content_block_start"
                     and hasattr(event, "content_block")
@@ -574,8 +575,8 @@ class AnthropicLLM(FastAgentLLM[MessageParam, Message]):
             async with anthropic.messages.stream(**arguments) as stream:
                 # Process the stream
                 response = await self._process_stream(stream, model, cancellation_token)
-        except CancellationError as e:
-            logger.info(f"Anthropic completion cancelled: {e.reason}")
+        except asyncio.CancelledError:
+            logger.info("Anthropic completion cancelled")
             # Return a response indicating cancellation
             return Prompt.assistant(
                 TextContent(type="text", text=""),

--- a/src/fast_agent/llm/provider/bedrock/llm_bedrock.py
+++ b/src/fast_agent/llm/provider/bedrock/llm_bedrock.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import re
@@ -18,7 +19,7 @@ from fast_agent.core.exceptions import ProviderKeyError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.event_progress import ProgressAction
 from fast_agent.interfaces import ModelT
-from fast_agent.llm.cancellation import CancellationError, CancellationToken
+from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.fastagent_llm import FastAgentLLM
 from fast_agent.llm.provider.bedrock.multipart_converter_bedrock import BedrockConverter
 from fast_agent.llm.provider_types import Provider
@@ -1027,7 +1028,7 @@ class BedrockLLM(FastAgentLLM[BedrockMessageParam, BedrockMessage]):
                 # Check for cancellation before processing each event
                 if cancellation_token and cancellation_token.is_cancelled:
                     self.logger.info("Stream cancelled by user")
-                    raise CancellationError(cancellation_token.cancel_reason or "cancelled")
+                    raise asyncio.CancelledError()
 
                 if "messageStart" in event:
                     # Message started

--- a/src/fast_agent/llm/provider/google/llm_google_native.py
+++ b/src/fast_agent/llm/provider/google/llm_google_native.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import secrets
 
@@ -17,7 +18,7 @@ from mcp.types import (
 
 from fast_agent.core.exceptions import ProviderKeyError
 from fast_agent.core.prompt import Prompt
-from fast_agent.llm.cancellation import CancellationError, CancellationToken
+from fast_agent.llm.cancellation import CancellationToken
 from fast_agent.llm.fastagent_llm import FastAgentLLM
 
 # Import the new converter class
@@ -161,7 +162,7 @@ class GoogleNativeLLM(FastAgentLLM[types.Content, types.Content]):
                 # Check for cancellation before processing each chunk
                 if cancellation_token and cancellation_token.is_cancelled:
                     self.logger.info("Stream cancelled by user")
-                    raise CancellationError(cancellation_token.cancel_reason or "cancelled")
+                    raise asyncio.CancelledError()
 
                 last_chunk = chunk
                 if getattr(chunk, "usage_metadata", None):


### PR DESCRIPTION
- Remove ExtendedAgentSideConnection workaround for non-compliant clients
- Add asyncio task tracking for proper cancellation via task.cancel()
- Replace custom CancellationError with asyncio.CancelledError
- Update all LLM providers to use asyncio.CancelledError
- Keep CancellationToken for cooperative cancellation in streaming loops

This aligns the cancellation implementation with standard Python asyncio patterns while maintaining backward compatibility through the CancellationToken.