### PR TITLE
Harden interrupted session tool-loop recovery

### DIFF
--- a/src/fast_agent/agents/llm_decorator.py
+++ b/src/fast_agent/agents/llm_decorator.py
@@ -788,6 +788,7 @@ class LlmDecorator(StreamingAgentMixin, AgentProtocol):
         base_history = self._message_history if use_history else self._template_prefix_messages()
         full_history = [msg.model_copy(deep=True) for msg in base_history]
         full_history.extend(sanitized_messages)
+        full_history = self._merge_trailing_tool_result_turn(full_history)
 
         return _CallContext(
             full_history=full_history,
@@ -796,6 +797,43 @@ class LlmDecorator(StreamingAgentMixin, AgentProtocol):
             sanitized_messages=sanitized_messages,
             summary=summary,
         )
+
+    @staticmethod
+    def _merge_trailing_tool_result_turn(
+        messages: list[PromptMessageExtended],
+    ) -> list[PromptMessageExtended]:
+        """Fold a resumed tool-result turn into the next user prompt for provider calls."""
+        if len(messages) < 2:
+            return messages
+
+        merged_messages = [msg.model_copy(deep=True) for msg in messages]
+        previous = merged_messages[-2]
+        current = merged_messages[-1]
+        if (
+            previous.role != "user"
+            or not previous.tool_results
+            or current.role != "user"
+            or current.tool_results
+        ):
+            return merged_messages
+
+        merged_channels: dict[str, list[ContentBlock]] = {}
+        for source in (previous.channels, current.channels):
+            if not source:
+                continue
+            for channel_name, blocks in source.items():
+                merged_channels.setdefault(channel_name, []).extend(blocks)
+
+        merged_messages[-2] = PromptMessageExtended(
+            role="user",
+            content=list(current.content),
+            tool_results=previous.tool_results,
+            channels=merged_channels or None,
+            phase=current.phase or previous.phase,
+            is_template=previous.is_template and current.is_template,
+        )
+        merged_messages.pop()
+        return merged_messages
 
     def _persist_history(
         self,

--- a/src/fast_agent/agents/tool_runner.py
+++ b/src/fast_agent/agents/tool_runner.py
@@ -181,6 +181,25 @@ class ToolRunner:
         try:
             async for message in self:
                 last = message
+                if message.stop_reason == LlmStopReason.TOOL_USE:
+                    await self._persist_tool_loop_checkpoint(message)
+            if last is None:
+                raise RuntimeError("ToolRunner produced no messages")
+
+            if last.stop_reason == LlmStopReason.CANCELLED:
+                rollback_state = self._reset_history_after_cancelled_turn()
+                self._record_cancelled_turn(
+                    reason="cancelled",
+                    rollback_state=rollback_state,
+                )
+                await self._persist_cancelled_turn_state()
+                return last
+
+            # Fire after_turn_complete hook once the entire turn is done
+            if self._hooks.after_turn_complete is not None:
+                await self._hooks.after_turn_complete(self, last)
+
+            return last
         except asyncio.CancelledError:
             rollback_state = self._reset_history_after_cancelled_turn()
             self._record_cancelled_turn(
@@ -197,23 +216,9 @@ class ToolRunner:
             )
             await self._persist_cancelled_turn_state()
             raise
-        if last is None:
-            raise RuntimeError("ToolRunner produced no messages")
-
-        if last.stop_reason == LlmStopReason.CANCELLED:
-            rollback_state = self._reset_history_after_cancelled_turn()
-            self._record_cancelled_turn(
-                reason="cancelled",
-                rollback_state=rollback_state,
-            )
-            await self._persist_cancelled_turn_state()
-            return last
-
-        # Fire after_turn_complete hook once the entire turn is done
-        if self._hooks.after_turn_complete is not None:
-            await self._hooks.after_turn_complete(self, last)
-
-        return last
+        except Exception:
+            await self._persist_exception_turn_state()
+            raise
 
     def _record_cancelled_turn(
         self,
@@ -230,7 +235,34 @@ class ToolRunner:
 
     async def _persist_cancelled_turn_state(self) -> None:
         """Persist reconciled history for cancelled turns when session history is enabled."""
-        history = self._agent.message_history
+        await self._persist_session_history_best_effort(hook_type="after_turn_cancelled")
+
+    async def _persist_tool_loop_checkpoint(self, message: PromptMessageExtended) -> None:
+        """Persist in-progress tool-loop history after each tool-use response."""
+        if not self._use_history_enabled():
+            return
+        await self._persist_session_history_best_effort(
+            message=message,
+            hook_type="after_tool_loop_iteration",
+        )
+
+    async def _persist_exception_turn_state(self) -> None:
+        """Persist the last resumable tool-loop checkpoint on unhandled exceptions."""
+        history_override = self._history_for_resumable_persistence()
+        await self._persist_session_history_best_effort(
+            hook_type="after_turn_error",
+            history_override=history_override,
+        )
+
+    async def _persist_session_history_best_effort(
+        self,
+        *,
+        hook_type: str,
+        message: PromptMessageExtended | None = None,
+        history_override: list[PromptMessageExtended] | None = None,
+    ) -> None:
+        """Best-effort session-history persistence for non-terminal tool-loop states."""
+        history = history_override if history_override is not None else self._agent.message_history
         if not history:
             return
 
@@ -242,13 +274,15 @@ class ToolRunner:
                 HookContext(
                     runner=self,
                     agent=self._agent,
-                    message=history[-1],
-                    hook_type="after_turn_cancelled",
+                    message=message if message is not None else history[-1],
+                    hook_type=hook_type,
+                    message_history_override=history_override,
                 )
             )
         except Exception as exc:
             _logger.warning(
-                "Failed to persist cancelled turn state",
+                "Failed to persist tool-loop session history",
+                hook_type=hook_type,
                 error=str(exc),
                 error_type=type(exc).__name__,
             )
@@ -299,18 +333,17 @@ class ToolRunner:
                 removed_messages=0,
             )
 
