### PR TITLE
fix: Bedrock multi-turn tool calling errors

### DIFF
--- a/src/fast_agent/llm/provider/bedrock/multipart_converter_bedrock.py
+++ b/src/fast_agent/llm/provider/bedrock/multipart_converter_bedrock.py
@@ -79,13 +79,14 @@ class BedrockConverter:
         # Handle tool calls (from assistant messages)
         if multipart_msg.tool_calls:
             for tool_use_id, call_request in multipart_msg.tool_calls.items():
-                content_list.append({
-                    "toolUse": {
-                        "toolUseId": tool_use_id,
+                content_list.append(
+                    {
+                        "type": "tool_use",
+                        "id": tool_use_id,
                         "name": call_request.params.name,
-                        "input": call_request.params.arguments or {}
+                        "input": call_request.params.arguments or {},
                     }
-                })
+                )
 
         # Handle regular content
         from mcp.types import TextContent

--- a/tests/unit/fast_agent/llm/providers/test_bedrock_converter.py
+++ b/tests/unit/fast_agent/llm/providers/test_bedrock_converter.py
@@ -1,0 +1,57 @@
+from mcp import Tool
+from mcp.types import CallToolRequest, CallToolRequestParams, ListToolsResult
+
+from fast_agent.llm.provider.bedrock.llm_bedrock import BedrockLLM
+from fast_agent.llm.provider.bedrock.multipart_converter_bedrock import BedrockConverter
+from fast_agent.types import PromptMessageExtended
+
+
+def test_bedrock_converter_emits_tool_use_items():
+    tool_call = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name="demo-tool", arguments={"x": 1}),
+    )
+    msg = PromptMessageExtended(role="assistant", content=[], tool_calls={"call_1": tool_call})
+
+    converted = BedrockConverter.convert_to_bedrock(msg)
+
+    assert converted["role"] == "assistant"
+    content = list(converted["content"])
+    assert content[0]["type"] == "tool_use"
+    assert content[0]["id"] == "call_1"
+    assert content[0]["name"] == "demo-tool"
+    assert content[0]["input"] == {"x": 1}
+
+
+def test_bedrock_convert_messages_to_bedrock_includes_tool_use_block():
+    tool_call = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name="demo-tool", arguments={"x": 1}),
+    )
+    msg = PromptMessageExtended(role="assistant", content=[], tool_calls={"call_1": tool_call})
+
+    converted = BedrockConverter.convert_to_bedrock(msg)
+    llm = object.__new__(BedrockLLM)
+
+    output = BedrockLLM._convert_messages_to_bedrock(llm, [converted])
+
+    assert output
+    content = output[0]["content"]
+    assert any("toolUse" in block for block in content)
+    tool_use = next(block["toolUse"] for block in content if "toolUse" in block)
+    assert tool_use["toolUseId"] == "call_1"
+    assert tool_use["name"] == "demo-tool"
+    assert tool_use["input"] == {"x": 1}
+
+
+def test_resolve_tool_use_name_uses_mapped_name():
+    tool_list = ListToolsResult(
+        tools=[Tool(name="my-tool", description="demo", inputSchema={"type": "object"})]
+    )
+    tool_name_mapping = {"my_tool": "my-tool"}
+
+    resolved = BedrockLLM._resolve_tool_use_name(
+        "call_1_my-tool", tool_list, tool_name_mapping
+    )
+
+    assert resolved == "my_tool"


### PR DESCRIPTION
Add tool_calls conversion and reconstruct missing assistant messages with toolUse blocks to prevent orphaned tool results that cause errors in Bedrock API.

Fixes https://github.com/evalstate/fast-agent/issues/624