### PR TITLE
Support local Codex auth.json override

### DIFF
--- a/docs-internal/CODEX_OAUTH.md
+++ b/docs-internal/CODEX_OAUTH.md
@@ -1,0 +1,24 @@
+# Codex OAuth Runtime Notes
+
+Use this note for operational/runtime details that should not live in the public README.
+
+## Auth file lookup
+
+- Default fallback path for Codex CLI tokens is `~/.codex/auth.json`.
+- `CODEX_AUTH_JSON_PATH` overrides the fallback path with an explicit file.
+- `CODEX_HOME` is also supported; when set, the fallback file becomes `${CODEX_HOME}/auth.json`.
+
+## Precedence
+
+- Without an override, Fast Agent keeps the existing precedence: keyring first, then `~/.codex/auth.json`.
+- When `CODEX_AUTH_JSON_PATH` or `CODEX_HOME` is set, Fast Agent prefers the overridden auth file before keyring so a service can be pinned to a local profile.
+
+## Persistence
+
+- When an override path is active, refreshed Codex OAuth tokens are written back into the overridden auth file.
+- This keeps long-running service profiles stable across restarts without depending on the global `~/.codex/auth.json`.
+
+## Intended use
+
+- Prefer `CODEX_AUTH_JSON_PATH` for service runtimes that need a repo-local or deployment-local Codex profile.
+- Prefer the environment variable over adding more CLI flags to `fast-agent serve`.

--- a/src/fast_agent/llm/provider/openai/codex_oauth.py
+++ b/src/fast_agent/llm/provider/openai/codex_oauth.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 import secrets
 import time
 from dataclasses import dataclass
@@ -55,9 +56,6 @@ CODEX_TOKEN_KEY = f"oauth:tokens:{CODEX_KEYRING_IDENTITY}"
 CODEX_TOKEN_META_KEY = f"{CODEX_TOKEN_KEY}:meta"
 CODEX_TOKEN_CHUNK_PREFIX = f"{CODEX_TOKEN_KEY}:chunk"
 CODEX_KEYRING_MAX_PAYLOAD_BYTES = 512
-CODEX_CLI_AUTH_PATH = Path("/root/.codex/auth.json")
-
-
 class CodexOAuthTokens(BaseModel):
     access_token: str
     refresh_token: str | None = None
@@ -224,6 +222,24 @@ def _chunk_key(index: int) -> str:
     return f"{CODEX_TOKEN_CHUNK_PREFIX}:{index}"
 
 