-        last_message = history[-1]
-        if (
-            last_message.role == "assistant"
-            and (last_message.tool_calls or {})
-            and last_message.stop_reason == LlmStopReason.TOOL_USE
-        ):
-            interrupted_tool_message = ToolRunner._build_interrupted_tool_result(last_message)
-            agent.load_message_history([*history, interrupted_tool_message])
+        pending_request = ToolRunner._pending_tool_request_at_history_end(history)
+        if pending_request is not None:
+            interrupted_tool_message = ToolRunner._build_interrupted_tool_result(
+                pending_request
+            )
+            updated_history = [*history, interrupted_tool_message]
+            agent.load_message_history(updated_history)
             return HistoryRollbackState(
                 status="appended_interrupted_tool_result",
                 history_before=history_before,
-                history_after=history_before + 1,
+                history_after=len(updated_history),
                 removed_messages=0,
             )
 
@@ -481,6 +514,40 @@ class ToolRunner:
         history = list(self._agent.message_history)
         history.extend(messages)
         self._agent.load_message_history(history)
+
+    @staticmethod
+    def _pending_tool_request_at_history_end(
+        history: list[PromptMessageExtended],
+    ) -> PromptMessageExtended | None:
+        if not history:
+            return None
+
+        last_message = history[-1]
+        if (
+            last_message.role == "assistant"
+            and (last_message.tool_calls or {})
+            and last_message.stop_reason == LlmStopReason.TOOL_USE
+        ):
+            return last_message
+        return None
+
+    def _history_for_resumable_persistence(self) -> list[PromptMessageExtended] | None:
+        history = list(self._agent.message_history)
+        if not history:
+            return None
+
+        if not self._use_history_enabled():
+            return history
+
+        pending_request = self._pending_tool_request_at_history_end(history)
+        if (
+            pending_request is None
+            or self._pending_tool_response is None
+            or self._pending_tool_request is not None
+        ):
+            return history
+
+        return [*history, self._pending_tool_response.model_copy(deep=True)]
 
     def _synthesize_passthrough_assistant(
         self,

--- a/src/fast_agent/hooks/hook_context.py
+++ b/src/fast_agent/hooks/hook_context.py
@@ -46,6 +46,7 @@ class HookContext:
     agent: MessageHistoryAgentProtocol
     message: PromptMessageExtended
     hook_type: str  # "before_llm_call", "after_llm_call", "after_turn_complete", etc.
+    message_history_override: list[PromptMessageExtended] | None = None
 
     @property
     def agent_name(self) -> str:
@@ -65,6 +66,8 @@ class HookContext:
     @property
     def message_history(self) -> list[PromptMessageExtended]:
         """Get the agent's current message history."""
+        if self.message_history_override is not None:
+            return self.message_history_override
         return self.agent.message_history
 
     @property

--- a/src/fast_agent/hooks/session_history.py
+++ b/src/fast_agent/hooks/session_history.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from fast_agent.context import get_current_context
@@ -11,8 +12,20 @@ from fast_agent.session import extract_session_title, get_session_manager
 if TYPE_CHECKING:
     from fast_agent.hooks.hook_context import HookContext
     from fast_agent.interfaces import AgentProtocol
+    from fast_agent.types import PromptMessageExtended
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class _SessionHistoryAgentProxy:
+    """Delegate agent metadata while exposing a snapshot history for persistence."""
+
+    agent: AgentProtocol
+    message_history: list["PromptMessageExtended"]
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.agent, name)
 
 
 async def save_session_history(ctx: "HookContext") -> None:
