### PR TITLE
fix: avoid gluing reasoning sentences across deltas

### DIFF
--- a/src/fast_agent/llm/provider/openai/llm_openai.py
+++ b/src/fast_agent/llm/provider/openai/llm_openai.py
@@ -236,7 +236,8 @@ class OpenAILLM(
         if not reasoning_text:
             return reasoning_active
 
-        normalized_text = normalize_reasoning_delta("".join(reasoning_segments), reasoning_text)
+        last_char = reasoning_segments[-1][-1] if reasoning_segments and reasoning_segments[-1] else None
+        normalized_text = normalize_reasoning_delta(last_char, reasoning_text)
         if not normalized_text:
             return reasoning_active
 

--- a/src/fast_agent/llm/provider/openai/openresponses_streaming.py
+++ b/src/fast_agent/llm/provider/openai/openresponses_streaming.py
@@ -202,9 +202,12 @@ class OpenResponsesStreamingMixin(OpenAIToolNotificationMixin):
                     part_type = getattr(part, "type", None)
                     part_text = getattr(part, "text", None)
                     if part_type in {"reasoning", "reasoning_text"} and part_text:
-                        normalized_delta = normalize_reasoning_delta(
-                            "".join(reasoning_segments), part_text
+                        last_char = (
+                            reasoning_segments[-1][-1]
+                            if reasoning_segments and reasoning_segments[-1]
+                            else None
                         )
+                        normalized_delta = normalize_reasoning_delta(last_char, part_text)
                         if not normalized_delta:
                             continue
                         reasoning_segments.append(normalized_delta)
@@ -224,7 +227,12 @@ class OpenResponsesStreamingMixin(OpenAIToolNotificationMixin):
                     "response.reasoning_summary.delta",
                 }:
                     if delta:
-                        normalized_delta = normalize_reasoning_delta("".join(reasoning_segments), delta)
+                        last_char = (
+                            reasoning_segments[-1][-1]
+                            if reasoning_segments and reasoning_segments[-1]
+                            else None
+                        )
+                        normalized_delta = normalize_reasoning_delta(last_char, delta)
                         if not normalized_delta:
                             continue
                         reasoning_segments.append(normalized_delta)
@@ -244,7 +252,12 @@ class OpenResponsesStreamingMixin(OpenAIToolNotificationMixin):
                     "response.reasoning_text.delta",
                 }:
                     if delta:
-                        normalized_delta = normalize_reasoning_delta("".join(reasoning_segments), delta)
+                        last_char = (
+                            reasoning_segments[-1][-1]
+                            if reasoning_segments and reasoning_segments[-1]
+                            else None
+                        )
+                        normalized_delta = normalize_reasoning_delta(last_char, delta)
                         if not normalized_delta:
                             continue
                         reasoning_segments.append(normalized_delta)

--- a/src/fast_agent/llm/provider/openai/responses_streaming.py
+++ b/src/fast_agent/llm/provider/openai/responses_streaming.py
@@ -157,7 +157,12 @@ class ResponsesStreamingMixin(OpenAIToolNotificationMixin):
             }:
                 delta = getattr(event, "delta", None)
                 if delta:
-                    normalized_delta = normalize_reasoning_delta("".join(reasoning_segments), delta)
+                    last_char = (
+                        reasoning_segments[-1][-1]
+                        if reasoning_segments and reasoning_segments[-1]
+                        else None
+                    )
+                    normalized_delta = normalize_reasoning_delta(last_char, delta)
                     if not normalized_delta:
                         continue
                     reasoning_segments.append(normalized_delta)

--- a/src/fast_agent/utils/reasoning_chunk_join.py
+++ b/src/fast_agent/utils/reasoning_chunk_join.py
@@ -1,65 +1,31 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-
 _SENTENCE_PUNCTUATION = ".!?;:"
-_MARKDOWN_OR_QUOTE_PREFIXES = "\"'`*_["
-_CLOSING_DELIMITERS = ")]}\"'"
+_MARKDOWN_PREFIXES = "\"`*["
 
 
-def _needs_reasoning_separator(existing: str, incoming: str) -> bool:
-    if not existing or not incoming:
-        return False
-
-    prev = existing[-1]
-    nxt = incoming[0]
-
-    if prev.isspace() or nxt.isspace():
-        return False
-
-    if prev.islower() and nxt.isupper():
-        return True
-
-    if prev.isdigit() and nxt.isupper():
-        return True
-
-    if prev in _SENTENCE_PUNCTUATION and (nxt.isupper() or nxt in _MARKDOWN_OR_QUOTE_PREFIXES):
-        return True
-
-    if prev in _CLOSING_DELIMITERS and nxt.isupper():
-        return True
-
-    if nxt in _MARKDOWN_OR_QUOTE_PREFIXES and (prev.isalnum() or prev in _SENTENCE_PUNCTUATION):
-        return True
-
-    return False
-
-
-def append_reasoning_chunk(existing: str, incoming: str) -> str:
-    if not existing:
-        return incoming
+def _looks_like_sentence_chunk(incoming: str) -> bool:
     if not incoming:
