### PR TITLE
Improve Codex plan picker activation flow

### DIFF
--- a/src/fast_agent/cli/runtime/agent_setup.py
+++ b/src/fast_agent/cli/runtime/agent_setup.py
@@ -128,17 +128,51 @@ async def _prompt_for_generic_model_spec(*, default_model: str = "llama3.2") -> 
         typer.echo("Please enter a non-empty model string.", err=True)
 
 
+def _activate_model_picker_provider(action: str) -> bool:
+    if action != "codex-login":
+        typer.echo(f"Unsupported provider activation action: {action}", err=True)
+        return False
+
+    from fast_agent.core.exceptions import ProviderKeyError, format_fast_agent_error
+    from fast_agent.llm.provider.openai.codex_oauth import login_codex_oauth
+    from fast_agent.ui import console
+
+    typer.echo("Starting Codex OAuth login...", err=True)
+    try:
+        console.ensure_blocking_console()
+        login_codex_oauth()
+    except ProviderKeyError as exc:
+        typer.echo(format_fast_agent_error(exc), err=True)
+        return False
+    except (EOFError, KeyboardInterrupt):
+        typer.echo("Codex OAuth login cancelled.", err=True)
+        return False
+
+    typer.echo("Codex OAuth login complete. Choose a Codex model to continue.", err=True)
+    return True
+
+
 async def _select_model_from_picker(request: AgentRunRequest) -> str:
     """Prompt user for model selection and return a resolved model string."""
     from fast_agent.ui.model_picker import run_model_picker_async
 
     config_path = Path(request.config_path) if request.config_path else None
+    initial_provider: str | None = None
 
     while True:
-        picker_result = await run_model_picker_async(config_path=config_path)
+        picker_result = await run_model_picker_async(
+            config_path=config_path,
+            initial_provider=initial_provider,
+        )
         if picker_result is None:
             typer.echo("Model selection cancelled.", err=True)
             raise typer.Exit(1)
