### PR TITLE
fix(hf-inference-acp): always set model and show provider info

### DIFF
--- a/publish/hf-inference-acp/src/hf_inference_acp/agents.py
+++ b/publish/hf-inference-acp/src/hf_inference_acp/agents.py
@@ -95,8 +95,8 @@ async def _lookup_and_format_providers(model: str) -> str | None:
             model_strings = result.format_model_strings()
             example = random.choice(model_strings)
             return (
-                f"**Available providers:** {providers}\n"
-                f"**To specify a provider:** `/set-model {example}`"
+                f"**Available providers:** {providers}\n\n"
+                f"**Autoroutes if no provider specified. Example use:** `/set-model {example}`"
             )
         elif result.exists:
             return "No inference providers currently available for this model."


### PR DESCRIPTION
Previously /set-model with a raw model ID would only show provider info without setting the model. Now it:
1. Always sets the model (with auto-added hf. prefix)
2. Shows provider info BEFORE the confirmation message
3. Shows a single random provider example instead of a list

Example output for `/set-model moonshotai/Kimi-K2-Thinking`:
```
**Available providers:** novita, nebius, together, featherless-ai
**To specify a provider:** `/set-model moonshotai/Kimi-K2-Thinking:together`

Active model set to: `hf.moonshotai/Kimi-K2-Thinking`

Config file updated: ~/.config/hf-inference/hf.config.yaml
```