-        return existing
-    if _needs_reasoning_separator(existing, incoming):
-        return f"{existing} {incoming}"
-    return existing + incoming
+        return False
+    if " " not in incoming:
+        return False
+    first = incoming[0]
+    return first.isupper() or first in _MARKDOWN_PREFIXES
 
 
-def join_reasoning_chunks(chunks: Sequence[str]) -> str:
-    combined = ""
-    for chunk in chunks:
-        if not chunk:
-            continue
-        combined = append_reasoning_chunk(combined, chunk)
-    return combined
+def normalize_reasoning_delta(last_char: str | None, incoming: str) -> str:
+    """Normalize one reasoning delta without rebuilding the full accumulated text.
 
-
-def normalize_reasoning_delta(existing: str, incoming: str) -> str:
+    Keep the Codex-style append-only flow, but patch the specific broken case where
+    providers split natural-language reasoning into sentence chunks without a
+    separating space, e.g. "approach." + "Specifying session retrieval format".
+    """
     if not incoming:
         return ""
-    combined = append_reasoning_chunk(existing, incoming)
-    return combined[len(existing) :]
+    if not last_char or last_char.isspace() or incoming[0].isspace():
+        return incoming
+    if last_char in _SENTENCE_PUNCTUATION and _looks_like_sentence_chunk(incoming):
+        return f" {incoming}"
+    if last_char.islower() and _looks_like_sentence_chunk(incoming):
+        return f" {incoming}"
+    return incoming

--- a/tests/unit/fast_agent/test_reasoning_chunk_join.py
+++ b/tests/unit/fast_agent/test_reasoning_chunk_join.py
@@ -2,6 +2,7 @@ from fast_agent.utils.reasoning_chunk_join import normalize_reasoning_delta
 
 
 def test_normalize_reasoning_delta_inserts_space_after_sentence_break() -> None:
+    last_char = None
     emitted = ""
     parts = [
         "approach.",
@@ -10,16 +11,30 @@ def test_normalize_reasoning_delta_inserts_space_after_sentence_break() -> None:
     ]
 
     for part in parts:
-        delta = normalize_reasoning_delta(emitted, part)
+        delta = normalize_reasoning_delta(last_char, part)
         emitted += delta
+        last_char = emitted[-1] if emitted else None
 
     assert emitted == "approach. Specifying session retrieval format Selecting session retrieval method"
 
 
-def test_normalize_reasoning_delta_preserves_tool_style_names() -> None:
+def test_normalize_reasoning_delta_preserves_contractions() -> None:
+    last_char = None
     emitted = ""
-    for part in ["voice.", "fetch", "(id=session_id, mode='transcript')"]:
-        delta = normalize_reasoning_delta(emitted, part)
+    for part in ["don", "'t do that"]:
+        delta = normalize_reasoning_delta(last_char, part)
         emitted += delta
+        last_char = emitted[-1] if emitted else None
 
-    assert emitted == "voice.fetch(id=session_id, mode='transcript')"
+    assert emitted == "don't do that"
+
+
+def test_normalize_reasoning_delta_preserves_identifier_fragments() -> None:
+    last_char = None
+    emitted = ""
+    for part in ["session", "_id is required"]:
+        delta = normalize_reasoning_delta(last_char, part)
+        emitted += delta
+        last_char = emitted[-1] if emitted else None
+
+    assert emitted == "session_id is required"


### PR DESCRIPTION
## Why
Some reasoning streams arrive in sentence-sized deltas.

Example:
- `approach.`
- `Specifying session retrieval format`

fast-agent currently concatenates them raw, which yields:
- `approach.Specifying ...`

That is not a formatting preference issue. It corrupts human-readable reasoning in the console.

## Change
Normalize reasoning deltas at the provider boundary.

Rules are intentionally small:
- insert one space when a new reasoning delta starts a new sentence/token boundary
- do not insert spaces for call-like fragments such as `voice.fetch(...)`

This keeps the fix local to reasoning stream assembly and avoids adding heuristics in the UI layer.

## Why this shape
Codex-style stream handling is simpler when text is fixed close to the event source.
UI should render, not repair token boundaries.

## Validation
- added focused tests for reasoning delta normalization
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`