### PR TITLE
Route stdio console output to stderr before stopping progress

### DIFF
--- a/src/fast_agent/core/fastagent.py
+++ b/src/fast_agent/core/fastagent.py
@@ -373,6 +373,11 @@ class FastAgent:
 
             # Stop progress display immediately if quiet mode is requested
             if self._programmatic_quiet:
+                if (
+                    getattr(self.args, "server", False)
+                    and getattr(self.args, "transport", None) in ["stdio", "acp"]
+                ):
+                    configure_console_stream("stderr")
                 from fast_agent.ui.progress_display import progress_display
 
                 progress_display.stop()
@@ -1246,6 +1251,7 @@ class FastAgent:
             self.args, "server", False
         ):
             quiet_mode = True
+            configure_console_stream("stderr")
         cli_model_override = getattr(self.args, "model", None)
 
         # Store the model source for UI display

--- a/tests/unit/fast_agent/core/test_stdio_quiet_console.py
+++ b/tests/unit/fast_agent/core/test_stdio_quiet_console.py
@@ -1,0 +1,30 @@
+import pytest
+
+import fast_agent.core.fastagent as fastagent_module
+import fast_agent.ui.progress_display as progress_display_module
+from fast_agent.core.fastagent import FastAgent
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_routes_console_before_progress_stop(monkeypatch):
+    agent = FastAgent("TestAgent", parse_cli_args=False)
+    agent.args.server = True
+    agent.args.transport = "stdio"
+    agent.args.quiet = False
+
+    state = {"configured": False}
+
+    def fake_configure(stream):
+        assert stream == "stderr"
+        state["configured"] = True
+
+    def fake_stop():
+        assert state["configured"] is True
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(fastagent_module, "configure_console_stream", fake_configure)
+    monkeypatch.setattr(progress_display_module.progress_display, "stop", fake_stop)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        async with agent.run():
+            pass


### PR DESCRIPTION
## Summary
- Route Rich console output to stderr early when running stdio/acp servers in quiet mode.
- Prevent blank line writes on stdout that break JSON-RPC parsing.
- Add a unit test to assert the console routing happens before progress display shutdown.

## Testing
- uv run pytest tests/unit/fast_agent/core/test_stdio_quiet_console.py
- uv run scripts/lint.py
- uv run scripts/typecheck.py