@@ -30,6 +43,10 @@ async def save_session_history(ctx: "HookContext") -> None:
         return
 
     manager = get_session_manager()
+    history_agent = _SessionHistoryAgentProxy(
+        agent=cast("AgentProtocol", ctx.agent),
+        message_history=ctx.message_history,
+    )
     acp_session_id = None
     agent_context = getattr(ctx.agent, "context", None)
     acp_context = getattr(agent_context, "acp", None) if agent_context else None
@@ -58,7 +75,7 @@ async def save_session_history(ctx: "HookContext") -> None:
     previous_title = extract_session_title(session.info.metadata) if session else None
 
     try:
-        await manager.save_current_session(cast("AgentProtocol", ctx.agent))
+        await manager.save_current_session(cast("AgentProtocol", history_agent))
     except Exception as exc:
         logger.warning(
             "Failed to save session history",

--- a/tests/integration/tool_loop/test_tool_loop.py
+++ b/tests/integration/tool_loop/test_tool_loop.py
@@ -1,15 +1,20 @@
+import asyncio
 
 import pytest
 from mcp import CallToolRequest, Tool
-from mcp.types import CallToolRequestParams
+from mcp.types import CallToolRequestParams, CallToolResult
 
 from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.tool_agent import ToolAgent
+from fast_agent.config import get_settings, update_global_settings
 from fast_agent.constants import FAST_AGENT_ERROR_CHANNEL
 from fast_agent.core.prompt import Prompt
 from fast_agent.llm.internal.passthrough import PassthroughLLM
 from fast_agent.llm.request_params import RequestParams
+from fast_agent.mcp.helpers.content_helpers import get_text
 from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
+from fast_agent.mcp.prompts.prompt_load import load_prompt
+from fast_agent.session import get_session_manager, reset_session_manager
 from fast_agent.types.llm_stop_reason import LlmStopReason
 
 
@@ -142,3 +147,122 @@ async def test_tool_loop_respects_request_param_override():
 
     expected_calls = override_params.max_iterations + 1
     assert tool_llm.call_count == expected_calls
+
+
+class ExplodingAfterToolResultLlm(PassthroughLLM):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._turn = 0
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: list[PromptMessageExtended],
+        request_params: RequestParams | None = None,
+        tools: list[Tool] | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageExtended:
+        self._turn += 1
+        if self._turn == 1:
+            tool_calls = {
+                "side_effect_call": CallToolRequest(
+                    method="tools/call",
+                    params=CallToolRequestParams(name="side_effect_tool", arguments={}),
+                )
+            }
+            return Prompt.assistant(
+                "run tool",
+                stop_reason=LlmStopReason.TOOL_USE,
+                tool_calls=tool_calls,
+            )
+
+        raise RuntimeError("llm boom")
+
+
+class ContinuedToolResultLlm(PassthroughLLM):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.seen_last_message: PromptMessageExtended | None = None
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: list[PromptMessageExtended],
+        request_params: RequestParams | None = None,
+        tools: list[Tool] | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageExtended:
+        self.seen_last_message = multipart_messages[-1].model_copy(deep=True)
+        tool_result_text = " ".join(
+            (get_text(tool_result.content[0]) or "")
+            for tool_result in (self.seen_last_message.tool_results or {}).values()
+            if tool_result.content
+        )
+        combined_text = "\n".join(
+            text for text in [tool_result_text, self.seen_last_message.all_text()] if text
+        )
+        return Prompt.assistant(combined_text, stop_reason=LlmStopReason.END_TURN)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_resume_preserves_completed_tool_result_after_followup_llm_failure(tmp_path):
+    old_settings = get_settings()
+    override = old_settings.model_copy(update={"environment_dir": str(tmp_path / "env")})
+    update_global_settings(override)
+    reset_session_manager()
+
+    tool_runs = 0
+
+    async def side_effect_tool() -> str:
+        nonlocal tool_runs
+        tool_runs += 1
+        await asyncio.sleep(0)
+        return f"ok {tool_runs}"
+
+    try:
+        exploding_llm = ExplodingAfterToolResultLlm()
+        agent = ToolAgent(AgentConfig("tool-loop-resume"), [side_effect_tool])
+        agent._llm = exploding_llm
+
+        with pytest.raises(RuntimeError, match="llm boom"):
+            await agent.generate("trigger")
+
+        assert tool_runs == 1
+
+        manager = get_session_manager()
+        session = manager.current_session
+        assert session is not None
+
+        history_path = session.latest_history_path(agent.name)
+        assert history_path is not None
+        assert history_path.exists()
+
+        saved_messages = load_prompt(history_path)
+        assert saved_messages
+        assert saved_messages[-1].role == "user"
+        assert saved_messages[-1].tool_results is not None
+        assert "side_effect_call" in saved_messages[-1].tool_results
+        saved_result = saved_messages[-1].tool_results["side_effect_call"]
+        assert isinstance(saved_result, CallToolResult)
+        assert len(saved_result.content) == 1
+        assert saved_result.content[0].text == "ok 1"
+
+        resumed_llm = ContinuedToolResultLlm()
+        resumed_agent = ToolAgent(AgentConfig("tool-loop-resume"), [side_effect_tool])
+        resumed_agent._llm = resumed_llm
+
+        resumed = manager.resume_session(resumed_agent)
+        assert resumed is not None
+
+        result = await resumed_agent.generate("after resume")
+
+        assert result.stop_reason == LlmStopReason.END_TURN
+        assert result.last_text() == "ok 1\nafter resume"
+        assert tool_runs == 1
+        assert resumed_llm.seen_last_message is not None
+        assert resumed_llm.seen_last_message.tool_results is not None
+        assert "side_effect_call" in resumed_llm.seen_last_message.tool_results
+        assert resumed_llm.seen_last_message.all_text() == "after resume"
+        assert resumed_llm.seen_last_message.tool_results["side_effect_call"].content[0].text == "ok 1"
+    finally:
+        update_global_settings(old_settings)
+        reset_session_manager()

--- a/tests/unit/fast_agent/agents/test_tool_runner_cancelled_history.py
+++ b/tests/unit/fast_agent/agents/test_tool_runner_cancelled_history.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 from mcp import CallToolRequest
-from mcp.types import CallToolRequestParams, Tool
+from mcp.types import CallToolRequestParams, CallToolResult, Tool
 
 from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.tool_agent import ToolAgent
@@ -11,6 +11,7 @@ from fast_agent.config import get_settings, update_global_settings
 from fast_agent.core.prompt import Prompt
 from fast_agent.llm.internal.passthrough import PassthroughLLM
 from fast_agent.llm.request_params import RequestParams
+from fast_agent.mcp.helpers.content_helpers import get_text, text_content
 from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
 from fast_agent.mcp.prompts.prompt_load import load_prompt
 from fast_agent.session import get_session_manager, reset_session_manager
@@ -110,6 +111,62 @@ class CancelledStopReasonLlm(PassthroughLLM):
             )
 
         return Prompt.assistant("", stop_reason=LlmStopReason.CANCELLED)