+def _default_codex_cli_auth_path() -> Path:
+    return Path.home() / ".codex" / "auth.json"
+
+
+def _resolve_codex_cli_auth_path() -> Path:
+    explicit = str(os.environ.get("CODEX_AUTH_JSON_PATH") or "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    codex_home = str(os.environ.get("CODEX_HOME") or "").strip()
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json"
+    return _default_codex_cli_auth_path()
+
+
+def _prefer_codex_cli_auth_path() -> bool:
+    return _resolve_codex_cli_auth_path() != _default_codex_cli_auth_path()
+
+
 def _safe_delete(keyring_module: _KeyringProtocol, username: str) -> None:
     try:
         keyring_module.delete_password(CODEX_KEYRING_SERVICE, username)
@@ -384,13 +400,14 @@ def _normalize_codex_cli_payload(payload: dict[str, Any]) -> dict[str, Any] | No
 
 
 def _load_codex_cli_tokens() -> CodexOAuthTokens | None:
+    auth_path = _resolve_codex_cli_auth_path()
     try:
-        if not CODEX_CLI_AUTH_PATH.exists():
+        if not auth_path.exists():
             return None
     except OSError:
         return None
     try:
-        payload = json.loads(CODEX_CLI_AUTH_PATH.read_text())
+        payload = json.loads(auth_path.read_text())
     except Exception:
         return None
     if not isinstance(payload, dict):
@@ -411,7 +428,41 @@ def _load_codex_cli_tokens() -> CodexOAuthTokens | None:
     return None
 
 
+def _save_codex_cli_tokens(tokens: CodexOAuthTokens) -> None:
+    auth_path = _resolve_codex_cli_auth_path()
+    payload: dict[str, Any] = {}
+    try:
+        if auth_path.exists():
+            existing = json.loads(auth_path.read_text())
+            if isinstance(existing, dict):
+                payload = existing
+    except Exception:
+        payload = {}
+
+    payload["auth_mode"] = payload.get("auth_mode") or "oauth"
+    payload["tokens"] = {
+        "access_token": tokens.access_token,
+        "refresh_token": tokens.refresh_token,
+        "expires_at": tokens.expires_at,
+        "scope": tokens.scope,
+        "token_type": tokens.token_type,
+    }
+    payload["last_refresh"] = int(time.time() * 1000)
+
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        auth_path.chmod(0o600)
+    except Exception:
+        pass
+
+
 def _load_codex_tokens_with_source() -> tuple[CodexOAuthTokens | None, str | None]:
+    if _prefer_codex_cli_auth_path():
+        tokens = _load_codex_cli_tokens()
+        if tokens:
+            return tokens, "auth.json"
+
     payload = _get_keyring_password()
     if payload:
         try:
@@ -431,12 +482,15 @@ def load_codex_tokens() -> CodexOAuthTokens | None:
         logger.info(
             "codex_cli_tokens",
             "Loaded Codex OAuth tokens from auth.json",
-            data={"path": str(CODEX_CLI_AUTH_PATH)},
+            data={"path": str(_resolve_codex_cli_auth_path())},
         )
     return tokens
 
 
 def save_codex_tokens(tokens: CodexOAuthTokens) -> None:
+    if _prefer_codex_cli_auth_path():
+        _save_codex_cli_tokens(tokens)
+        return
     _set_keyring_password(tokens.model_dump_json())
 
 

--- a/tests/unit/fast_agent/llm/providers/test_codex_oauth.py
+++ b/tests/unit/fast_agent/llm/providers/test_codex_oauth.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+from fast_agent.llm.provider.openai import codex_oauth
+from fast_agent.llm.provider.openai.codex_oauth import CodexOAuthTokens
+
+
+def test_resolve_codex_cli_auth_path_defaults_to_user_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("CODEX_AUTH_JSON_PATH", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setattr(codex_oauth.Path, "home", lambda: tmp_path)
+
+    assert codex_oauth._resolve_codex_cli_auth_path() == tmp_path / ".codex" / "auth.json"
+
+
+def test_explicit_auth_json_path_overrides_keyring(monkeypatch, tmp_path: Path) -> None:
+    auth_path = tmp_path / "local-auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "auth_mode": "oauth",
+                "tokens": {
+                    "access_token": "local-token",
+                    "refresh_token": "local-refresh",
+                    "token_type": "Bearer",
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("CODEX_AUTH_JSON_PATH", str(auth_path))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setattr(
+        codex_oauth,
+        "_get_keyring_password",
+        lambda: json.dumps({"access_token": "keyring-token", "token_type": "Bearer"}),
+    )
+
+    tokens, source = codex_oauth._load_codex_tokens_with_source()
+
+    assert source == "auth.json"
+    assert tokens is not None
+    assert tokens.access_token == "local-token"
+
+
+def test_save_codex_tokens_writes_local_auth_file_without_keyring(monkeypatch, tmp_path: Path) -> None:
+    auth_path = tmp_path / ".codex" / "auth.json"
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps({"OPENAI_API_KEY": "preserve-me"}))
+    monkeypatch.setenv("CODEX_AUTH_JSON_PATH", str(auth_path))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+
+    def _unexpected_keyring_write(_: str) -> None:
+        raise AssertionError("keyring should not be used when CODEX_AUTH_JSON_PATH is set")
+
+    monkeypatch.setattr(codex_oauth, "_set_keyring_password", _unexpected_keyring_write)
+
+    codex_oauth.save_codex_tokens(
+        CodexOAuthTokens(
+            access_token="saved-token",
+            refresh_token="saved-refresh",
+            expires_at=1234.5,
+            scope="openid profile",
+            token_type="Bearer",
+        )
+    )
+
+    payload = json.loads(auth_path.read_text())
+    assert payload["OPENAI_API_KEY"] == "preserve-me"
+    assert payload["tokens"]["access_token"] == "saved-token"
+    assert payload["tokens"]["refresh_token"] == "saved-refresh"
+    assert payload["tokens"]["expires_at"] == 1234.5
+    assert payload["tokens"]["scope"] == "openid profile"


### PR DESCRIPTION
## Summary
- default Codex CLI auth fallback now resolves to `~/.codex/auth.json` instead of `/root/.codex/auth.json`
- add `CODEX_AUTH_JSON_PATH` and `CODEX_HOME` support for service-local auth file overrides
- when an override path is active, prefer that auth file before keyring and write refreshed tokens back to the same file
- document the operator-facing runtime behavior in `docs-internal/CODEX_OAUTH.md`
- add unit coverage for default path resolution, override precedence, and local file persistence

## Why
Service runtimes sometimes need to pin Codex OAuth to a repo-local or deployment-local profile without depending on the host-global `~/.codex/auth.json`. An env var is enough here; this does not need another CLI flag.

## Validation
- `uv run pytest -q tests/unit/fast_agent/llm/providers/test_codex_oauth.py tests/unit/fast_agent/llm/test_model_factory.py`
