### PR TITLE
Include full tool args in ACP titles

### DIFF
--- a/src/fast_agent/acp/tool_permissions.py
+++ b/src/fast_agent/acp/tool_permissions.py
@@ -247,8 +247,8 @@ class ACPToolPermissionManager:
         # Create descriptive title with argument summary
         title = f"{server_name}/{tool_name}"
         if arguments:
-            # Include key argument info in title for user context
-            arg_str = ", ".join(f"{k}={v}" for k, v in list(arguments.items())[:2])
+            # Include trimmed arg list info in title for user context
+            arg_str = ", ".join(f"{k}={v}" for k, v in list(arguments.items()))
             if len(arg_str) > 50:
                 arg_str = arg_str[:47] + "..."
             title = f"{title}({arg_str})"

--- a/src/fast_agent/acp/tool_progress.py
+++ b/src/fast_agent/acp/tool_progress.py
@@ -443,8 +443,8 @@ class ACPToolProgressManager:
         # Create title
         title = f"{server_name}/{tool_name}"
         if arguments:
-            # Include key argument info in title
-            arg_str = ", ".join(f"{k}={v}" for k, v in list(arguments.items())[:2])
+            # Include trimmed arg list info in title
+            arg_str = ", ".join(f"{k}={v}" for k, v in list(arguments.items()))
             if len(arg_str) > 50:
                 arg_str = arg_str[:47] + "..."
             title = f"{title}({arg_str})"

--- a/tests/unit/acp/test_tool_permissions.py
+++ b/tests/unit/acp/test_tool_permissions.py
@@ -588,7 +588,12 @@ class TestACPToolPermissionManager:
             cwd=temp_dir,
         )
 
-        result = await manager.check_permission("tool1", "server1", {"arg": "value"})
+        arguments = {
+            "prompt": "lion",
+            "quality": "low",
+            "tool_result": "image",
+        }
+        result = await manager.check_permission("tool1", "server1", arguments)
 
         assert result.allowed is True
         assert result.remember is False
@@ -597,9 +602,12 @@ class TestACPToolPermissionManager:
         # Verify tool_call contains rawInput per ACP spec (now stored as dict)
         request = connection.permission_requests[0]
         assert request["tool_call"] is not None
-        assert request["tool_call"].rawInput == {"arg": "value"}
-        # Title should include argument summary
-        assert "server1/tool1" in request["tool_call"].title
+        assert request["tool_call"].rawInput == arguments
+        # Title should include trimmed argument summary
+        title = request["tool_call"].title
+        assert "server1/tool1" in title
+        assert "prompt=lion" in title
+        assert "tool_result=image" in title
 
     @pytest.mark.asyncio
     async def test_persists_allow_always_to_store(self, temp_dir: Path) -> None:

--- a/tests/unit/acp/test_tool_progress.py
+++ b/tests/unit/acp/test_tool_progress.py
@@ -72,6 +72,31 @@ class TestACPToolProgressManager:
         assert notification.status == "pending"
 
     @pytest.mark.asyncio
+    async def test_on_tool_start_includes_all_args_in_title(self) -> None:
+        """Tool start title should include trimmed argument list."""
+        connection = FakeAgentSideConnection()
+        manager = ACPToolProgressManager(connection, "test-session")
+
+        arguments = {
+            "prompt": "lion",
+            "quality": "low",
+            "tool_result": "image",
+        }
+
+        await manager.on_tool_start(
+            tool_name="openai-images-generate",
+            server_name="media-gen",
+            arguments=arguments,
+        )
+
+        assert len(connection.notifications) == 1
+        notification = connection.notifications[0]
+        assert notification.sessionUpdate == "tool_call"
+        assert "media-gen/openai-images-generate" in notification.title
+        assert "prompt=lion" in notification.title
+        assert "tool_result=image" in notification.title
+
+    @pytest.mark.asyncio
     async def test_delta_events_only_notify_after_threshold(self) -> None:
         """Delta notifications are only sent after 25 chunks to reduce UI noise."""
         connection = FakeAgentSideConnection()

--- a/tests/unit/fast_agent/llm/providers/test_llm_anthropic_caching.py
+++ b/tests/unit/fast_agent/llm/providers/test_llm_anthropic_caching.py
@@ -94,7 +94,8 @@ class TestAnthropicCaching:
         # Template messages should have cache_control
         # The last template message should have cache_control on its last block
         found_cache_control = False
-        for i, msg in enumerate(converted[:2]):  # First 2 are templates
+        template_count = len(template_msgs)
+        for i, msg in enumerate(converted[:template_count]):  # First template_count are templates
             if "content" in msg:
                 for block in msg["content"]:
                     if isinstance(block, dict) and "cache_control" in block:


### PR DESCRIPTION
## Summary
- include full tool argument list in ACP tool call titles (trimmed to 50 chars)
- add unit coverage for tool title formatting
- remove hard-coded template slice in Anthropic caching test

## Testing
- PYTHONPATH=src pytest tests/unit/acp/test_tool_progress.py tests/unit/acp/test_tool_permissions.py tests/unit/fast_agent/llm/providers/test_llm_anthropic_caching.py