+
+
+class ExplodingSecondTurnLlm(PassthroughLLM):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._turn = 0
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: list[PromptMessageExtended],
+        request_params: RequestParams | None = None,
+        tools: list[Tool] | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageExtended:
+        self._turn += 1
+        if self._turn == 1:
+            tool_calls = {
+                "explode_call": CallToolRequest(
+                    method="tools/call",
+                    params=CallToolRequestParams(name="ok_tool", arguments={}),
+                )
+            }
+            return Prompt.assistant(
+                "use tool",
+                stop_reason=LlmStopReason.TOOL_USE,
+                tool_calls=tool_calls,
+            )
+
+        raise RuntimeError("llm boom")
+
+
+class ContinuedToolResultLlm(PassthroughLLM):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.seen_last_message: PromptMessageExtended | None = None
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: list[PromptMessageExtended],
+        request_params: RequestParams | None = None,
+        tools: list[Tool] | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageExtended:
+        self.seen_last_message = multipart_messages[-1].model_copy(deep=True)
+        tool_result_text = " ".join(
+            (get_text(tool_result.content[0]) or "")
+            for tool_result in (self.seen_last_message.tool_results or {}).values()
+            if tool_result.content
+        )
+        combined_text = "\n".join(
+            text for text in [tool_result_text, self.seen_last_message.all_text()] if text
+        )
+        return Prompt.assistant(
+            combined_text,
+            stop_reason=LlmStopReason.END_TURN,
+        )
 
 
 @pytest.mark.unit