+
+        initial_provider = picker_result.provider
+
+        if picker_result.activation_action is not None:
+            _activate_model_picker_provider(picker_result.activation_action)
+            continue
 
         if (
             picker_result.provider == Provider.GENERIC.config_name

--- a/src/fast_agent/llm/provider/openai/codex_oauth.py
+++ b/src/fast_agent/llm/provider/openai/codex_oauth.py
@@ -558,7 +558,9 @@ def login_codex_oauth(timeout_seconds: int = 300) -> CodexOAuthTokens:
     code: str | None = None
     returned_state: str | None = None
 
+    console.ensure_blocking_console()
     console.console.print("[bold]Open this link to authorize:[/bold]")
+    console.ensure_blocking_console()
     console.console.print(f"[link={auth_url}]{auth_url}[/link]")
 
     try:
@@ -573,10 +575,12 @@ def login_codex_oauth(timeout_seconds: int = 300) -> CodexOAuthTokens:
         server.close()
 
     if not code:
+        console.ensure_blocking_console()
         console.console.print(
             "Paste the full callback URL after completing the authorization in your browser:",
             style="bold",
         )
+        console.ensure_blocking_console()
         pasted = console.console.input("Callback URL: ")
         parsed = urlparse(pasted)
         params = parse_qs(parsed.query)

--- a/src/fast_agent/ui/model_picker.py
+++ b/src/fast_agent/ui/model_picker.py
@@ -23,9 +23,11 @@ from fast_agent.ui.model_picker_common import (
     REFER_TO_DOCS_PROVIDERS,
     ModelOption,
     ModelSource,
+    ProviderActivationAction,
     ProviderOption,
     build_snapshot,
     model_options_for_provider,
+    provider_activation_action,
 )
 
 StyleFragments = list[tuple[str, str]]
@@ -39,6 +41,7 @@ class ModelPickerResult:
     resolved_model: str | None
     source: ModelSource
     refer_to_docs: bool
+    activation_action: ProviderActivationAction | None = None
 
 
 @dataclass
@@ -53,10 +56,16 @@ class PickerState:
 class _SplitListPicker:
     LIST_VISIBLE_ROWS = 15
 
-    def __init__(self, *, config_path: Path | None) -> None:
+    def __init__(
+        self,
+        *,
+        config_path: Path | None,
+        initial_provider: str | None = None,
+    ) -> None:
         self.snapshot = build_snapshot(config_path)
         if not self.snapshot.providers:
             raise ValueError("No providers found in model catalog.")
+        self._initial_provider_name = initial_provider
 
         self.state = PickerState(
             provider_index=self._initial_provider_index(),
@@ -120,6 +129,7 @@ class _SplitListPicker:
                 {
                     "selected": "reverse",
                     "active": "ansigreen",
+                    "attention": "ansiyellow",
                     "inactive": "ansibrightblack",
                     "muted": "ansibrightblack",
                     "focus": "ansicyan",
@@ -137,6 +147,13 @@ class _SplitListPicker:
 
     def _provider_requires_docs_only(self) -> bool:
         return self.current_provider.provider in REFER_TO_DOCS_PROVIDERS
+
+    def _provider_activation_action(
+        self,
+        option: ProviderOption | None = None,
+    ) -> ProviderActivationAction | None:
+        provider_option = option or self.current_provider
+        return provider_activation_action(self.snapshot, provider_option.provider)
 
     @property
     def current_models(self) -> list[ModelOption]:
@@ -175,6 +192,10 @@ class _SplitListPicker:
         return max(30, min(42, cols // 3))
 
     def _initial_provider_index(self) -> int:
+        if self._initial_provider_name:
+            for index, option in enumerate(self.snapshot.providers):
+                if option.provider.config_name == self._initial_provider_name:
+                    return index
         for index, option in enumerate(self.snapshot.providers):
             if option.active:
                 return index
@@ -229,15 +250,34 @@ class _SplitListPicker:
         self.state.model_scroll_top = 0
         self._sync_model_scroll()
 
-    def _row_style(self, *, selected: bool, available: bool) -> str:
+    def _row_style(
+        self,
+        *,
+        selected: bool,
+        availability: Literal["active", "attention", "inactive"],
+    ) -> str:
         parts: list[str] = []
         if selected:
             parts.append("class:selected")
-        if available:
-            parts.append("class:active")
-        else:
-            parts.append("class:inactive")
+        parts.append(f"class:{availability}")
         return " ".join(parts)
+
+    def _provider_availability_label(self, option: ProviderOption) -> str:
+        if option.active:
+            return "available"
+        if self._provider_activation_action(option) is not None:
+            return "sign in required"
+        return "not configured"
+
+    def _provider_availability_style(
+        self,
+        option: ProviderOption,
+    ) -> Literal["active", "attention", "inactive"]:
+        if option.active:
+            return "active"
+        if self._provider_activation_action(option) is not None:
+            return "attention"
+        return "inactive"
 
     @staticmethod
     def _provider_display_name(config_name: str, default_name: str) -> str:
@@ -259,8 +299,11 @@ class _SplitListPicker:
         for index, option in enumerate(self.snapshot.providers):
             selected = index == self.state.provider_index
             cursor = "❯ " if self.state.focus == "providers" and selected else "  "
-            line_style = self._row_style(selected=selected, available=option.active)
-            availability = "available" if option.active else "not configured"
+            line_style = self._row_style(
+                selected=selected,
+                availability=self._provider_availability_style(option),
+            )
+            availability = self._provider_availability_label(option)
             provider_name = self._provider_display_name(
                 option.provider.config_name,
                 option.provider.display_name,
@@ -286,8 +329,17 @@ class _SplitListPicker:
         for index, model in enumerate(models):
             selected = index == self.state.model_index
             cursor = "❯ " if self.state.focus == "models" and selected else "  "
-            line_style = self._row_style(selected=selected, available=provider_available)
-            marker = "✓" if provider_available else "✗"
+            line_style = self._row_style(
+                selected=selected,
+                availability=(
+                    "active"
+                    if provider_available
+                    else "attention"
+                    if model.activation_action is not None
+                    else "inactive"
+                ),
+            )
+            marker = "✓" if provider_available else "!" if model.activation_action else "✗"
             fragments.append((line_style, f"{cursor}{marker} {model.label}\n"))
 
         return fragments
@@ -299,10 +351,12 @@ class _SplitListPicker:
             provider.provider.display_name,
         )
         scope = "curated" if self.state.source == "curated" else "all catalog"
-        status = "available" if provider.active else "not configured"
+        status = self._provider_availability_label(provider)
         warning = ""
         if self._provider_requires_docs_only():
             warning = " · see docs"
+        elif self._provider_activation_action(provider) is not None:
+            warning = " · press Enter to log in"
 
         models = self.current_models
         model_count = len(models)
@@ -319,7 +373,7 @@ class _SplitListPicker:
             ),
             (
                 "class:muted",
-                "Keys: ←/→ focus · ↑/↓ move · Tab swap · c scope · Enter select · q quit",
+                "Keys: ←/→ focus · ↑/↓ move · Tab swap · c scope · Enter select/log in · q quit",
             ),
         ]
 
@@ -369,6 +423,20 @@ class _SplitListPicker:
                 return
 
             provider = self.current_provider
+            if selected_model.activation_action is not None:
+                event.app.exit(
+                    result=ModelPickerResult(
+                        provider=provider.provider.config_name,
+                        provider_available=provider.active,
+                        selected_model=selected_model.spec,
+                        resolved_model=None,
+                        source=self.state.source,
+                        refer_to_docs=False,
+                        activation_action=selected_model.activation_action,
+                    )
+                )
+                return
+
             if (
                 provider.provider.config_name == "generic"
                 and selected_model.spec == GENERIC_CUSTOM_MODEL_SENTINEL
@@ -381,6 +449,7 @@ class _SplitListPicker:
                         resolved_model=None,
                         source=self.state.source,
                         refer_to_docs=False,
+                        activation_action=None,
                     )
                 )
                 return
@@ -394,6 +463,7 @@ class _SplitListPicker:
                         resolved_model=None,
                         source=self.state.source,
                         refer_to_docs=True,
+                        activation_action=None,
                     )
                 )
                 return
