### PR TITLE
fix(mcp): reject non-finite or non-positive connect timeouts

### DIFF
--- a/src/fast_agent/commands/handlers/mcp_runtime.py
+++ b/src/fast_agent/commands/handlers/mcp_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 import shlex
 from dataclasses import dataclass
@@ -123,6 +124,10 @@ def parse_connect_input(target_text: str) -> ParsedMcpConnectInput:
             if idx >= len(tokens):
                 raise ValueError("Missing value for --timeout")
             timeout_seconds = float(tokens[idx])
+            if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+                raise ValueError(
+                    "Invalid value for --timeout: expected a finite number greater than 0"
+                )
         elif token == "--oauth":
             trigger_oauth = True
         elif token == "--no-oauth":

--- a/tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py
+++ b/tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py
@@ -152,6 +152,15 @@ class _OAuthFailureManager(_Manager):
             "for this connection mode."
         )
 
+
+@pytest.mark.parametrize("raw_timeout", ["nan", "inf", "-inf", "0", "-1"])
+def test_parse_connect_input_rejects_non_finite_or_non_positive_timeout(
+    raw_timeout: str,
+) -> None:
+    with pytest.raises(ValueError, match="--timeout"):
+        mcp_runtime.parse_connect_input(f"npx demo-server --timeout {raw_timeout}")
+
+
 @pytest.mark.asyncio
 async def test_handle_mcp_connect_and_disconnect() -> None:
     manager = _Manager()


### PR DESCRIPTION
## Summary
Validate `/mcp connect --timeout` values to reject non-finite and non-positive numbers.

Previously `parse_connect_input` accepted `float(...)` without finiteness checks, which allowed values like `nan` and `inf`.

## Changes
- `src/fast_agent/commands/handlers/mcp_runtime.py`
  - After parsing timeout via `float`, require:
    - `math.isfinite(timeout_seconds)`
    - `timeout_seconds > 0`
  - Raise a clear `ValueError` when invalid.
- `tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py`
  - Added parameterized coverage for `nan`, `inf`, `-inf`, `0`, and `-1`.

## Validation
- `uv run pytest tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py -q`
- `uv run ruff check src/fast_agent/commands/handlers/mcp_runtime.py tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py`
