### PR TITLE
fix: Bedrock Agents-As-Tools validation errors

### DIFF
--- a/src/fast_agent/llm/provider/bedrock/llm_bedrock.py
+++ b/src/fast_agent/llm/provider/bedrock/llm_bedrock.py
@@ -1017,12 +1017,19 @@ class BedrockLLM(FastAgentLLM[BedrockMessageParam, BedrockMessage]):
             if isinstance(content, str):
                 bedrock_message["content"].append({"text": content})
             elif isinstance(content, list):
+                # CRITICAL: For assistant messages, text blocks MUST come before toolUse blocks
+                # Bedrock rejects messages where toolUse comes before text
+                text_blocks = []
+                tool_use_blocks = []
+                tool_result_blocks = []
+                other_blocks = []
+                
                 for item in content:
                     item_type = item.get("type")
                     if item_type == "text":
-                        bedrock_message["content"].append({"text": item.get("text", "")})
+                        text_blocks.append({"text": item.get("text", "")})
                     elif item_type == "tool_use":
-                        bedrock_message["content"].append(
+                        tool_use_blocks.append(
                             {
                                 "toolUse": {
                                     "toolUseId": item.get("id", ""),
@@ -1039,15 +1046,13 @@ class BedrockLLM(FastAgentLLM[BedrockMessageParam, BedrockMessage]):
                         bedrock_content_list = []
                         if raw_content:
                             for part in raw_content:
-                                # FIX: The content parts are dicts, not TextContent objects.
                                 if isinstance(part, dict) and "text" in part:
                                     bedrock_content_list.append({"text": part.get("text", "")})
 
-                        # Bedrock requires content for error statuses.
                         if not bedrock_content_list and status == "error":
                             bedrock_content_list.append({"text": "Tool call failed with an error."})
 
-                        bedrock_message["content"].append(
+                        tool_result_blocks.append(
                             {
                                 "toolResult": {
                                     "toolUseId": tool_use_id,
@@ -1056,6 +1061,12 @@ class BedrockLLM(FastAgentLLM[BedrockMessageParam, BedrockMessage]):
                                 }
                             }
                         )
+                    else:
+                        # Handle any other content types
+                        other_blocks.append(item)
+                
+                # Order: text first, then toolUse, then toolResult, then others
+                bedrock_message["content"] = text_blocks + tool_use_blocks + tool_result_blocks + other_blocks
 
             # Only add the message if it has content
             if bedrock_message["content"]:
@@ -1558,14 +1569,67 @@ class BedrockLLM(FastAgentLLM[BedrockMessageParam, BedrockMessage]):
                         f"Inserted reconstructed assistant message with {len(tool_use_blocks)} toolUse blocks before message {msg_idx}"
                     )
 
-            if (
-                schema_choice in (ToolSchemaType.ANTHROPIC, ToolSchemaType.DEFAULT)
-                and isinstance(tools_payload, list)
-                and (tools_payload or has_tool_results)
-            ):
-                # Include toolConfig when we have tools OR when conversation has tool results
-                # If we have tool results but no tools, use empty list to satisfy Bedrock's requirement
-                converse_args["toolConfig"] = {"tools": tools_payload if tools_payload else []}
+            # Handle orphaned toolUse blocks without corresponding toolResult
+            # This happens in Agents-As-Tools pattern when child agent history gets corrupted
+            if has_tool_use:
+                messages = converse_args["messages"]
+                for msg_idx, msg in enumerate(messages):
+                    if isinstance(msg, dict) and msg.get("role") == "assistant" and msg.get("content"):
+                        tool_use_ids = [
+                            content["toolUse"].get("toolUseId") or content["toolUse"].get("tool_use_id")
+                            for content in msg["content"]
+                            if isinstance(content, dict) and "toolUse" in content
+                        ]
+                        if not tool_use_ids:
+                            continue
+                        # Check if next message has matching toolResults
+                        next_msg = messages[msg_idx + 1] if msg_idx + 1 < len(messages) else None
+                        if next_msg and next_msg.get("role") == "user":
+                            existing_result_ids = {
+                                content["toolResult"].get("toolUseId") or content["toolResult"].get("tool_use_id")
+                                for content in next_msg.get("content", [])
+                                if isinstance(content, dict) and "toolResult" in content
+                            }
+                            missing_ids = [tid for tid in tool_use_ids if tid not in existing_result_ids]
+                        else:
+                            missing_ids = tool_use_ids
+                        # Add placeholder toolResults for orphaned toolUse blocks
+                        if missing_ids:
+                            self.logger.warning(
+                                f"Detected {len(missing_ids)} orphaned toolUse blocks without toolResult - "
+                                "injecting placeholder toolResult messages"
+                            )
+                            placeholder_content = [
+                                {"toolResult": {"toolUseId": tid, "status": "error", "content": [{"text": "Tool was interrupted."}]}}
+                                for tid in missing_ids
+                            ]
+                            if next_msg and next_msg.get("role") == "user":
+                                next_msg["content"].extend(placeholder_content)
+                            else:
+                                messages.insert(msg_idx + 1, {"role": "user", "content": placeholder_content})
+
+            # Noop tool spec for when we need toolConfig but have no actual tools
+            # Bedrock requires at least one tool in toolConfig, so we use a placeholder
+            noop_tool_spec = {
+                "toolSpec": {
+                    "name": "noop",
+                    "description": "This is a placeholder tool that should be ignored.",
+                    "inputSchema": {"json": {"type": "object", "properties": {}}}
+                }
+            }
+
+            # Include toolConfig when we have tools OR when conversation has tool results/use blocks
+            # Bedrock requires toolConfig when toolUse/toolResult blocks are in the conversation
+            # This applies to ALL schema types, not just ANTHROPIC/DEFAULT
+            if schema_choice in (ToolSchemaType.ANTHROPIC, ToolSchemaType.DEFAULT):
+                if isinstance(tools_payload, list) and tools_payload:
+                    converse_args["toolConfig"] = {"tools": tools_payload}
+                elif has_tool_results or has_tool_use:
+                    # Use noop tool since Bedrock requires at least one tool
+                    converse_args["toolConfig"] = {"tools": [noop_tool_spec]}
+            elif has_tool_results or has_tool_use:
+                # For other schemas (like SYSTEM_PROMPT), still need toolConfig if tool blocks exist
+                converse_args["toolConfig"] = {"tools": [noop_tool_spec]}
 
             # Inference configuration and overrides
             inference_config: dict[str, Any] = {}
@@ -1792,14 +1856,57 @@ class BedrockLLM(FastAgentLLM[BedrockMessageParam, BedrockMessage]):
                                     f"System: {system_text}\n\nUser: {original_text}"
                                 )
 
-                        # Re-add tools
+                        # Re-add tools or noop toolConfig if conversation has tool blocks
+                        noop_tool_spec = {
+                            "toolSpec": {
+                                "name": "noop",
+                                "description": "This is a placeholder tool that should be ignored.",
+                                "inputSchema": {"json": {"type": "object", "properties": {}}}
+                            }
+                        }
                         if (
                             schema_choice
                             in (ToolSchemaType.ANTHROPIC.value, ToolSchemaType.DEFAULT.value)
-                            and isinstance(tools_payload, list)
-                            and tools_payload
                         ):
-                            converse_args["toolConfig"] = {"tools": tools_payload}
+                            if isinstance(tools_payload, list) and tools_payload:
+                                converse_args["toolConfig"] = {"tools": tools_payload}
+                            elif has_tool_results or has_tool_use:
+                                converse_args["toolConfig"] = {"tools": [noop_tool_spec]}
+                        elif has_tool_results or has_tool_use:
+                            # For other schemas, still need toolConfig if tool blocks exist
+                            converse_args["toolConfig"] = {"tools": [noop_tool_spec]}
+
+                        # Handle orphaned toolUse blocks without corresponding toolResult (retry path)
+                        if has_tool_use:
+                            retry_messages = converse_args["messages"]
+                            for msg_idx, msg in enumerate(retry_messages):
+                                if isinstance(msg, dict) and msg.get("role") == "assistant" and msg.get("content"):
+                                    tool_use_ids = [
+                                        content["toolUse"].get("toolUseId") or content["toolUse"].get("tool_use_id")
+                                        for content in msg["content"]
+                                        if isinstance(content, dict) and "toolUse" in content
+                                    ]
+                                    if not tool_use_ids:
+                                        continue
+                                    next_msg = retry_messages[msg_idx + 1] if msg_idx + 1 < len(retry_messages) else None
+                                    if next_msg and next_msg.get("role") == "user":
+                                        existing_result_ids = {
+                                            content["toolResult"].get("toolUseId") or content["toolResult"].get("tool_use_id")
+                                            for content in next_msg.get("content", [])
+                                            if isinstance(content, dict) and "toolResult" in content
+                                        }
+                                        missing_ids = [tid for tid in tool_use_ids if tid not in existing_result_ids]
+                                    else:
+                                        missing_ids = tool_use_ids
+                                    if missing_ids:
+                                        placeholder_content = [
+                                            {"toolResult": {"toolUseId": tid, "status": "error", "content": [{"text": "Tool was interrupted."}]}}
+                                            for tid in missing_ids
+                                        ]
+                                        if next_msg and next_msg.get("role") == "user":
+                                            next_msg["content"].extend(placeholder_content)
+                                        else:
+                                            retry_messages.insert(msg_idx + 1, {"role": "user", "content": placeholder_content})
 
                         # Same streaming decision using cache
                         has_tools = bool(tools_payload) and bool(


### PR DESCRIPTION
This PR fixes https://github.com/evalstate/fast-agent/issues/667

- Reorder content blocks: text must come before toolUse (undocumented Bedrock requirement)
- Add noop tool placeholder when toolConfig required but no tools available
- Extend toolConfig to SYSTEM_PROMPT schema (not just ANTHROPIC/DEFAULT)
- Detect and patch orphaned toolUse blocks with placeholder toolResults
- Apply fixes to both initial call and retry/fallback paths

Fixes Agents-As-Tools pattern failures with AWS Bedrock where parent agents call child agents as tools. Three distinct validation issues addressed:

1. Content Block Ordering: Bedrock rejects assistant messages where toolUse blocks appear before text blocks
2. Missing toolConfig: Schema fallback to SYSTEM_PROMPT failed when tool blocks present; empty tools array also rejected
3. Orphaned toolUse: Edge cases with incomplete tool call history