@@ -406,6 +476,7 @@ class _SplitListPicker:
                     resolved_model=selected_model.spec,
                     source=self.state.source,
                     refer_to_docs=False,
+                    activation_action=None,
                 )
             )
 
@@ -434,13 +505,21 @@ class _SplitListPicker:
         return None
 
 
-def run_model_picker(*, config_path: Path | None = None) -> ModelPickerResult | None:
+def run_model_picker(
+    *,
+    config_path: Path | None = None,
+    initial_provider: str | None = None,
+) -> ModelPickerResult | None:
     """Run the interactive model picker and return the selected model configuration."""
-    picker = _SplitListPicker(config_path=config_path)
+    picker = _SplitListPicker(config_path=config_path, initial_provider=initial_provider)
     return picker.run()
 
 
-async def run_model_picker_async(*, config_path: Path | None = None) -> ModelPickerResult | None:
+async def run_model_picker_async(
+    *,
+    config_path: Path | None = None,
+    initial_provider: str | None = None,
+) -> ModelPickerResult | None:
     """Run the interactive model picker from within an active asyncio event loop."""
-    picker = _SplitListPicker(config_path=config_path)
+    picker = _SplitListPicker(config_path=config_path, initial_provider=initial_provider)
     return await picker.run_async()

--- a/src/fast_agent/ui/model_picker_common.py
+++ b/src/fast_agent/ui/model_picker_common.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 ModelSource = Literal["curated", "all"]
+ProviderActivationAction = Literal["codex-login"]
 KEEP_VALUE = "__keep__"
 DEFAULT_VALUE = "__default__"
 
@@ -44,6 +45,7 @@ REFER_TO_DOCS_PROVIDERS: tuple[Provider, ...] = (
 )
 
 GENERIC_CUSTOM_MODEL_SENTINEL = "generic.__custom__"
+CODEX_LOGIN_SENTINEL = "codexresponses.__login__"
 
 
 @dataclass(frozen=True)
@@ -60,6 +62,7 @@ class ModelOption:
     alias: str | None = None
     fast: bool = False
     curated: bool = False
+    activation_action: ProviderActivationAction | None = None
 
 
 @dataclass(frozen=True)
@@ -165,6 +168,16 @@ def active_provider_names(snapshot: ModelPickerSnapshot) -> list[str]:
     return [option.provider.display_name for option in snapshot.providers if option.active]
 
 
+def provider_activation_action(
+    snapshot: ModelPickerSnapshot,
+    provider: Provider,
+) -> ProviderActivationAction | None:
+    option = find_provider(snapshot, provider.config_name)
+    if provider == Provider.CODEX_RESPONSES and not option.active:
+        return "codex-login"
+    return None
+
+
 def _model_identity(model_spec: str) -> tuple[Provider, str] | None:
     try:
         parsed = ModelFactory.parse_model_string(model_spec)
