### PR TITLE
Review ACP implementation with new SDK Union types

### DIFF
--- a/src/fast_agent/acp/content_conversion.py
+++ b/src/fast_agent/acp/content_conversion.py
@@ -103,7 +103,7 @@ def _convert_annotations(
     if not acp_annotations:
         return None
 
-    audience = cast(list[mcp_types.Role], list(acp_annotations.audience)) if acp_annotations.audience else None
+    audience = cast("list[mcp_types.Role]", list(acp_annotations.audience)) if acp_annotations.audience else None
     return mcp_types.Annotations(
         audience=audience,
         priority=getattr(acp_annotations, "priority", None),

--- a/src/fast_agent/acp/server/agent_acp_server.py
+++ b/src/fast_agent/acp/server/agent_acp_server.py
@@ -24,6 +24,8 @@ from acp import (
 )
 from acp.helpers import (
     ContentBlock as ACPContentBlock,
+)
+from acp.helpers import (
     update_agent_message_text,
     update_agent_thought_text,
 )

--- a/src/fast_agent/acp/tool_progress.py
+++ b/src/fast_agent/acp/tool_progress.py
@@ -27,12 +27,14 @@ from acp.schema import ToolKind
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
-    ContentBlock as MCPContentBlock,
     EmbeddedResource,
     ImageContent,
     ResourceLink,
     TextContent,
     TextResourceContents,
+)
+from mcp.types import (
+    ContentBlock as MCPContentBlock,
 )
 
 from fast_agent.core.logging.logger import get_logger


### PR DESCRIPTION
…ling

- Import ContentBlock from acp.helpers instead of manually defining ACPContentBlock Union in content_conversion.py
- Update agent_acp_server.py prompt method signature to use ACPContentBlock
- Refactor tool_progress.py to use match statements for MCP to ACP content conversion (more pythonic)
- Use SDK's resource_block helper for embedded resource conversion
- Extract tool kind patterns into class-level constant for cleaner code
- Simplify annotation conversion with getattr() instead of hasattr checks
- Remove redundant Union imports

All 133 tests pass (78 unit + 55 integration).