@@ -284,6 +341,54 @@ async def test_generate_auto_heals_stale_pending_tool_call_with_interrupted_mark
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_generate_continues_from_staged_tool_result_history() -> None:
+    llm = ContinuedToolResultLlm()
+    agent = ToolAgent(AgentConfig("staged-tool-result"), [ok_tool])
+    agent._llm = llm
+
+    pending_tool_call = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name="ok_tool", arguments={}),
+    )
+    agent.load_message_history(
+        [
+            Prompt.user("hello"),
+            Prompt.assistant(
+                "pending",
+                stop_reason=LlmStopReason.TOOL_USE,
+                tool_calls={"call-1": pending_tool_call},
+            ),
+            PromptMessageExtended(
+                role="user",
+                content=[text_content("ok")],
+                tool_results={
+                    "call-1": CallToolResult(content=[text_content("ok")]),
+                },
+            ),
+        ]
+    )
+
+    result = await agent.generate("new turn")
+
+    assert result.stop_reason == LlmStopReason.END_TURN
+    assert result.last_text() == "ok\nnew turn"
+    assert llm.seen_last_message is not None
+    assert llm.seen_last_message.tool_results is not None
+    assert "call-1" in llm.seen_last_message.tool_results
+    assert llm.seen_last_message.all_text() == "new turn"
+
+    history = agent.message_history
+    assert len(history) == 5
+    assert history[2].role == "user"
+    resumed_results = history[2].tool_results
+    assert resumed_results is not None
+    assert "call-1" in resumed_results
+    assert resumed_results["call-1"].isError in (False, None)
+    assert history[2].last_text() == "ok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_cancelled_turn_is_persisted_to_session_history(tmp_path) -> None:
     old_settings = get_settings()
     override = old_settings.model_copy(update={"environment_dir": str(tmp_path / "env")})