@@ -205,6 +218,15 @@ def model_options_for_provider(
         ]
 
     provider_option = find_provider(snapshot, provider.config_name)
+    activation_action = provider_activation_action(snapshot, provider)
+    if activation_action is not None:
+        return [
+            ModelOption(
+                spec=CODEX_LOGIN_SENTINEL,
+                label="Log in to enable Codex (Plan)",
+                activation_action=activation_action,
+            )
+        ]
 
     curated_options: list[ModelOption] = []
     for entry in provider_option.curated_entries:

--- a/tests/unit/fast_agent/ui/test_model_picker.py
+++ b/tests/unit/fast_agent/ui/test_model_picker.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from fast_agent.llm.model_selection import CatalogModelEntry
+from fast_agent.llm.provider_types import Provider
 from fast_agent.ui.model_picker import _SplitListPicker
+from fast_agent.ui.model_picker_common import (
+    ModelOption,
+    ModelPickerSnapshot,
+    ProviderOption,
+    model_options_for_provider,
+    provider_activation_action,
+)
 
 
 def test_models_window_vertical_scroll_tracks_picker_scroll_state() -> None:
@@ -39,3 +48,57 @@ def test_models_window_vertical_scroll_tracks_picker_scroll_state() -> None:
 
 def test_provider_display_name_uses_local_generic_label() -> None:
     assert _SplitListPicker._provider_display_name("generic", "Generic") == "Local (Generic)"
+
+
+def test_codex_inactive_provider_uses_activation_option() -> None:
+    snapshot = ModelPickerSnapshot(
+        providers=(
+            ProviderOption(
+                provider=Provider.CODEX_RESPONSES,
+                active=False,
+                curated_entries=(
+                    CatalogModelEntry(alias="codexplan", model="codexresponses.o4-mini"),
+                ),
+            ),
+        ),
+        config_payload={},
+    )
+
+    assert provider_activation_action(snapshot, Provider.CODEX_RESPONSES) == "codex-login"
+
+    options = model_options_for_provider(
+        snapshot,
+        Provider.CODEX_RESPONSES,
+        source="curated",
+    )
+
+    assert options == [
+        ModelOption(
+            spec="codexresponses.__login__",
+            label="Log in to enable Codex (Plan)",
+            activation_action="codex-login",
+        )
+    ]
+
+
+def test_codex_inactive_provider_is_shown_as_sign_in_required() -> None:
+    picker = _SplitListPicker(config_path=None, initial_provider="codexresponses")
+    picker.snapshot = ModelPickerSnapshot(
+        providers=(
+            ProviderOption(
+                provider=Provider.CODEX_RESPONSES,
+                active=False,
+                curated_entries=(
+                    CatalogModelEntry(alias="codexplan", model="codexresponses.o4-mini"),
+                ),
+            ),
+        ),
+        config_payload={},
+    )
+    picker.state.provider_index = 0
+    picker.state.model_index = 0
+
+    provider = picker.current_provider
+    assert picker._provider_availability_label(provider) == "sign in required"
+    status_line = picker._render_status_bar()[0][1]
+    assert "press Enter to log in" in status_line


### PR DESCRIPTION
## Summary
- show inactive Codex (Plan) entries in yellow and label them as sign-in required
- let the picker trigger the Codex OAuth flow directly, then reopen on Codex so users can immediately pick a model
- ensure the Codex OAuth console switches to a blocking TTY before printing the auth URL from the interactive picker flow

## Testing
- `uv run pytest tests/unit/fast_agent/ui/test_model_picker.py tests/unit/fast_agent/llm/test_model_factory.py`
- `uv run pytest tests/unit/fast_agent/ui`
- `uv run scripts/lint.py --fix`
- `uv run scripts/typecheck.py`
- `uv run scripts/cpd.py --check` *(fails on a pre-existing duplication in `src/fast_agent/resources/examples/mcp/elicitations/elicitation_game_server.py`)*

## PR question
You're given a calfskin wallet for your birthday. How would you feel about using it?

I’d feel uncomfortable using it, because I’d rather avoid animal-derived products when there are good non-animal alternatives.
