### PR TITLE
Implement structured JSON outputs for agents

### DIFF
--- a/src/fast_agent/config.py
+++ b/src/fast_agent/config.py
@@ -279,6 +279,9 @@ class AnthropicSettings(BaseModel):
     - "auto": Currently same as "prompt" - caches tools+system prompt (1 block) and template content.
     """
 
+    default_headers: dict[str, str] | None = None
+    """Custom headers to include in all requests to the Anthropic API."""
+
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 

--- a/tests/unit/fast_agent/llm/test_model_database.py
+++ b/tests/unit/fast_agent/llm/test_model_database.py
@@ -223,3 +223,25 @@ def test_huggingface_explicit_provider_overrides_default():
     assert llm.default_request_params.model == "moonshotai/kimi-k2-instruct"
     args = _hf_request_args(llm)
     assert args["model"] == "moonshotai/kimi-k2-instruct:custom"
+
+
+def test_model_database_native_structured_output_support():
+    """Test that ModelDatabase correctly identifies models with native structured output support."""
+    # Models that should support native structured output (Anthropic 4.5+ models)
+    assert ModelDatabase.supports_native_structured_output("claude-sonnet-4-5")
+    assert ModelDatabase.supports_native_structured_output("claude-sonnet-4-5-20250929")
+    assert ModelDatabase.supports_native_structured_output("claude-opus-4-1")
+    assert ModelDatabase.supports_native_structured_output("claude-opus-4-5")
+    assert ModelDatabase.supports_native_structured_output("claude-haiku-4-5")
+    assert ModelDatabase.supports_native_structured_output("claude-haiku-4-5-20251001")
+
+    # Models that should NOT support native structured output
+    assert not ModelDatabase.supports_native_structured_output("claude-sonnet-4-0")
+    assert not ModelDatabase.supports_native_structured_output("claude-opus-4-0")
+    assert not ModelDatabase.supports_native_structured_output("claude-3-5-sonnet-latest")
+    assert not ModelDatabase.supports_native_structured_output("claude-3-7-sonnet-latest")
+    assert not ModelDatabase.supports_native_structured_output("gpt-4o")
+    assert not ModelDatabase.supports_native_structured_output("gemini-2.0-flash")
+
+    # Unknown models should return False
+    assert not ModelDatabase.supports_native_structured_output("unknown-model")


### PR DESCRIPTION
Implement Anthropic's new native structured outputs feature (via output_format parameter) for supported models (Claude Sonnet 4.5, Opus 4.1+, Haiku 4.5).

Changes:
- Add native_structured_output field to ModelParameters in model_database.py
- Create new model parameter configs for Anthropic models with structured output support
- Add supports_native_structured_output() method to ModelDatabase
- Add default_headers support to AnthropicSettings in config.py
- Modify AnthropicLLM to use native structured outputs when supported:
  - Uses beta API with structured-outputs-2025-11-13 header
  - Falls back to tool-based method for unsupported models
  - Automatically adds additionalProperties: false to JSON schemas
- Add comprehensive unit tests for the new functionality