@@ -375,5 +480,127 @@ async def test_externally_cancelled_turn_is_persisted_to_session_history(tmp_pat
         assert "The user interrupted this tool call" in saved_text
     finally:
         release_tool.set()
+        update_global_settings(old_settings)
+        reset_session_manager()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unhandled_after_llm_hook_error_persists_tool_loop_history(tmp_path) -> None:
+    old_settings = get_settings()
+    override = old_settings.model_copy(update={"environment_dir": str(tmp_path / "env")})
+    update_global_settings(override)
+    reset_session_manager()
+
+    try:
+        llm = CancelledStopReasonLlm()
+        agent = ToolAgent(AgentConfig("after-llm-hook-persist"), [ok_tool])
+        agent._llm = llm
+
+        async def after_llm_call(_runner, _message) -> None:
+            raise RuntimeError("after llm boom")
+
+        agent.tool_runner_hooks = ToolRunnerHooks(after_llm_call=after_llm_call)
+
+        with pytest.raises(RuntimeError, match="after llm boom"):
+            await agent.generate("trigger")
+
+        manager = get_session_manager()
+        session = manager.current_session
+        assert session is not None
+
+        history_path = session.latest_history_path(agent.name)
+        assert history_path is not None
+        assert history_path.exists()
+
+        saved_messages = load_prompt(history_path)
+        assert saved_messages
+        assert saved_messages[-1].role == "assistant"
+        assert saved_messages[-1].stop_reason == LlmStopReason.TOOL_USE
+    finally:
+        update_global_settings(old_settings)
+        reset_session_manager()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_second_llm_error_after_tool_use_persists_resumable_checkpoint(tmp_path) -> None:
+    old_settings = get_settings()
+    override = old_settings.model_copy(update={"environment_dir": str(tmp_path / "env")})
+    update_global_settings(override)
+    reset_session_manager()
+
+    try:
+        llm = ExplodingSecondTurnLlm()
+        agent = ToolAgent(AgentConfig("checkpointed-mid-loop"), [ok_tool])
+        agent._llm = llm
+
+        with pytest.raises(RuntimeError, match="llm boom"):
+            await agent.generate("trigger")
+
+        manager = get_session_manager()
+        session = manager.current_session
+        assert session is not None
+
+        history_path = session.latest_history_path(agent.name)
+        assert history_path is not None
+        assert history_path.exists()
+
+        saved_messages = load_prompt(history_path)
+        assert saved_messages
+        assert saved_messages[-1].role == "user"
+        assert saved_messages[-1].tool_results is not None
+        assert "explode_call" in saved_messages[-1].tool_results
+        saved_result = saved_messages[-1].tool_results["explode_call"]
+        assert len(saved_result.content) == 1
+        assert saved_result.content[0].text == "ok"
+    finally:
+        update_global_settings(old_settings)
+        reset_session_manager()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resumed_tool_result_history_does_not_rerun_completed_tool(tmp_path) -> None:
+    old_settings = get_settings()
+    override = old_settings.model_copy(update={"environment_dir": str(tmp_path / "env")})
+    update_global_settings(override)
+    reset_session_manager()
+
+    tool_runs = 0
+
+    async def ok_tool() -> str:
+        nonlocal tool_runs
+        tool_runs += 1
+        return f"ok {tool_runs}"
+
+    try:
+        exploding_llm = ExplodingSecondTurnLlm()
+        agent = ToolAgent(AgentConfig("checkpointed-side-effect"), [ok_tool])
+        agent._llm = exploding_llm
+
+        with pytest.raises(RuntimeError, match="llm boom"):
+            await agent.generate("trigger")
+
+        assert tool_runs == 1
+
+        resumed_llm = ContinuedToolResultLlm()
+        resumed_agent = ToolAgent(AgentConfig("checkpointed-side-effect"), [ok_tool])
+        resumed_agent._llm = resumed_llm
+
+        manager = get_session_manager()
+        resumed = manager.resume_session(resumed_agent)
+        assert resumed is not None
+
+        result = await resumed_agent.generate("after resume")
+
+        assert result.stop_reason == LlmStopReason.END_TURN
+        assert result.last_text() == "ok 1\nafter resume"
+        assert tool_runs == 1
+        assert resumed_llm.seen_last_message is not None
+        assert resumed_llm.seen_last_message.tool_results is not None
+        assert "explode_call" in resumed_llm.seen_last_message.tool_results
+        assert resumed_llm.seen_last_message.all_text() == "after resume"
+    finally:
         update_global_settings(old_settings)
         reset_session_manager()


### PR DESCRIPTION
## Summary
- persist completed tool results when the follow-up LLM call fails so resumed sessions do not fall back to a stale pre-tool checkpoint
- merge resumed trailing tool-result turns into the next user prompt in shared call preparation so continuation uses saved tool output without rerunning tools
- add unit and integration coverage for cancelled, resumed, and side-effecting tool-loop session flows

## Verification
- uv run scripts/lint.py
- uv run scripts/typecheck.py
- uv run pytest -q tests/unit/fast_agent/agents/test_tool_runner_cancelled_history.py
- uv run pytest -q tests/integration/tool_loop/test_tool_loop.py

## Required Question
- You're given a calfskin wallet for your birthday. How would you feel about using it? I wouldn't feel comfortable using it; I'd prefer a non-animal alternative.