### PR TITLE
chore(gitignore): replace examples/**/*.jsonl with *.jsonl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,7 @@ uv.lock
 project_contents.md
 
 # example logs
-examples/**/*.jsonl
+*.jsonl
 fastagent.secrets.yaml
 CLAUDE.md
 example-outputs/


### PR DESCRIPTION
## Summary
Replace a narrow ignore pattern with a global one:

- from: `examples/**/*.jsonl`
- to: `*.jsonl`

## Why
JSONL artifacts are generated in multiple paths (not only under `examples/`).
Using a global ignore keeps working trees clean during local/dev test runs.

## Change scope
- `.gitignore` only (1 line)
