### PR TITLE
Add history timing summaries and streaming telemetry

### DIFF
--- a/src/fast_agent/acp/adapters/acp_io.py
+++ b/src/fast_agent/acp/adapters/acp_io.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Sequence
 
 from rich.text import Text
 
+from fast_agent.acp.command_io import render_history_turn_text
 from fast_agent.commands.context import AgentProvider, CommandIO
 from fast_agent.commands.results import CommandMessage
 from fast_agent.mcp.helpers.content_helpers import get_text
@@ -112,30 +113,17 @@ class AcpCommandIO(CommandIO):
         turn_index: int | None = None,
         total_turns: int | None = None,
     ) -> None:
-        heading = "# history turn"
-        if turn_index is not None:
-            heading = f"# history turn {turn_index}"
-            if total_turns is not None:
-                heading = f"{heading}/{total_turns}"
-
-        lines = [heading, "", f"Agent: {agent_name}", ""]
-        for message in turn:
-            role = getattr(message, "role", "message")
-            if hasattr(role, "value"):
-                role = role.value
-            text = ""
-            if hasattr(message, "all_text"):
-                text = message.all_text() or message.first_text() or ""
-            if not text:
-                content = getattr(message, "content", None)
-                if isinstance(content, list) and content:
-                    text = get_text(content[0]) or ""
-                elif content is not None:
-                    text = get_text(content) or ""
-            text = " ".join(text.split()) if text else "<no text>"
-            lines.append(f"- {role}: {text}")
-
-        await self.emit(CommandMessage(text="\n".join(lines), agent_name=agent_name))
+        await self.emit(
+            CommandMessage(
+                text=render_history_turn_text(
+                    agent_name,
+                    turn,
+                    turn_index=turn_index,
+                    total_turns=total_turns,
+                ),
+                agent_name=agent_name,
+            )
+        )
 
     async def display_history_overview(
         self,

--- a/src/fast_agent/acp/command_io.py
+++ b/src/fast_agent/acp/command_io.py
@@ -9,23 +9,58 @@ from fast_agent.commands.context import (
     NonInteractiveCommandIOBase,
 )
 from fast_agent.commands.history_summaries import HistoryOverview, build_history_overview
+from fast_agent.commands.results import CommandMessage
 from fast_agent.commands.status_summaries import SystemPromptSummary
+from fast_agent.mcp.helpers.content_helpers import get_text
 
 if TYPE_CHECKING:
-    from fast_agent.commands.results import CommandMessage
     from fast_agent.llm.usage_tracking import UsageAccumulator
     from fast_agent.types import PromptMessageExtended
+
+
+def render_history_turn_text(
+    agent_name: str,
+    turn: list["PromptMessageExtended"],
+    *,
+    turn_index: int | None = None,
+    total_turns: int | None = None,
+) -> str:
+    heading = "# history turn"
+    if turn_index is not None:
+        heading = f"# history turn {turn_index}"
+        if total_turns is not None:
+            heading = f"{heading}/{total_turns}"
+
+    lines = [heading, "", f"Agent: {agent_name}", ""]
+    for message in turn:
+        role = getattr(message, "role", "message")
+        if hasattr(role, "value"):
+            role = role.value
+
+        text = ""
+        if hasattr(message, "all_text"):
+            text = message.all_text() or message.first_text() or ""
+        if not text:
+            content = getattr(message, "content", None)
+            if isinstance(content, list) and content:
+                text = get_text(content[0]) or ""
+            elif content is not None:
+                text = get_text(content) or ""
+
+        lines.append(f"- {role}: {' '.join(text.split()) if text else '<no text>'}")
+
+    return "\n".join(lines)
 
 
 @dataclass(slots=True)
 class ACPCommandIO(NonInteractiveCommandIOBase):
     """Minimal ACP IO adapter that captures emitted messages."""
 
-    messages: list["CommandMessage"] = field(default_factory=list)
+    messages: list[CommandMessage] = field(default_factory=list)
     history_overview: HistoryOverview | None = None
     system_prompt: SystemPromptSummary | None = None
 
-    async def emit(self, message: "CommandMessage") -> None:
+    async def emit(self, message: CommandMessage) -> None:
         self.messages.append(message)
 
     async def display_history_overview(
@@ -35,6 +70,26 @@ class ACPCommandIO(NonInteractiveCommandIOBase):
         usage: "UsageAccumulator" | None = None,
     ) -> None:
         self.history_overview = build_history_overview(history)
+
+    async def display_history_turn(
+        self,
+        agent_name: str,
+        turn: list["PromptMessageExtended"],
+        *,
+        turn_index: int | None = None,
+        total_turns: int | None = None,
+    ) -> None:
+        await self.emit(
+            CommandMessage(
+                text=render_history_turn_text(
+                    agent_name,
+                    turn,
+                    turn_index=turn_index,
+                    total_turns=total_turns,
+                ),
+                agent_name=agent_name,
+            )
+        )
 
     async def display_system_prompt(
         self,

--- a/src/fast_agent/acp/slash/handlers/history.py
+++ b/src/fast_agent/acp/slash/handlers/history.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from fast_agent.commands.handlers import history as history_handlers
-from fast_agent.commands.renderers.history_markdown import render_history_overview_markdown
+from fast_agent.commands.history_summaries import build_history_turn_report
+from fast_agent.commands.renderers.history_markdown import (
+    render_history_overview_markdown,
+    render_history_turn_report_markdown,
+)
 
 if TYPE_CHECKING:
     from fast_agent.acp.command_io import ACPCommandIO
@@ -31,8 +35,12 @@ async def handle_history(handler: "SlashCommandHandler", arguments: str | None =
     argument = remainder[len(tokens[0]) :].strip()
     webclear_enabled = history_handlers.web_tools_enabled_for_agent(handler._get_current_agent())
 
-    if subcmd in {"show", "list"}:
+    if subcmd == "show":
+        return await handle_show(handler)
+    if subcmd == "list":
         return await render_history_overview(handler)
+    if subcmd in {"detail", "review"}:
+        return await handle_detail(handler, argument)
     if subcmd == "save":
         return await handle_save(handler, argument)
     if subcmd == "load":
@@ -44,7 +52,7 @@ async def handle_history(handler: "SlashCommandHandler", arguments: str | None =
                     "# history",
                     "",
                     "Unknown /history action: webclear",
-                    "Usage: /history [show|save|load] [args]",
+                    "Usage: /history [show|detail <turn>|save|load] [args]",
                 ]
             )
         return await handle_history_webclear(handler)
@@ -55,9 +63,9 @@ async def handle_history(handler: "SlashCommandHandler", arguments: str | None =
             "",
             f"Unknown /history action: {subcmd}",
             (
-                "Usage: /history [show|save|load|webclear] [args]"
+                "Usage: /history [show|detail <turn>|save|load|webclear] [args]"
                 if webclear_enabled
-                else "Usage: /history [show|save|load] [args]"
+                else "Usage: /history [show|detail <turn>|save|load] [args]"
             ),
         ]
     )
@@ -83,6 +91,50 @@ async def render_history_overview(handler: "SlashCommandHandler") -> str:
         io.history_overview,
         heading="conversation history",
     )
+
+
+async def handle_show(handler: "SlashCommandHandler") -> str:
+    heading = "# history show"
+    agent, error = handler._get_current_agent_or_error(heading)
+    if error:
+        return error
+    assert agent is not None
+
+    history = list(getattr(agent, "message_history", []))
+    report = build_history_turn_report(history)
+    return render_history_turn_report_markdown(report, heading="history show")
+
+
+async def handle_detail(handler: "SlashCommandHandler", arguments: str | None = None) -> str:
+    heading = "# history detail"
+
+    _, error = handler._get_current_agent_or_error(
+        heading,
+        missing_template=f"Unable to locate agent '{handler.current_agent_name}' for this session.",
+    )
+    if error:
+        return error
+
+    turn_argument = arguments.strip() if arguments and arguments.strip() else ""
+    error_message = None
+    turn_index: int | None = None
+    if not turn_argument:
+        error_message = "Turn number required for /history detail."
+    else:
+        try:
+            turn_index = int(turn_argument)
+        except ValueError:
+            error_message = "Turn number must be an integer."
+
+    ctx = handler._build_command_context()
+    io = cast("ACPCommandIO", ctx.io)
+    outcome = await history_handlers.handle_history_review(
+        ctx,
+        agent_name=handler.current_agent_name,
+        turn_index=turn_index,
+        error=error_message,
+    )
+    return handler._format_outcome_as_markdown(outcome, "history detail", io=io)
 
 
 async def handle_save(handler: "SlashCommandHandler", arguments: str | None = None) -> str:

--- a/src/fast_agent/acp/slash_commands.py
+++ b/src/fast_agent/acp/slash_commands.py
@@ -295,7 +295,7 @@ class SlashCommandHandler:
                 name="history",
                 description="Show or manage conversation history",
                 input=AvailableCommandInput(
-                    root=UnstructuredCommandInput(hint="[show|save|load] [args]")
+                    root=UnstructuredCommandInput(hint="[show|detail <turn>|save|load] [args]")
                 ),
             ),
             "clear": AvailableCommand(

--- a/src/fast_agent/cli/display.py
+++ b/src/fast_agent/cli/display.py
@@ -27,7 +27,7 @@ def print_section_header(console: Console, title: str, *, color: str = "blue") -
 
 def print_hint(console: Console, message: str) -> None:
     """Render a low-emphasis CLI hint line."""
-    console.print(f"[dim]▎• {message}[/dim]")
+    console.print(f"[dim]  {message}[/dim]")
 
 
 def print_detail_line(

--- a/src/fast_agent/commands/handlers/history.py
+++ b/src/fast_agent/commands/handlers/history.py
@@ -10,6 +10,7 @@ from fast_agent.commands.handlers.shared import (
     load_prompt_messages_from_file,
     replace_agent_history,
 )
+from fast_agent.commands.history_summaries import collect_user_turns, group_history_turns
 from fast_agent.commands.results import CommandOutcome
 from fast_agent.constants import (
     ANTHROPIC_ASSISTANT_RAW_CONTENT,
@@ -22,56 +23,6 @@ from fast_agent.types import LlmStopReason, PromptMessageExtended
 
 if TYPE_CHECKING:
     from fast_agent.commands.context import CommandContext
-
-
-def _group_turns_for_history_actions(
-    history: list[PromptMessageExtended],
-) -> list[tuple[int, list[PromptMessageExtended]]]:
-    turns: list[tuple[int, list[PromptMessageExtended]]] = []
-    current: list[PromptMessageExtended] = []
-    current_start = 0
-    saw_assistant = False
-
-    for idx, message in enumerate(history):
-        is_new_user = message.role == "user" and not message.tool_results
-        if is_new_user:
-            if not current:
-                current = [message]
-                current_start = idx
-                saw_assistant = False
-                continue
-            if not saw_assistant:
-                current.append(message)
-                continue
-            turns.append((current_start, current))
-            current = [message]
-            current_start = idx
-            saw_assistant = False
-            continue
-
-        if current:
-            current.append(message)
-            if message.role == "assistant":
-                saw_assistant = True
-
-    if current:
-        turns.append((current_start, current))
-    return turns
-
-
-def _collect_user_turns(
-    history: list[PromptMessageExtended],
-) -> list[tuple[int, PromptMessageExtended]]:
-    turns = _group_turns_for_history_actions(list(history))
-    user_turns: list[tuple[int, PromptMessageExtended]] = []
-    for offset, turn in turns:
-        if not turn:
-            continue
-        first = turn[0]
-        if first.role != "user" or first.tool_results:
-            continue
-        user_turns.append((offset, first))
-    return user_turns
 
 
 def _trim_history_for_rewind(
@@ -217,7 +168,7 @@ async def handle_history_rewind(
 
     agent_obj = ctx.agent_provider._agent(agent_name)
     history = getattr(agent_obj, "message_history", [])
-    user_turns = _collect_user_turns(list(history))
+    user_turns = collect_user_turns(list(history))
     if not user_turns:
         outcome.add_message(
             "No user turns available to rewind.",
@@ -282,12 +233,12 @@ async def handle_history_review(
         return outcome
     if turn_index is None:
         outcome.add_message(
-            "Usage: /history review <turn>",
+            "Usage: /history detail <turn>",
             channel="warning",
             agent_name=agent_name,
         )
         outcome.add_message(
-            "Tip: press Tab after '/history review ' to see turn options.",
+            "Tip: press Tab after '/history detail ' to see turn options.",
             channel="info",
             agent_name=agent_name,
         )
@@ -297,7 +248,7 @@ async def handle_history_review(
     history = getattr(agent_obj, "message_history", [])
     turns = [
         turn
-        for _, turn in _group_turns_for_history_actions(list(history))
+        for _, turn in group_history_turns(list(history))
         if turn and turn[0].role == "user" and not turn[0].tool_results
     ]
     user_turns = turns
@@ -314,7 +265,7 @@ async def handle_history_review(
 
     selected_turn = user_turns[turn_index - 1]
     outcome.add_message(
-        f"History review: turn {turn_index}",
+        f"History detail: turn {turn_index}",
         channel="info",
         agent_name=agent_name,
     )

--- a/src/fast_agent/commands/history_summaries.py
+++ b/src/fast_agent/commands/history_summaries.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from fast_agent.constants import FAST_AGENT_TIMING, FAST_AGENT_TOOL_TIMING, FAST_AGENT_USAGE
 from fast_agent.mcp.helpers.content_helpers import get_text
 from fast_agent.types.conversation_summary import ConversationSummary
 
@@ -29,6 +32,44 @@ class HistoryOverview:
     recent_messages: list[HistoryMessageSnippet]
 
 
+@dataclass(slots=True)
+class HistoryToolTiming:
+    timing_ms: float | None
+    transport_channel: str | None
+
+
+@dataclass(slots=True)
+class HistoryTurnSummary:
+    turn_index: int
+    user_snippet: str
+    assistant_snippet: str
+    tool_calls: int
+    tool_errors: int
+    llm_time_ms: float | None
+    tool_time_ms: float | None
+    turn_time_ms: float | None
+    ttft_ms: float | None
+    response_ms: float | None
+    output_tokens: int | None
+    tps: float | None
+
+
+@dataclass(slots=True)
+class HistoryTurnReport:
+    turn_count: int
+    total_tool_calls: int
+    total_tool_errors: int
+    total_llm_time_ms: float
+    total_tool_time_ms: float
+    total_turn_time_ms: float
+    average_turn_time_ms: float | None
+    average_tool_time_ms: float | None
+    average_ttft_ms: float | None
+    average_response_ms: float | None
+    average_tps: float | None
+    turns: list[HistoryTurnSummary]
+
+
 def _extract_message_text(message: "PromptMessageExtended") -> str:
     if hasattr(message, "all_text"):
         text = message.all_text() or message.first_text() or ""
@@ -39,6 +80,413 @@ def _extract_message_text(message: "PromptMessageExtended") -> str:
         else:
             text = ""
     return text
+
+
+def _normalize_text(value: str | None) -> str:
+    return "" if not value else " ".join(value.split())
+
+
+def _preview_text(value: str | None, *, limit: int = 60) -> str:
+    normalized = _normalize_text(value)
+    if not normalized:
+        return "(no text content)"
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 3]}..."
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _extract_channel_payload(
+    message: "PromptMessageExtended",
+    channel_name: str,
+) -> dict[str, Any] | None:
+    channels = getattr(message, "channels", None)
+    if not isinstance(channels, Mapping):
+        return None
+
+    channel_blocks = channels.get(channel_name)
+    if not channel_blocks:
+        return None
+
+    channel_text = get_text(channel_blocks[0])
+    if not channel_text:
+        return None
+
+    try:
+        payload = json.loads(channel_text)
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def extract_message_timing_payload(
+    message: "PromptMessageExtended",
+) -> dict[str, Any] | None:
+    return _extract_channel_payload(message, FAST_AGENT_TIMING)
+
+
+def extract_message_duration_ms(message: "PromptMessageExtended") -> float | None:
+    payload = extract_message_timing_payload(message)
+    if payload is None:
+        return None
+    return _coerce_float(payload.get("duration_ms"))
+
+
+def extract_message_tool_timings(
+    message: "PromptMessageExtended",
+) -> dict[str, HistoryToolTiming]:
+    payload = _extract_channel_payload(message, FAST_AGENT_TOOL_TIMING)
+    if payload is None:
+        return {}
+
+    timings: dict[str, HistoryToolTiming] = {}
+    for tool_id, value in payload.items():
+        if isinstance(value, Mapping):
+            timings[tool_id] = HistoryToolTiming(
+                timing_ms=_coerce_float(value.get("timing_ms")),
+                transport_channel=(
+                    value.get("transport_channel")
+                    if isinstance(value.get("transport_channel"), str)
+                    else None
+                ),
+            )
+            continue
+        timings[tool_id] = HistoryToolTiming(
+            timing_ms=_coerce_float(value),
+            transport_channel=None,
+        )
+    return timings
+
+
+def extract_message_usage_payload(
+    message: "PromptMessageExtended",
+) -> dict[str, Any] | None:
+    return _extract_channel_payload(message, FAST_AGENT_USAGE)
+
+
+def extract_message_output_tokens(message: "PromptMessageExtended") -> int | None:
+    payload = extract_message_usage_payload(message)
+    if payload is None:
+        return None
+    turn_payload = payload.get("turn")
+    if not isinstance(turn_payload, Mapping):
+        return None
+    return _coerce_int(turn_payload.get("output_tokens"))
+
+
+def _extract_message_metric_ms(
+    message: "PromptMessageExtended",
+    *,
+    keys: Sequence[str],
+) -> float | None:
+    timing_payload = extract_message_timing_payload(message)
+    if timing_payload is not None:
+        for key in keys:
+            metric_value = _coerce_float(timing_payload.get(key))
+            if metric_value is not None:
+                return metric_value
+
+    usage_payload = extract_message_usage_payload(message)
+    if usage_payload is None:
+        return None
+
+    for section_name in ("turn", "raw_usage"):
+        section = usage_payload.get(section_name)
+        if not isinstance(section, Mapping):
+            continue
+        for key in keys:
+            metric_value = _coerce_float(section.get(key))
+            if metric_value is not None:
+                return metric_value
+    return None
+
+
+def extract_message_ttft_ms(message: "PromptMessageExtended") -> float | None:
+    return _extract_message_metric_ms(
+        message,
+        keys=(
+            "ttft_ms",
+            "first_activity_ms",
+            "time_to_first_token_ms",
+            "first_token_ms",
+            "first_token_latency_ms",
+        ),
+    )
+
+
+def extract_message_response_ms(message: "PromptMessageExtended") -> float | None:
+    return _extract_message_metric_ms(
+        message,
+        keys=(
+            "time_to_response_ms",
+            "first_response_ms",
+            "response_ms",
+            "ttft_ms",
+        ),
+    )
+
+
+def group_history_turns(
+    messages: list["PromptMessageExtended"],
+) -> list[tuple[int, list["PromptMessageExtended"]]]:
+    turns: list[tuple[int, list[PromptMessageExtended]]] = []
+    current: list[PromptMessageExtended] = []
+    current_start = 0
+    saw_assistant = False
+
+    for idx, message in enumerate(messages):
+        is_new_user = message.role == "user" and not message.tool_results
+        if is_new_user:
+            if not current:
+                current = [message]
+                current_start = idx
+                saw_assistant = False
+                continue
+            if not saw_assistant:
+                current.append(message)
+                continue
+            turns.append((current_start, current))
+            current = [message]
+            current_start = idx
+            saw_assistant = False
+            continue
+
+        if current:
+            current.append(message)
+            if message.role == "assistant":
+                saw_assistant = True
+
+    if current:
+        turns.append((current_start, current))
+    return turns
+
+
+def collect_user_turns(
+    messages: list["PromptMessageExtended"],
+) -> list[tuple[int, "PromptMessageExtended"]]:
+    turns = group_history_turns(messages)
+    user_turns: list[tuple[int, PromptMessageExtended]] = []
+    for offset, turn in turns:
+        if not turn:
+            continue
+        first = turn[0]
+        if first.role != "user" or first.tool_results:
+            continue
+        user_turns.append((offset, first))
+    return user_turns
+
+
+def _summarize_turn_messages(
+    turn: Sequence["PromptMessageExtended"],
+) -> tuple[str, str]:
+    user_parts: list[str] = []
+    assistant_parts: list[str] = []
+
+    for message in turn:
+        text = _extract_message_text(message)
+        if message.role == "user" and not message.tool_results:
+            normalized = _normalize_text(text)
+            if normalized:
+                user_parts.append(normalized)
+        elif message.role == "assistant":
+            normalized = _normalize_text(text)
+            if normalized:
+                assistant_parts.append(normalized)
+
+    user_text = " / ".join(user_parts)
+    assistant_text = assistant_parts[-1] if assistant_parts else ""
+    return _preview_text(user_text), _preview_text(assistant_text)
+
+
+def _calculate_tokens_per_second(
+    *,
+    output_tokens: int | None,
+    llm_time_ms: float | None,
+    response_ms: float | None,
+) -> float | None:
+    if output_tokens is None or output_tokens <= 0 or llm_time_ms is None or llm_time_ms <= 0:
+        return None
+
+    effective_ms = llm_time_ms
+    if response_ms is not None and 0 < response_ms < llm_time_ms:
+        effective_ms = llm_time_ms - response_ms
+    if effective_ms <= 0:
+        return None
+    return output_tokens / (effective_ms / 1000.0)
+
+
+def build_history_turn_report(messages: list["PromptMessageExtended"]) -> HistoryTurnReport:
+    turn_rows: list[HistoryTurnSummary] = []
+
+    total_tool_calls = 0
+    total_tool_errors = 0
+    total_llm_time_ms = 0.0
+    total_tool_time_ms = 0.0
+    total_turn_time_ms = 0.0
+
+    known_turn_times: list[float] = []
+    known_tool_times: list[float] = []
+    known_ttfts: list[float] = []
+    known_responses: list[float] = []
+    known_tps: list[float] = []
+
+    turns = [
+        turn
+        for _, turn in group_history_turns(messages)
+        if turn and turn[0].role == "user" and not turn[0].tool_results
+    ]
+
+    for turn_index, turn in enumerate(turns, start=1):
+        user_snippet, assistant_snippet = _summarize_turn_messages(turn)
+
+        tool_calls = 0
+        tool_errors = 0
+        llm_time_ms = 0.0
+        saw_llm_time = False
+        tool_time_ms = 0.0
+        saw_tool_time = False
+        output_tokens_total = 0
+        saw_output_tokens = False
+        ttft_ms: float | None = None
+        response_ms: float | None = None
+        first_start: float | None = None
+        last_end: float | None = None
+
+        for message in turn:
+            if message.tool_calls:
+                tool_calls += len(message.tool_calls)
+
+            if message.tool_results:
+                tool_errors += sum(
+                    1 for result in message.tool_results.values() if getattr(result, "isError", False)
+                )
+                for tool_timing in extract_message_tool_timings(message).values():
+                    if tool_timing.timing_ms is None:
+                        continue
+                    tool_time_ms += tool_timing.timing_ms
+                    saw_tool_time = True
+
+            if message.role != "assistant":
+                continue
+
+            duration_ms = extract_message_duration_ms(message)
+            if duration_ms is not None:
+                llm_time_ms += duration_ms
+                saw_llm_time = True
+
+            output_tokens = extract_message_output_tokens(message)
+            if output_tokens is not None:
+                output_tokens_total += output_tokens
+                saw_output_tokens = True
+
+            if ttft_ms is None:
+                ttft_ms = extract_message_ttft_ms(message)
+            if response_ms is None:
+                response_ms = extract_message_response_ms(message)
+
+            timing_payload = extract_message_timing_payload(message)
+            if timing_payload is None:
+                continue
+
+            start_time = _coerce_float(timing_payload.get("start_time"))
+            end_time = _coerce_float(timing_payload.get("end_time"))
+            if start_time is not None and (first_start is None or start_time < first_start):
+                first_start = start_time
+            if end_time is not None and (last_end is None or end_time > last_end):
+                last_end = end_time
+
+        tool_time_value = tool_time_ms if saw_tool_time else None
+        llm_time_value = llm_time_ms if saw_llm_time else None
+        output_tokens_value = output_tokens_total if saw_output_tokens else None
+
+        turn_time_ms: float | None = None
+        if first_start is not None and last_end is not None and last_end >= first_start:
+            turn_time_ms = round((last_end - first_start) * 1000.0, 2)
+        elif llm_time_value is not None or tool_time_value is not None:
+            turn_time_ms = round(float((llm_time_value or 0.0) + (tool_time_value or 0.0)), 2)
+
+        tps = _calculate_tokens_per_second(
+            output_tokens=output_tokens_value,
+            llm_time_ms=llm_time_value,
+            response_ms=response_ms,
+        )
+
+        turn_rows.append(
+            HistoryTurnSummary(
+                turn_index=turn_index,
+                user_snippet=user_snippet,
+                assistant_snippet=assistant_snippet,
+                tool_calls=tool_calls,
+                tool_errors=tool_errors,
+                llm_time_ms=llm_time_value,
+                tool_time_ms=tool_time_value,
+                turn_time_ms=turn_time_ms,
+                ttft_ms=ttft_ms,
+                response_ms=response_ms,
+                output_tokens=output_tokens_value,
+                tps=tps,
+            )
+        )
+
+        total_tool_calls += tool_calls
+        total_tool_errors += tool_errors
+        total_llm_time_ms += llm_time_ms
+        total_tool_time_ms += tool_time_ms
+        if turn_time_ms is not None:
+            total_turn_time_ms += turn_time_ms
+            known_turn_times.append(turn_time_ms)
+        if tool_time_value is not None:
+            known_tool_times.append(tool_time_value)
+        if ttft_ms is not None:
+            known_ttfts.append(ttft_ms)
+        if response_ms is not None:
+            known_responses.append(response_ms)
+        if tps is not None:
+            known_tps.append(tps)
+
+    average_turn_time_ms = (
+        sum(known_turn_times) / len(known_turn_times) if known_turn_times else None
+    )
+    average_tool_time_ms = (
+        sum(known_tool_times) / len(known_tool_times) if known_tool_times else None
+    )
+    average_ttft_ms = sum(known_ttfts) / len(known_ttfts) if known_ttfts else None
+    average_response_ms = (
+        sum(known_responses) / len(known_responses) if known_responses else None
+    )
+    average_tps = sum(known_tps) / len(known_tps) if known_tps else None
+
+    return HistoryTurnReport(
+        turn_count=len(turn_rows),
+        total_tool_calls=total_tool_calls,
+        total_tool_errors=total_tool_errors,
+        total_llm_time_ms=total_llm_time_ms,
+        total_tool_time_ms=total_tool_time_ms,
+        total_turn_time_ms=total_turn_time_ms,
+        average_turn_time_ms=average_turn_time_ms,
+        average_tool_time_ms=average_tool_time_ms,
+        average_ttft_ms=average_ttft_ms,
+        average_response_ms=average_response_ms,
+        average_tps=average_tps,
+        turns=turn_rows,
+    )
 
 
 def build_history_overview(

--- a/src/fast_agent/commands/renderers/history_markdown.py
+++ b/src/fast_agent/commands/renderers/history_markdown.py
@@ -5,7 +5,25 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from fast_agent.commands.history_summaries import HistoryOverview
+    from fast_agent.commands.history_summaries import HistoryOverview, HistoryTurnReport
+
+
+def _format_time(value: float | None) -> str:
+    if value is None:
+        return "-"
+    if value < 1000:
+        return f"{value:.0f}ms"
+    return f"{value / 1000:.1f}s"
+
+
+def _format_tps(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.1f}"
+
+
+def _escape_table_cell(value: str) -> str:
+    return value.replace("|", r"\|")
 
 
 def render_history_overview_markdown(
@@ -33,5 +51,59 @@ def render_history_overview_markdown(
     else:
         lines.append("")
         lines.append("No messages yet.")
+
+    return "\n".join(lines)
+
+
+def render_history_turn_report_markdown(
+    report: "HistoryTurnReport",
+    *,
+    heading: str,
+) -> str:
+    lines = [f"# {heading}", ""]
+
+    lines.append(f"Turns: {report.turn_count}")
+    lines.append(
+        "Tools: "
+        f"{report.total_tool_calls} (errors: {report.total_tool_errors})"
+    )
+    lines.append(
+        "Totals: "
+        f"turn {_format_time(report.total_turn_time_ms if report.total_turn_time_ms > 0 else None)}"
+        f", llm {_format_time(report.total_llm_time_ms if report.total_llm_time_ms > 0 else None)}"
+        f", tool {_format_time(report.total_tool_time_ms if report.total_tool_time_ms > 0 else None)}"
+    )
+    lines.append(
+        "Averages: "
+        f"turn {_format_time(report.average_turn_time_ms)}, "
+        f"tool {_format_time(report.average_tool_time_ms)}, "
+        f"ttft {_format_time(report.average_ttft_ms)}, "
+        f"resp {_format_time(report.average_response_ms)}, "
+        f"tps {_format_tps(report.average_tps)}"
+    )
+
+    if not report.turns:
+        lines.extend(["", "No user turns yet."])
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            "",
+            "| # | Turn | Time | Tool | TTFT | Resp | TPS |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+
+    for turn in report.turns:
+        lines.append(
+            "| "
+            f"{turn.turn_index} | "
+            f"{_escape_table_cell(f'{turn.user_snippet} → {turn.assistant_snippet}')} | "
+            f"{_format_time(turn.turn_time_ms)} | "
+            f"{_format_time(turn.tool_time_ms)} | "
+            f"{_format_time(turn.ttft_ms)} | "
+            f"{_format_time(turn.response_ms)} | "
+            f"{_format_tps(turn.tps)} |"
+        )
 
     return "\n".join(lines)

--- a/src/fast_agent/constants.py
+++ b/src/fast_agent/constants.py
@@ -45,7 +45,7 @@ DEFAULT_MAX_ITERATIONS = 99
 """Maximum number of User/Assistant turns to take"""
 
 DEFAULT_STREAMING_TIMEOUT = 300.0
-"""Default streaming timeout in seconds for provider streaming responses."""
+"""Default idle timeout in seconds between provider streaming events."""
 
 DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT = 8192
 """Baseline byte limit for ACP terminal output when no model info exists."""

--- a/src/fast_agent/hooks/hook_messages.py
+++ b/src/fast_agent/hooks/hook_messages.py
@@ -77,7 +77,7 @@ def _build_metadata_line(
     style_name = getattr(display.style, "name", None)
     if style_name == "a3":
         line = Text()
-        line.append("▎• ", style=prefix_style)
+        line.append("▎ ", style=prefix_style)
         line.append_text(content)
         return line
 
@@ -99,7 +99,7 @@ def show_hook_message(
         width = console.console.size.width
         prefix_style = f"bold {style}"
         style_name = getattr(display.style, "name", None)
-        prefix_text = "▎• "
+        prefix_text = "  "
         indent = " " * len(prefix_text)
 
         header = _build_hook_header(hook_kind, hook_name, style=style)

--- a/src/fast_agent/llm/fastagent_llm.py
+++ b/src/fast_agent/llm/fastagent_llm.py
@@ -23,7 +23,6 @@ from mcp import Tool
 from mcp.types import (
     GetPromptResult,
     PromptMessage,
-    TextContent,
 )
 from openai import NotGiven
 from openai.lib._parsing import type_to_response_format_param as _type_to_response_format
@@ -32,14 +31,10 @@ from rich import print as rich_print
 
 from fast_agent.constants import (
     CONTROL_MESSAGE_SAVE_HISTORY,
-    DEFAULT_MAX_ITERATIONS,
-    FAST_AGENT_TIMING,
-    FAST_AGENT_USAGE,
 )
 from fast_agent.context_dependent import ContextDependent
 from fast_agent.core.exceptions import AgentConfigError, ProviderKeyError, ServerConfigError
 from fast_agent.core.logging.logger import get_logger
-from fast_agent.core.model_resolution import get_context_model_aliases, resolve_model_alias
 from fast_agent.core.prompt import Prompt
 from fast_agent.event_progress import ProgressAction
 from fast_agent.interfaces import (
@@ -53,6 +48,20 @@ from fast_agent.llm.reasoning_effort import (
     ReasoningEffortSetting,
     ReasoningEffortSpec,
     validate_reasoning_setting,
+)
+from fast_agent.llm.request_param_resolution import (
+    get_provider_config,
+    initialize_base_default_params,
+    merge_request_params,
+    normalize_model_name,
+    resolve_config_default_model,
+    resolve_model_aliases,
+)
+from fast_agent.llm.response_telemetry import (
+    RequestTimingCapture,
+    add_timing_channel,
+    append_usage_channel,
+    start_request_timing_capture,
 )
 from fast_agent.llm.stream_types import StreamChunk
 from fast_agent.llm.text_verbosity import (
@@ -75,29 +84,6 @@ if TYPE_CHECKING:
 
 # Context variable for storing MCP metadata
 _mcp_metadata_var: ContextVar[dict[str, Any] | None] = ContextVar("mcp_metadata", default=None)
-
-
-def deep_merge(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, Any]:
-    """
-    Recursively merges `dict2` into `dict1` in place.
-
-    If a key exists in both dictionaries and their values are dictionaries,
-    the function merges them recursively. Otherwise, the value from `dict2`
-    overwrites or is added to `dict1`.
-
-    Args:
-        dict1 (Dict): The dictionary to be updated.
-        dict2 (Dict): The dictionary to merge into `dict1`.
-
-    Returns:
-        Dict: The updated `dict1`.
-    """
-    for key in dict2:
-        if key in dict1 and isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
-            deep_merge(dict1[key], dict2[key])
-        else:
-            dict1[key] = dict2[key]
-    return dict1
 
 
 class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT, MessageT]):
@@ -314,27 +300,12 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
 
     def _get_provider_config(self) -> Any | None:
         """Return provider-specific config section when available."""
-        context_config = getattr(self.context, "config", None)
-        if context_config is None:
-            return None
-
-        checked_sections: set[str] = set()
-        for section_name in (
-            *self._provider_config_sections(),
-            *self._provider_config_fallback_sections(),
-        ):
-            if not section_name or section_name in checked_sections:
-                continue
-            checked_sections.add(section_name)
-
-            if not hasattr(context_config, section_name):
-                continue
-
-            provider_config = getattr(context_config, section_name)
-            if provider_config is not None:
-                return provider_config
-
-        return None
+        return get_provider_config(
+            context_config=getattr(self.context, "config", None),
+            provider_value=getattr(self.provider, "value", None),
+            config_section=getattr(self, "config_section", None),
+            fallback_sections=self._provider_config_fallback_sections(),
+        )
 
     def _provider_config_sections(self) -> tuple[str, ...]:
         section_name = getattr(self, "config_section", None) or getattr(self.provider, "value", None)
@@ -345,28 +316,19 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
 
     def _resolve_config_default_model(self) -> str | None:
         """Resolve optional provider-level default model from config."""
-        provider_config = self._get_provider_config()
-        if provider_config is None:
-            return None
-
-        value = getattr(provider_config, "default_model", None)
-        if not isinstance(value, str):
-            return None
-
-        normalized = value.strip()
-        return normalized or None
+        return resolve_config_default_model(
+            context_config=getattr(self.context, "config", None),
+            provider_value=getattr(self.provider, "value", None),
+            config_section=getattr(self, "config_section", None),
+            fallback_sections=self._provider_config_fallback_sections(),
+        )
 
     @staticmethod
     def _normalize_model_name(value: str | None) -> str | None:
-        if not isinstance(value, str):
-            return None
-
-        normalized = value.strip()
-        return normalized or None
+        return normalize_model_name(value)
 
     def _resolve_model_aliases(self, value: str) -> str:
-        aliases = get_context_model_aliases(self.context)
-        return resolve_model_alias(value, aliases)
+        return resolve_model_aliases(context=self.context, value=value)
 
     def _resolve_default_model_name(
         self,
@@ -410,18 +372,7 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
 
     def _initialize_base_default_params(self, kwargs: dict[str, Any]) -> RequestParams:
         """Provider-agnostic default request params."""
-        # Get model-aware default max tokens
-        model = kwargs.get("model")
-        max_tokens = ModelDatabase.get_default_max_tokens(model) if model else 16384
-
-        return RequestParams(
-            model=model,
-            maxTokens=max_tokens,
-            systemPrompt=self.instruction,
-            parallel_tool_calls=True,
-            max_iterations=DEFAULT_MAX_ITERATIONS,
-            use_history=True,
-        )
+        return initialize_base_default_params(instruction=self.instruction, kwargs=kwargs)
 
     async def _execute_with_retry(
         self,
@@ -582,13 +533,21 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         # The caller supplies the full conversation to send
         full_history = messages
 
-        # Track timing for this generation
-        start_time = time.perf_counter()
-        assistant_response: PromptMessageExtended = await self._execute_with_retry(
-            self._apply_prompt_provider_specific, full_history, request_params, tools
-        )
+        timing_capture, cleanup_timing_capture = self._start_request_timing_capture()
+        try:
+            assistant_response = await self._execute_with_retry(
+                self._apply_prompt_provider_specific, full_history, request_params, tools
+            )
+        finally:
+            cleanup_timing_capture()
         end_time = time.perf_counter()
-        self._add_timing_channel(assistant_response, start_time, end_time)
+        self._add_timing_channel(
+            assistant_response,
+            timing_capture.start_time,
+            end_time,
+            ttft_ms=timing_capture.ttft_ms,
+            time_to_response_ms=timing_capture.time_to_response_ms,
+        )
 
         self.usage_accumulator.count_tools(len(assistant_response.tool_calls or {}))
         self._append_usage_channel(assistant_response)
@@ -596,67 +555,41 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         return assistant_response
 
     def _append_usage_channel(self, response: PromptMessageExtended) -> None:
-        usage_payload = self._build_usage_payload()
-        if not usage_payload:
-            return
-
-        channels = dict(response.channels or {})
-        if FAST_AGENT_USAGE in channels:
-            return
-
-        channels[FAST_AGENT_USAGE] = [
-            TextContent(type="text", text=json.dumps(usage_payload))
-        ]
-        response.channels = channels
-
+        append_usage_channel(response, self.usage_accumulator)
 
     def _add_timing_channel(
         self,
         response: PromptMessageExtended,
         start_time: float,
         end_time: float,
+        *,
+        ttft_ms: float | None = None,
+        time_to_response_ms: float | None = None,
     ) -> None:
         """Add timing data to response channels if not already present.
 
         Preserves original timing when loading saved history.
         """
-        duration_ms = round((end_time - start_time) * 1000, 2)
-        channels = dict(response.channels or {})
-        if FAST_AGENT_TIMING not in channels:
-            timing_data = {
-                "start_time": start_time,
-                "end_time": end_time,
-                "duration_ms": duration_ms,
-            }
-            channels[FAST_AGENT_TIMING] = [TextContent(type="text", text=json.dumps(timing_data))]
-            response.channels = channels
+        add_timing_channel(
+            response,
+            start_time,
+            end_time,
+            ttft_ms=ttft_ms,
+            time_to_response_ms=time_to_response_ms,
+        )
+
+    def _start_request_timing_capture(self) -> tuple[RequestTimingCapture, Callable[[], None]]:
+        return start_request_timing_capture(self)
 
     def _build_usage_payload(self) -> dict[str, Any] | None:
-        if not self.usage_accumulator or not self.usage_accumulator.turns:
-            return None
+        from fast_agent.llm.response_telemetry import build_usage_payload
 
-        turn_usage = self.usage_accumulator.turns[-1]
-        return {
-            "turn": turn_usage.model_dump(mode="json", exclude={"raw_usage"}),
-            "raw_usage": self._serialize_raw_usage(turn_usage.raw_usage),
-            "summary": self.usage_accumulator.get_summary(),
-        }
+        return build_usage_payload(self.usage_accumulator)
 
     def _serialize_raw_usage(self, raw_usage: object) -> object:
-        for attr in ("model_dump", "dict"):
-            method = getattr(raw_usage, attr, None)
-            if callable(method):
-                try:
-                    return method()
-                except Exception:
-                    continue
-        raw_dict = getattr(raw_usage, "__dict__", None)
-        if isinstance(raw_dict, dict):
-            try:
-                return dict(raw_dict)
-            except Exception:
-                pass
-        return str(raw_usage)
+        from fast_agent.llm.response_telemetry import serialize_raw_usage
+
+        return serialize_raw_usage(raw_usage)
 
     @abstractmethod
     async def _apply_prompt_provider_specific(
@@ -713,21 +646,29 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
 
         full_history = messages
 
-        # Track timing for this structured generation
-        start_time = time.perf_counter()
-        result_or_response = await self._execute_with_retry(
-            self._apply_prompt_provider_specific_structured,
-            full_history,
-            model,
-            request_params,
-            on_final_error=self._handle_retry_failure,
-        )
+        timing_capture, cleanup_timing_capture = self._start_request_timing_capture()
+        try:
+            result_or_response = await self._execute_with_retry(
+                self._apply_prompt_provider_specific_structured,
+                full_history,
+                model,
+                request_params,
+                on_final_error=self._handle_retry_failure,
+            )
+        finally:
+            cleanup_timing_capture()
         if isinstance(result_or_response, PromptMessageExtended):
             result, assistant_response = self._structured_from_multipart(result_or_response, model)
         else:
             result, assistant_response = result_or_response
         end_time = time.perf_counter()
-        self._add_timing_channel(assistant_response, start_time, end_time)
+        self._add_timing_channel(
+            assistant_response,
+            timing_capture.start_time,
+            end_time,
+            ttft_ms=timing_capture.ttft_ms,
+            time_to_response_ms=timing_capture.time_to_response_ms,
+        )
 
         self.usage_accumulator.count_tools(len(assistant_response.tool_calls or {}))
         self._append_usage_channel(assistant_response)
@@ -765,7 +706,6 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         Returns:
             Schema as a string, or empty string if conversion fails
         """
-        import json
 
         try:
             schema = model.model_json_schema()
@@ -875,14 +815,7 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         self, default_params: RequestParams, provided_params: RequestParams
     ) -> RequestParams:
         """Merge default and provided request parameters"""
-
-        merged = deep_merge(
-            default_params.model_dump(),
-            provided_params.model_dump(exclude_unset=True),
-        )
-        final_params = RequestParams(**merged)
-
-        return final_params
+        return merge_request_params(default_params, provided_params)
 
     def get_request_params(
         self,

--- a/src/fast_agent/llm/model_factory.py
+++ b/src/fast_agent/llm/model_factory.py
@@ -92,7 +92,7 @@ class ModelFactory:
         "minimax2.5": "hf.MiniMaxAI/MiniMax-M2.5:novita?temperature=1.0&top_p=0.95&top_k=40",
         "minimax21": "hf.MiniMaxAI/MiniMax-M2.1:novita",
         "kimi": "hf.moonshotai/Kimi-K2-Instruct-0905:groq",
-        "gpt-oss": "hf.openai/gpt-oss-120b:cerebras",
+        "gpt-oss": "hf.openai/gpt-oss-120b:sambanova",
         "gpt-oss-20b": "hf.openai/gpt-oss-20b",
         "glm47": "hf.zai-org/GLM-4.7:cerebras",
         "glm5": "hf.zai-org/GLM-5:novita",

--- a/src/fast_agent/llm/model_selection.py
+++ b/src/fast_agent/llm/model_selection.py
@@ -120,7 +120,7 @@ class ModelSelectionCatalog:
                     "&presence_penalty=1.5&repetition_penalty=1.0&reasoning=off"
                 ),
             ),
-            CatalogModelEntry(alias="gpt-oss", model="hf.openai/gpt-oss-120b:cerebras", fast=True),
+            CatalogModelEntry(alias="gpt-oss", model="hf.openai/gpt-oss-120b:sambanova", fast=True),
             CatalogModelEntry(
                 alias="glm47",
                 model="hf.zai-org/GLM-4.7:cerebras",

--- a/src/fast_agent/llm/provider/openai/llm_openai.py
+++ b/src/fast_agent/llm/provider/openai/llm_openai.py
@@ -45,6 +45,7 @@ from fast_agent.llm.provider.openai.schema_sanitizer import (
     sanitize_tool_input_schema,
     should_strip_tool_schema_defaults,
 )
+from fast_agent.llm.provider.openai.streaming_utils import with_stream_idle_timeout
 from fast_agent.llm.provider.openai.tool_notifications import OpenAIToolNotificationMixin
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.reasoning_effort import format_reasoning_setting, parse_reasoning_setting
@@ -895,54 +896,39 @@ class OpenAILLM(
         try:
             async with self._openai_client() as client:
                 stream = await client.chat.completions.create(**arguments)
-                # Process the stream
                 timeout = request_params.streaming_timeout
-                if timeout is None:
-                    try:
-                        response, streamed_reasoning = await self._process_stream(
-                            stream, model_name, capture_filename
-                        )
-                    except EmptyStreamError as exc:
-                        self.logger.error(
-                            "OpenAI stream returned no chunks; retrying without streaming",
-                            data={
-                                "model": model_name,
-                                "error": str(exc),
-                            },
-                        )
-                        response = await client.chat.completions.create(
-                            **self._prepare_non_streaming_request(arguments)
-                        )
-                        streamed_reasoning = []
-                else:
-                    try:
-                        response, streamed_reasoning = await asyncio.wait_for(
-                            self._process_stream(stream, model_name, capture_filename),
-                            timeout=timeout,
-                        )
-                    except EmptyStreamError as exc:
-                        self.logger.error(
-                            "OpenAI stream returned no chunks; retrying without streaming",
-                            data={
-                                "model": model_name,
-                                "error": str(exc),
-                            },
-                        )
-                        response = await client.chat.completions.create(
-                            **self._prepare_non_streaming_request(arguments)
-                        )
-                        streamed_reasoning = []
-                    except asyncio.TimeoutError as exc:
-                        self.logger.error(
-                            "Streaming timeout while waiting for OpenAI completion",
-                            data={
-                                "model": model_name,
-                                "timeout_seconds": timeout,
-                            },
-                        )
-                        raise TimeoutError(
-                            f"Streaming did not complete within {timeout} seconds."
-                        ) from exc
+                timed_stream = with_stream_idle_timeout(
+                    stream,
+                    idle_timeout_seconds=timeout,
+                    timeout_message=f"Streaming was idle for more than {timeout} seconds.",
+                )
+                try:
+                    response, streamed_reasoning = await self._process_stream(
+                        timed_stream, model_name, capture_filename
+                    )
+                except EmptyStreamError as exc:
+                    self.logger.error(
+                        "OpenAI stream returned no chunks; retrying without streaming",
+                        data={
+                            "model": model_name,
+                            "error": str(exc),
+                        },
+                    )
+                    response = await client.chat.completions.create(
+                        **self._prepare_non_streaming_request(arguments)
+                    )
+                    streamed_reasoning = []
+                except TimeoutError:
+                    if timeout is None:
+                        raise
+                    self.logger.error(
+                        "Streaming idle timeout while waiting for OpenAI completion",
+                        data={
+                            "model": model_name,
+                            "timeout_seconds": timeout,
+                        },
+                    )
+                    raise
         except asyncio.CancelledError as e:
             reason = str(e) if e.args else "cancelled"
             self.logger.info(f"OpenAI completion cancelled: {reason}")

--- a/src/fast_agent/llm/provider/openai/responses.py
+++ b/src/fast_agent/llm/provider/openai/responses.py
@@ -46,6 +46,7 @@ from fast_agent.llm.provider.openai.schema_sanitizer import (
     sanitize_tool_input_schema,
     should_strip_tool_schema_defaults,
 )
+from fast_agent.llm.provider.openai.streaming_utils import with_stream_idle_timeout
 from fast_agent.llm.provider.openai.web_tools import build_web_search_tool, resolve_web_search
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.reasoning_effort import format_reasoning_setting, parse_reasoning_setting
@@ -920,27 +921,26 @@ class ResponsesLLM(
                 _save_stream_request(capture_filename, arguments)
                 async with client.responses.stream(**arguments) as stream:
                     timeout = request_params.streaming_timeout
-                    if timeout is None:
+                    timed_stream = with_stream_idle_timeout(
+                        stream,
+                        idle_timeout_seconds=timeout,
+                        timeout_message=f"Streaming was idle for more than {timeout} seconds.",
+                    )
+                    try:
                         response, streamed_summary = await self._process_stream(
-                            stream, model_name, capture_filename
+                            timed_stream, model_name, capture_filename
                         )
-                    else:
-                        try:
-                            response, streamed_summary = await asyncio.wait_for(
-                                self._process_stream(stream, model_name, capture_filename),
-                                timeout=timeout,
-                            )
-                        except asyncio.TimeoutError as exc:
-                            self.logger.error(
-                                "Streaming timeout while waiting for Responses",
-                                data={
-                                    "model": model_name,
-                                    "timeout_seconds": timeout,
-                                },
-                            )
-                            raise TimeoutError(
-                                f"Streaming did not complete within {timeout} seconds."
-                            ) from exc
+                    except TimeoutError:
+                        if timeout is None:
+                            raise
+                        self.logger.error(
+                            "Streaming idle timeout while waiting for Responses",
+                            data={
+                                "model": model_name,
+                                "timeout_seconds": timeout,
+                            },
+                        )
+                        raise
                 return response, streamed_summary, normalized_input
         except AuthenticationError as e:
             raise ProviderKeyError(
@@ -1005,27 +1005,26 @@ class ResponsesLLM(
                 )
                 await send_response_request(connection.websocket, planned_request)
                 stream = WebSocketResponsesStream(connection.websocket)
-                if timeout is None:
+                timed_stream = with_stream_idle_timeout(
+                    stream,
+                    idle_timeout_seconds=timeout,
+                    timeout_message=f"Streaming was idle for more than {timeout} seconds.",
+                )
+                try:
                     response, streamed_summary = await self._process_stream(
-                        stream, model_name, capture_filename
+                        timed_stream, model_name, capture_filename
                     )
-                else:
-                    try:
-                        response, streamed_summary = await asyncio.wait_for(
-                            self._process_stream(stream, model_name, capture_filename),
-                            timeout=timeout,
-                        )
-                    except asyncio.TimeoutError as exc:
-                        self.logger.error(
-                            "Streaming timeout while waiting for Responses websocket",
-                            data={
-                                "model": model_name,
-                                "timeout_seconds": timeout,
-                            },
-                        )
-                        raise TimeoutError(
-                            f"Streaming did not complete within {timeout} seconds."
-                        ) from exc
+                except TimeoutError:
+                    if timeout is None:
+                        raise
+                    self.logger.error(
+                        "Streaming idle timeout while waiting for Responses websocket",
+                        data={
+                            "model": model_name,
+                            "timeout_seconds": timeout,
+                        },
+                    )
+                    raise
                 planner.commit(arguments, planned_request, response)
                 keep_connection = True
                 if reconnected:

--- a/src/fast_agent/llm/provider/openai/responses_output.py
+++ b/src/fast_agent/llm/provider/openai/responses_output.py
@@ -64,6 +64,36 @@ class ResponsesOutputMixin:
     ) -> AssistantMessagePhase | None:
         return coerce_assistant_message_phase(raw_phase)
 
+    @staticmethod
+    def _extract_phase_message_text(content: object) -> str | None:
+        if not isinstance(content, Sequence) or isinstance(content, str):
+            return None
+
+        text_segments: list[str] = []
+        for part in content:
+            part_text = getattr(part, "text", None)
+            if isinstance(part_text, str) and part_text:
+                text_segments.append(part_text)
+
+        combined_text = "".join(text_segments).strip()
+        return combined_text or None
+
+    @classmethod
+    def _print_phase_message(
+        cls,
+        output_item: Any,
+        serialized_item: Mapping[str, Any] | None = None,
+    ) -> None:
+        phase = cls._coerce_assistant_message_phase(getattr(output_item, "phase", None))
+        if phase is None:
+            return
+
+        content_text = cls._extract_phase_message_text(getattr(output_item, "content", None))
+        if content_text is None and serialized_item is not None:
+            content_text = json.dumps(dict(serialized_item), ensure_ascii=False)
+        if not content_text:
+            return
+
     @classmethod
     def _serialize_assistant_message_item(cls, item: Any) -> dict[str, Any] | None:
         model_dump = getattr(item, "model_dump", None)
@@ -145,6 +175,7 @@ class ResponsesOutputMixin:
 
             serialized_item = self._serialize_assistant_message_item(output_item)
             if serialized_item is not None:
+                self._print_phase_message(output_item, serialized_item)
                 serialized_items.append(serialized_item)
 
         if not phases:
@@ -160,7 +191,9 @@ class ResponsesOutputMixin:
     def _record_usage(self, usage: Any, model_name: str) -> None:
         try:
             provider_value = getattr(self, "provider", Provider.RESPONSES)
-            provider = provider_value if isinstance(provider_value, Provider) else Provider.RESPONSES
+            provider = (
+                provider_value if isinstance(provider_value, Provider) else Provider.RESPONSES
+            )
             input_tokens = getattr(usage, "input_tokens", 0) or 0
             output_tokens = getattr(usage, "output_tokens", 0) or 0
             total_tokens = getattr(usage, "total_tokens", 0) or (input_tokens + output_tokens)
@@ -304,14 +337,13 @@ class ResponsesOutputMixin:
     ) -> list[ContentBlock]:
         reasoning_blocks: list[ContentBlock] = []
         for output_item in getattr(response, "output", []) or []:
-            if not isinstance(output_item, ResponseReasoningItem) and getattr(
-                output_item, "type", None
-            ) != "reasoning":
+            if (
+                not isinstance(output_item, ResponseReasoningItem)
+                and getattr(output_item, "type", None) != "reasoning"
+            ):
                 continue
             summary = getattr(output_item, "summary", None) or []
-            summary_text = "\n".join(
-                part.text for part in summary if getattr(part, "text", None)
-            )
+            summary_text = "\n".join(part.text for part in summary if getattr(part, "text", None))
             if summary_text.strip():
                 reasoning_blocks.append(text_content(summary_text.strip()))
         if reasoning_blocks:
@@ -341,7 +373,9 @@ class ResponsesOutputMixin:
         return encrypted_blocks
 
     @staticmethod
-    def _web_citation_dedupe_key(payload: Mapping[str, Any]) -> tuple[str, str] | tuple[str, str, str]:
+    def _web_citation_dedupe_key(
+        payload: Mapping[str, Any],
+    ) -> tuple[str, str] | tuple[str, str, str]:
         raw_url = payload.get("url")
         if isinstance(raw_url, str) and raw_url:
             return ("url", raw_url.strip().lower())
@@ -370,7 +404,9 @@ class ResponsesOutputMixin:
             if item_type == "web_search_call":
                 tool_payload, call_citations = normalize_web_search_call_payload(output_item)
                 if tool_payload is not None:
-                    web_tool_payloads.append(TextContent(type="text", text=json.dumps(tool_payload)))
+                    web_tool_payloads.append(
+                        TextContent(type="text", text=json.dumps(tool_payload))
+                    )
                 for citation in call_citations:
                     append_citation(citation)
                 continue

--- a/src/fast_agent/llm/provider/openai/responses_websocket.py
+++ b/src/fast_agent/llm/provider/openai/responses_websocket.py
@@ -330,10 +330,17 @@ async def connect_websocket(
     headers: Mapping[str, str],
     timeout_seconds: float | None = None,
 ) -> ManagedWebSocketConnection:
-    timeout = aiohttp.ClientTimeout(total=timeout_seconds) if timeout_seconds else None
-    session = aiohttp.ClientSession(timeout=timeout)
+    # Stream idleness is enforced while iterating websocket events, so avoid a
+    # second websocket/session timeout here. A separate wall-clock timeout would
+    # race the idle timeout logic and prematurely kill healthy long-running
+    # streams that are still producing events.
+    session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=None))
     try:
-        websocket = await session.ws_connect(url, headers=dict(headers), autoping=True)
+        if timeout_seconds is None:
+            websocket = await session.ws_connect(url, headers=dict(headers), autoping=True)
+        else:
+            async with asyncio.timeout(timeout_seconds):
+                websocket = await session.ws_connect(url, headers=dict(headers), autoping=True)
     except Exception:
         await session.close()
         raise

--- a/src/fast_agent/llm/provider/openai/streaming_utils.py
+++ b/src/fast_agent/llm/provider/openai/streaming_utils.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Protocol
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import TYPE_CHECKING, Any, Callable, Protocol, Self, TypeVar
 
 if TYPE_CHECKING:
     from fast_agent.core.logging.logger import Logger
 from fast_agent.event_progress import ProgressAction
+
+_StreamEventT = TypeVar("_StreamEventT")
 
 
 class ToolFallbackEmitter(Protocol):
@@ -15,6 +19,57 @@ class ToolFallbackEmitter(Protocol):
         *,
         model: str,
     ) -> None: ...
+
+
+class _IdleTimeoutAsyncStream(AsyncIterator[_StreamEventT]):
+    """Apply an idle timeout to an async stream while preserving stream helpers.
+
+    The timeout is enforced between stream events, not across the total stream
+    lifetime. This allows healthy long-running generations to continue while
+    still failing a stream that stops producing events entirely.
+    """
+
+    def __init__(
+        self,
+        stream: AsyncIterable[_StreamEventT],
+        *,
+        idle_timeout_seconds: float | None,
+        timeout_message: str,
+    ) -> None:
+        self._stream = stream
+        self._iterator = stream.__aiter__()
+        self._idle_timeout_seconds = idle_timeout_seconds
+        self._timeout_message = timeout_message
+
+    def __aiter__(self) -> Self:
+        return self
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    async def __anext__(self) -> _StreamEventT:
+        next_event = self._iterator.__anext__()
+        if self._idle_timeout_seconds is None:
+            return await next_event
+        try:
+            return await asyncio.wait_for(next_event, timeout=self._idle_timeout_seconds)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(self._timeout_message) from exc
+
+
+def with_stream_idle_timeout(
+    stream: AsyncIterable[_StreamEventT],
+    *,
+    idle_timeout_seconds: float | None,
+    timeout_message: str,
+) -> AsyncIterator[_StreamEventT]:
+    """Return a stream iterator that times out only when the stream goes idle."""
+
+    return _IdleTimeoutAsyncStream(
+        stream,
+        idle_timeout_seconds=idle_timeout_seconds,
+        timeout_message=timeout_message,
+    )
 
 
 def finalize_stream_response(

--- a/src/fast_agent/llm/request_param_resolution.py
+++ b/src/fast_agent/llm/request_param_resolution.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fast_agent.constants import DEFAULT_MAX_ITERATIONS
+from fast_agent.core.model_resolution import get_context_model_aliases, resolve_model_alias
+from fast_agent.llm.model_database import ModelDatabase
+from fast_agent.llm.request_params import RequestParams
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+def deep_merge(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, Any]:
+    """Recursively merge ``dict2`` into ``dict1`` in place."""
+    for key in dict2:
+        if key in dict1 and isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
+            deep_merge(dict1[key], dict2[key])
+        else:
+            dict1[key] = dict2[key]
+    return dict1
+
+
+def get_provider_config(
+    *,
+    context_config: object | None,
+    provider_value: str | None,
+    config_section: str | None = None,
+    fallback_sections: Sequence[str] = (),
+) -> Any | None:
+    """Return the first configured provider section that exists and is non-null."""
+    if context_config is None:
+        return None
+
+    checked_sections: set[str] = set()
+    section_names = (config_section or provider_value, *fallback_sections)
+    for section_name in section_names:
+        if not section_name or section_name in checked_sections:
+            continue
+        checked_sections.add(section_name)
+
+        if not hasattr(context_config, section_name):
+            continue
+
+        provider_config = getattr(context_config, section_name)
+        if provider_config is not None:
+            return provider_config
+
+    return None
+
+
+def normalize_model_name(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+    return normalized or None
+
+
+def resolve_config_default_model(
+    *,
+    context_config: object | None,
+    provider_value: str | None,
+    config_section: str | None = None,
+    fallback_sections: Sequence[str] = (),
+) -> str | None:
+    """Resolve an optional provider-level default model from config."""
+    provider_config = get_provider_config(
+        context_config=context_config,
+        provider_value=provider_value,
+        config_section=config_section,
+        fallback_sections=fallback_sections,
+    )
+    if provider_config is None:
+        return None
+
+    value = getattr(provider_config, "default_model", None)
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+    return normalized or None
+
+
+def resolve_model_aliases(*, context: object, value: str) -> str:
+    aliases = get_context_model_aliases(context)
+    return resolve_model_alias(value, aliases)
+
+
+def initialize_base_default_params(
+    *,
+    instruction: str | None,
+    kwargs: Mapping[str, Any],
+) -> RequestParams:
+    """Build provider-agnostic default request params."""
+    model = kwargs.get("model")
+    max_tokens = ModelDatabase.get_default_max_tokens(model) if model else 16384
+
+    return RequestParams(
+        model=model,
+        maxTokens=max_tokens,
+        systemPrompt=instruction,
+        parallel_tool_calls=True,
+        max_iterations=DEFAULT_MAX_ITERATIONS,
+        use_history=True,
+    )
+def merge_request_params(
+    default_params: RequestParams,
+    provided_params: RequestParams,
+) -> RequestParams:
+    """Merge default and provided request parameters."""
+    merged = deep_merge(
+        default_params.model_dump(),
+        provided_params.model_dump(exclude_unset=True),
+    )
+    return RequestParams(**merged)

--- a/src/fast_agent/llm/request_params.py
+++ b/src/fast_agent/llm/request_params.py
@@ -108,7 +108,8 @@ class RequestParams(CreateMessageRequestParams):
 
     streaming_timeout: float | None = DEFAULT_STREAMING_TIMEOUT
     """
-    Maximum time in seconds to wait for streaming completion. Set to None to disable.
+    Maximum idle time in seconds to wait between streaming events. Set to None
+    to disable idle timeout enforcement.
     """
 
     top_p: float | None = Field(

--- a/src/fast_agent/llm/response_telemetry.py
+++ b/src/fast_agent/llm/response_telemetry.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, Protocol
+
+from mcp.types import TextContent
+
+from fast_agent.constants import FAST_AGENT_TIMING, FAST_AGENT_USAGE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from fast_agent.llm.stream_types import StreamChunk
+    from fast_agent.llm.usage_tracking import UsageAccumulator
+    from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
+
+
+class TimingListenerSource(Protocol):
+    def add_stream_listener(
+        self, listener: "Callable[[StreamChunk], None]"
+    ) -> "Callable[[], None]": ...
+
+    def add_tool_stream_listener(
+        self, listener: "Callable[[str, dict[str, Any] | None], None]"
+    ) -> "Callable[[], None]": ...
+
+
+class RequestTimingCapture:
+    def __init__(self, *, start_time: float) -> None:
+        self.start_time = start_time
+        self.first_activity_time: float | None = None
+        self.first_response_time: float | None = None
+
+    def _mark_activity(self, observed_time: float) -> None:
+        if self.first_activity_time is None:
+            self.first_activity_time = observed_time
+
+    def _mark_response(self, observed_time: float) -> None:
+        if self.first_response_time is None:
+            self.first_response_time = observed_time
+
+    def observe_stream_chunk(self, chunk: StreamChunk) -> None:
+        if not chunk.text.strip():
+            return
+
+        observed_time = time.perf_counter()
+        self._mark_activity(observed_time)
+        if not chunk.is_reasoning:
+            self._mark_response(observed_time)
+
+    def observe_tool_event(self, event_type: str, payload: dict[str, Any] | None) -> None:
+        del payload
+        if event_type != "start":
+            return
+
+        observed_time = time.perf_counter()
+        self._mark_activity(observed_time)
+        self._mark_response(observed_time)
+
+    def _elapsed_ms(self, observed_time: float | None) -> float | None:
+        if observed_time is None or observed_time < self.start_time:
+            return None
+        return round((observed_time - self.start_time) * 1000, 2)
+
+    @property
+    def ttft_ms(self) -> float | None:
+        return self._elapsed_ms(self.first_activity_time)
+
+    @property
+    def time_to_response_ms(self) -> float | None:
+        return self._elapsed_ms(self.first_response_time)
+
+
+def start_request_timing_capture(
+    source: TimingListenerSource,
+) -> tuple[RequestTimingCapture, "Callable[[], None]"]:
+    capture = RequestTimingCapture(start_time=time.perf_counter())
+    remove_stream_listener = source.add_stream_listener(capture.observe_stream_chunk)
+    remove_tool_stream_listener = source.add_tool_stream_listener(capture.observe_tool_event)
+
+    def cleanup() -> None:
+        remove_tool_stream_listener()
+        remove_stream_listener()
+
+    return capture, cleanup
+
+
+def add_timing_channel(
+    response: "PromptMessageExtended",
+    start_time: float,
+    end_time: float,
+    *,
+    ttft_ms: float | None = None,
+    time_to_response_ms: float | None = None,
+) -> None:
+    """Add timing data to response channels if not already present."""
+    duration_ms = round((end_time - start_time) * 1000, 2)
+    channels = dict(response.channels or {})
+    if FAST_AGENT_TIMING in channels:
+        return
+
+    timing_data = {
+        "start_time": start_time,
+        "end_time": end_time,
+        "duration_ms": duration_ms,
+    }
+    if ttft_ms is not None:
+        timing_data["ttft_ms"] = ttft_ms
+    if time_to_response_ms is not None:
+        timing_data["time_to_response_ms"] = time_to_response_ms
+
+    channels[FAST_AGENT_TIMING] = [TextContent(type="text", text=json.dumps(timing_data))]
+    response.channels = channels
+
+
+def append_usage_channel(
+    response: "PromptMessageExtended",
+    usage_accumulator: "UsageAccumulator | None",
+) -> None:
+    usage_payload = build_usage_payload(usage_accumulator)
+    if not usage_payload:
+        return
+
+    channels = dict(response.channels or {})
+    if FAST_AGENT_USAGE in channels:
+        return
+
+    channels[FAST_AGENT_USAGE] = [
+        TextContent(type="text", text=json.dumps(usage_payload))
+    ]
+    response.channels = channels
+
+
+def build_usage_payload(usage_accumulator: "UsageAccumulator | None") -> dict[str, Any] | None:
+    if not usage_accumulator or not usage_accumulator.turns:
+        return None
+
+    turn_usage = usage_accumulator.turns[-1]
+    return {
+        "turn": turn_usage.model_dump(mode="json", exclude={"raw_usage"}),
+        "raw_usage": serialize_raw_usage(turn_usage.raw_usage),
+        "summary": usage_accumulator.get_summary(),
+    }
+
+
+def serialize_raw_usage(raw_usage: object) -> object:
+    for attr in ("model_dump", "dict"):
+        method = getattr(raw_usage, attr, None)
+        if callable(method):
+            try:
+                return method()
+            except Exception:
+                continue
+    raw_dict = getattr(raw_usage, "__dict__", None)
+    if isinstance(raw_dict, dict):
+        try:
+            return dict(raw_dict)
+        except Exception:
+            pass
+    return str(raw_usage)

--- a/src/fast_agent/marketplace/registry_urls.py
+++ b/src/fast_agent/marketplace/registry_urls.py
@@ -29,13 +29,34 @@ def _canonical_registry_url(url: str) -> str:
     """Return a canonical source URL key for de-duplicating equivalent entries."""
     normalized = url.strip()
     parsed = urlparse(normalized)
+
+    def _is_default_marketplace_path(file_path: str) -> bool:
+        return file_path in {".claude-plugin/marketplace.json", "marketplace.json"}
+
     if parsed.netloc in {"github.com", "www.github.com"}:
         parts = parsed.path.strip("/").split("/")
-        # Treat GitHub blob URLs and their raw equivalents as one source.
+        if len(parts) >= 2:
+            org, repo = parts[:2]
+            if len(parts) == 2:
+                return f"https://github.com/{org}/{repo}"
+            if len(parts) >= 4 and parts[2] == "tree":
+                ref = parts[3]
+                file_path = "/".join(parts[4:])
+                if ref in {"main", "master"} and not file_path:
+                    return f"https://github.com/{org}/{repo}"
         if len(parts) >= 5 and parts[2] == "blob":
             org, repo, _, ref = parts[:4]
             file_path = "/".join(parts[4:])
+            if ref in {"main", "master"} and _is_default_marketplace_path(file_path):
+                return f"https://github.com/{org}/{repo}"
             return f"https://raw.githubusercontent.com/{org}/{repo}/{ref}/{file_path}"
+    if parsed.netloc == "raw.githubusercontent.com":
+        parts = parsed.path.strip("/").split("/")
+        if len(parts) >= 4:
+            org, repo, ref = parts[:3]
+            file_path = "/".join(parts[3:])
+            if ref in {"main", "master"} and _is_default_marketplace_path(file_path):
+                return f"https://github.com/{org}/{repo}"
     return normalized
 
 

--- a/src/fast_agent/skills/registry.py
+++ b/src/fast_agent/skills/registry.py
@@ -257,6 +257,7 @@ def format_skills_for_prompt(
       <name>skill-name</name>
       <description>Brief capability summary</description>
       <location>/absolute/path/to/SKILL.md</location>
+      <directory>/absolute/path/to/skill-name</directory>
     </skill>
 
     Args:
@@ -270,6 +271,7 @@ def format_skills_for_prompt(
     formatted_parts: list[str] = []
 
     for manifest in manifests:
+        skill_dir = manifest.path.parent
         lines: list[str] = ["<skill>"]
         lines.append(f"  <name>{manifest.name}</name>")
 
@@ -279,6 +281,12 @@ def format_skills_for_prompt(
 
         # Use absolute path per Agent Skills specification
         lines.append(f"  <location>{manifest.path}</location>")
+        lines.append(f"  <directory>{skill_dir}</directory>")
+
+        for tag_name in ("scripts", "references", "assets"):
+            subdir = skill_dir / tag_name
+            if subdir.is_dir():
+                lines.append(f"  <{tag_name}>{subdir}</{tag_name}>")
 
         lines.append("</skill>")
         formatted_parts.append("\n".join(lines))
@@ -292,6 +300,14 @@ def format_skills_for_prompt(
         "Skills provide specialized capabilities and domain knowledge. Use a Skill if it seems "
         "relevant to the user's task, intent, or would increase your effectiveness.\n"
         f"To use a Skill, read its SKILL.md file from the specified location using the '{read_tool_name}' tool.\n"
+        "Prefer that file-reading tool over shell commands when loading skill content or "
+        "skill resources.\n"
+        "The <location> value is the absolute path to the skill's SKILL.md file, and "
+        "<directory> is the resolved absolute path to the skill's root directory.\n"
+        "When present, <scripts>, <references>, and <assets> provide resolved absolute paths "
+        "for standard skill resource directories.\n"
+        "When a skill references relative paths, resolve them against the skill's "
+        "directory (the parent of SKILL.md) and use absolute paths in tool calls.\n"
         "Only use Skills listed in <available_skills> below.\n\n"
     )
 

--- a/src/fast_agent/tools/function_tool_loader.py
+++ b/src/fast_agent/tools/function_tool_loader.py
@@ -5,17 +5,98 @@ Loads Python functions from files for use as agent tools.
 Supports both direct callables and string specs like "module.py:function_name".
 """
 
+import asyncio
 import importlib.util
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Self, cast
 
-from mcp.server.fastmcp.tools.base import Tool as FastMCPTool
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.fastmcp.tools.base import Tool as BaseFastMCPTool
+from mcp.shared.exceptions import UrlElicitationRequiredError
+from mcp.types import Icon, ToolAnnotations
 
 from fast_agent.core.exceptions import AgentConfigError
 from fast_agent.core.logging.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class FastMCPTool(BaseFastMCPTool):
+    """fast-agent wrapper around FastMCP tools.
+
+    FastMCP executes synchronous tool functions inline. For local Python function
+    tools that can block on I/O or long-running computation, that would block the
+    MCP server event loop and serialize otherwise independent requests.
+
+    This override preserves FastMCP's schema/validation behavior while offloading
+    synchronous tool bodies to a worker thread.
+    """
+
+    @classmethod
+    def from_function(
+        cls,
+        fn: Callable[..., Any],
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        context_kwarg: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,
+    ) -> Self:
+        return cast(
+            "Self",
+            super().from_function(
+                fn,
+                name=name,
+                title=title,
+                description=description,
+                context_kwarg=context_kwarg,
+                annotations=annotations,
+                icons=icons,
+                meta=meta,
+                structured_output=structured_output,
+            ),
+        )
+
+    async def run(
+        self,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+        convert_result: bool = False,
+    ) -> Any:
+        """Run the tool with validated arguments.
+
+        Async functions are awaited directly.
+        Sync functions are executed via ``asyncio.to_thread`` to keep the event
+        loop responsive while preserving validated argument and context injection.
+        """
+
+        try:
+            arguments_pre_parsed = self.fn_metadata.pre_parse_json(arguments)
+            arguments_parsed_model = self.fn_metadata.arg_model.model_validate(
+                arguments_pre_parsed
+            )
+            arguments_parsed_dict = arguments_parsed_model.model_dump_one_level()
+
+            if self.context_kwarg is not None:
+                arguments_parsed_dict[self.context_kwarg] = context
+
+            if self.is_async:
+                result = await self.fn(**arguments_parsed_dict)
+            else:
+                result = await asyncio.to_thread(self.fn, **arguments_parsed_dict)
+
+            if convert_result:
+                result = self.fn_metadata.convert_result(result)
+
+            return result
+        except UrlElicitationRequiredError:
+            raise
+        except Exception as exc:
+            raise ToolError(f"Error executing tool {self.name}: {exc}") from exc
 
 
 def load_function_from_spec(spec: str, base_path: Path | None = None) -> Callable[..., Any]:

--- a/src/fast_agent/ui/command_payloads.py
+++ b/src/fast_agent/ui/command_payloads.py
@@ -98,6 +98,12 @@ class ShowHistoryCommand(CommandBase):
 
 
 @dataclass(frozen=True, slots=True)
+class HistoryShowCommand(CommandBase):
+    agent: str | None
+    kind: Literal["history_show"] = "history_show"
+
+
+@dataclass(frozen=True, slots=True)
 class ClearCommand(CommandBase):
     kind: Literal["clear_history", "clear_last"]
     agent: str | None
@@ -337,6 +343,7 @@ CommandPayload = (
     | ListPromptsCommand
     | ListSkillsCommand
     | ShowHistoryCommand
+    | HistoryShowCommand
     | ClearCommand
     | SkillsCommand
     | CardsCommand

--- a/src/fast_agent/ui/console_display.py
+++ b/src/fast_agent/ui/console_display.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import contextmanager
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Union
@@ -10,8 +11,9 @@ from rich.panel import Panel
 from rich.text import Text
 
 from fast_agent.config import LoggerSettings, Settings
-from fast_agent.constants import REASONING
+from fast_agent.constants import OPENAI_ASSISTANT_MESSAGE_ITEMS, REASONING
 from fast_agent.core.logging.logger import get_logger
+from fast_agent.types.assistant_message_phase import coerce_assistant_message_phase
 from fast_agent.ui import console
 from fast_agent.ui.display_suppression import (
     display_chat_enabled,
@@ -52,6 +54,8 @@ CODE_STYLE = "native"
 
 # Glyph to indicate tool hooks are active
 HOOK_INDICATOR_GLYPH = "◆"
+
+PHASE_LABELS = {"final_answer": "Final Answer:", "commentary": "Commentary"}
 
 
 class ConsoleDisplay:
@@ -726,6 +730,64 @@ class ConsoleDisplay:
 
         return Text(joined, style="dim italic")
 
+    @staticmethod
+    def _extract_openai_phase_content(message: "PromptMessageExtended") -> str | None:
+        channels = message.channels or {}
+        raw_blocks = (
+            channels.get(OPENAI_ASSISTANT_MESSAGE_ITEMS) if isinstance(channels, Mapping) else None
+        )
+        if not raw_blocks:
+            return None
+
+        sections: list[str] = []
+        saw_phase = False
+
+        for block in raw_blocks:
+            raw_text = getattr(block, "text", None)
+            if not isinstance(raw_text, str) or not raw_text:
+                continue
+
+            try:
+                payload = json.loads(raw_text)
+            except (TypeError, ValueError):
+                continue
+
+            if not isinstance(payload, Mapping) or payload.get("type") != "message":
+                continue
+
+            phase = coerce_assistant_message_phase(payload.get("phase"))
+            content = payload.get("content")
+            if not isinstance(content, list):
+                continue
+
+            text_segments: list[str] = []
+            for part in content:
+                if not isinstance(part, Mapping):
+                    continue
+                part_type = part.get("type")
+                part_text = part.get("text")
+                if (
+                    part_type in {"output_text", "text"}
+                    and isinstance(part_text, str)
+                    and part_text
+                ):
+                    text_segments.append(part_text)
+
+            section_text = "".join(text_segments).strip()
+            if not section_text:
+                continue
+
+            if phase is not None:
+                saw_phase = True
+                phase_label = PHASE_LABELS.get(phase, phase)
+                sections.append(f"▎{phase_label} {section_text}")
+            else:
+                sections.append(section_text)
+
+        if not sections or not saw_phase:
+            return None
+        return "\n\n".join(sections)
+
     async def show_assistant_message(
         self,
         message_text: Union[str, Text, "PromptMessageExtended"],
@@ -765,7 +827,12 @@ class ConsoleDisplay:
         if isinstance(message_text, PromptMessageExtended):
             # Prefer full assistant text so streamed/finalized multi-block responses
             # (e.g., provider-side web tool turns) are preserved after live refresh.
-            display_text = message_text.all_text() or message_text.last_text() or ""
+            display_text = (
+                self._extract_openai_phase_content(message_text)
+                or message_text.all_text()
+                or message_text.last_text()
+                or ""
+            )
             pre_content = self._extract_reasoning_content(message_text)
         else:
             display_text = message_text

--- a/src/fast_agent/ui/history_display.py
+++ b/src/fast_agent/ui/history_display.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from rich import print as rich_print
 from rich.text import Text
 
+from fast_agent.commands.history_summaries import build_history_turn_report
 from fast_agent.constants import FAST_AGENT_TIMING, FAST_AGENT_TOOL_TIMING
 from fast_agent.mcp.helpers.content_helpers import get_text
 from fast_agent.types.conversation_summary import ConversationSummary
@@ -23,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 NON_TEXT_MARKER = "^"
 TIMELINE_WIDTH = 20
-SUMMARY_COUNT = 8
+SUMMARY_COUNT = 12
 ROLE_COLUMN_WIDTH = 17
 
 
@@ -292,6 +293,12 @@ def format_time(value: float | None) -> str:
     if value < 1000:
         return f"{value:.0f}ms"
     return f"{value / 1000:.1f}s"
+
+
+def _format_tps(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.1f}"
 
 
 def _build_history_rows(history: Sequence[PromptMessageExtended]) -> list[dict]:
@@ -602,23 +609,47 @@ def _render_statistics(
     printer("")
 
 
-def display_history_overview(
-    agent_name: str,
-    history: Sequence[PromptMessageExtended],
-    usage_accumulator: "UsageAccumulator" | None = None,
+def _render_turn_statistics(
     *,
-    console: Console | None = None,
+    turn_count: int,
+    total_turn_time_ms: float,
+    total_tool_time_ms: float,
+    average_ttft_ms: float | None,
+    average_response_ms: float | None,
+    average_tps: float | None,
+    printer,
 ) -> None:
-    if not history:
-        printer = console.print if console else rich_print
-        printer("[dim]No conversation history yet[/dim]")
-        return
+    summary_line = Text("  ", style="dim")
+    summary_line.append("Turns: ", style="dim")
+    summary_line.append(str(turn_count), style="default")
+    summary_line.append("  •  ", style="dim")
+    summary_line.append("Turn Time: ", style="dim")
+    summary_line.append(format_time(total_turn_time_ms if total_turn_time_ms > 0 else None), style="default")
+    summary_line.append("  •  ", style="dim")
+    summary_line.append("Tool Time: ", style="dim")
+    summary_line.append(format_time(total_tool_time_ms if total_tool_time_ms > 0 else None), style="default")
+    printer(summary_line)
 
-    printer = console.print if console else rich_print
+    detail_line = Text("  ", style="dim")
+    detail_line.append("Avg TTFT: ", style="dim")
+    detail_line.append(format_time(average_ttft_ms), style="default")
+    detail_line.append("  •  ", style="dim")
+    detail_line.append("Avg Resp: ", style="dim")
+    detail_line.append(format_time(average_response_ms), style="default")
+    detail_line.append("  •  ", style="dim")
+    detail_line.append("Avg TPS: ", style="dim")
+    detail_line.append(_format_tps(average_tps), style="default")
+    printer(detail_line)
+    printer("")
 
-    # Create conversation summary for statistics
-    summary = ConversationSummary(messages=list(history))
 
+def _render_history_chrome(
+    history: Sequence[PromptMessageExtended],
+    usage_accumulator: "UsageAccumulator" | None,
+    *,
+    console: Console | None,
+    printer,
+) -> None:
     rows = _build_history_rows(history)
     timeline_entries = _aggregate_timeline_entries(rows)
 
@@ -630,11 +661,6 @@ def display_history_overview(
         current_tokens = 0
         window = None
     context_bar, context_detail = _build_context_bar_line(current_tokens, window)
-
-    _render_header_line(agent_name, console=console, printer=printer)
-
-    # Render conversation statistics
-    _render_statistics(summary, console=console, printer=printer)
 
     gap = Text("   ")
     combined_line = Text()
@@ -666,6 +692,35 @@ def display_history_overview(
         Text(" " + "─" * (history_bar.cell_len + context_bar.cell_len + gap.cell_len), style="dim")
     )
 
+
+def display_history_overview(
+    agent_name: str,
+    history: Sequence[PromptMessageExtended],
+    usage_accumulator: "UsageAccumulator" | None = None,
+    *,
+    console: Console | None = None,
+) -> None:
+    if not history:
+        printer = console.print if console else rich_print
+        printer("[dim]No conversation history yet[/dim]")
+        return
+
+    printer = console.print if console else rich_print
+
+    # Create conversation summary for statistics
+    summary = ConversationSummary(messages=list(history))
+    rows = _build_history_rows(history)
+
+    # Render conversation statistics
+    _render_header_line(agent_name, console=console, printer=printer)
+    _render_statistics(summary, console=console, printer=printer)
+    _render_history_chrome(
+        history,
+        usage_accumulator,
+        console=console,
+        printer=printer,
+    )
+
     summary_candidates = [row for row in rows if not row.get("hide_summary")]
     summary_rows = summary_candidates[-SUMMARY_COUNT:]
     start_index = len(summary_candidates) - len(summary_rows) + 1
@@ -678,7 +733,6 @@ def display_history_overview(
     except Exception:
         total_width = 80
 
-    # Responsive column layout based on terminal width
     show_time = total_width >= 60
     show_chars = total_width >= 50
 
@@ -735,6 +789,85 @@ def display_history_overview(
             max_width=summary_width,
         )
         line.append_text(summary_text)
+        printer(line)
+
+    printer("")
+
+
+def display_history_show(
+    agent_name: str,
+    history: Sequence[PromptMessageExtended],
+    usage_accumulator: "UsageAccumulator" | None = None,
+    *,
+    console: Console | None = None,
+) -> None:
+    if not history:
+        printer = console.print if console else rich_print
+        printer("[dim]No conversation history yet[/dim]")
+        return
+
+    printer = console.print if console else rich_print
+
+    turn_report = build_history_turn_report(list(history))
+    _render_header_line(agent_name, console=console, printer=printer)
+    _render_turn_statistics(
+        turn_count=turn_report.turn_count,
+        total_turn_time_ms=turn_report.total_turn_time_ms,
+        total_tool_time_ms=turn_report.total_tool_time_ms,
+        average_ttft_ms=turn_report.average_ttft_ms,
+        average_response_ms=turn_report.average_response_ms,
+        average_tps=turn_report.average_tps,
+        printer=printer,
+    )
+    _render_history_chrome(
+        history,
+        usage_accumulator,
+        console=console,
+        printer=printer,
+    )
+
+    if not turn_report.turns:
+        printer("[dim]No user turns yet[/dim]")
+        printer("")
+        return
+
+    try:
+        total_width = console.width if console else get_terminal_size().columns
+    except Exception:
+        total_width = 100
+
+    fixed_columns = 3 + 8 + 8 + 8 + 8 + 7
+    preview_width = max(24, total_width - fixed_columns - 10)
+
+    header_line = Text(" ")
+    header_line.append(f"{'#':>2}", style="dim")
+    header_line.append(" ", style="dim")
+    header_line.append(f"{'Turn':<{preview_width}}", style="dim")
+    header_line.append(f" {'Turn':>7}", style="dim")
+    header_line.append(f" {'Tool':>7}", style="dim")
+    header_line.append(f" {'TTFT':>7}", style="dim")
+    header_line.append(f" {'Resp':>7}", style="dim")
+    header_line.append(f" {'TPS':>6}", style="dim")
+    printer(header_line)
+
+    for turn in turn_report.turns:
+        turn_preview = Text()
+        turn_preview.append(turn.user_snippet, style=Colours.USER)
+        turn_preview.append(" → ", style="dim")
+        turn_preview.append(turn.assistant_snippet, style=Colours.ASSISTANT)
+        preview_text = _truncate_text_segment(turn_preview, preview_width)
+
+        line = Text(" ")
+        line.append(f"{turn.turn_index:>2}", style="dim")
+        line.append(" ")
+        line.append_text(preview_text)
+        if preview_text.cell_len < preview_width:
+            line.append(" " * (preview_width - preview_text.cell_len))
+        line.append(f" {format_time(turn.turn_time_ms):>7}", style="dim")
+        line.append(f" {format_time(turn.tool_time_ms):>7}", style="dim")
+        line.append(f" {format_time(turn.ttft_ms):>7}", style="dim")
+        line.append(f" {format_time(turn.response_ms):>7}", style="dim")
+        line.append(f" {_format_tps(turn.tps):>6}", style="dim")
         printer(line)
 
     printer("")

--- a/src/fast_agent/ui/interactive/command_dispatch.py
+++ b/src/fast_agent/ui/interactive/command_dispatch.py
@@ -33,6 +33,7 @@ from fast_agent.ui.command_payloads import (
     HistoryFixCommand,
     HistoryReviewCommand,
     HistoryRewindCommand,
+    HistoryShowCommand,
     HistoryWebClearCommand,
     InterruptCommand,
     ListPromptsCommand,
@@ -68,6 +69,7 @@ from fast_agent.ui.command_payloads import (
     TitleSessionCommand,
     UnknownCommand,
 )
+from fast_agent.ui.history_display import display_history_show
 
 from .command_context import build_command_context, emit_command_outcome
 from .mcp_connect_flow import handle_mcp_connect
@@ -245,6 +247,15 @@ async def dispatch_command_payload(
                 target_agent=target_agent,
             )
             await emit_command_outcome(context, outcome)
+            return result
+        case HistoryShowCommand(agent=target_agent):
+            target_name = target_agent or agent
+            target = owner._get_agent_or_warn(prompt_provider, target_name)
+            if target is None:
+                return result
+            history = list(getattr(target, "message_history", []))
+            usage = getattr(target, "usage_accumulator", None)
+            display_history_show(target_name, history, usage)
             return result
         case HistoryRewindCommand(turn_index=turn_index, error=error):
             context = build_command_context(prompt_provider, agent)

--- a/src/fast_agent/ui/message_styles.py
+++ b/src/fast_agent/ui/message_styles.py
@@ -285,7 +285,7 @@ class A3MessageStyle:
 
     def metadata_line(self, content: Text, width: int) -> Text:  # noqa: ARG002
         line = Text()
-        line.append("▎• ", style="dim")
+        line.append("  ", style="dim")
         line.append_text(content)
         return line
 
@@ -304,7 +304,7 @@ class A3MessageStyle:
         if max_item_length:
             display_items = _shorten_items(items, max_item_length)
 
-        prefix = Text("▎• ", style="dim")
+        prefix = Text("▎ ", style="dim")
         available = max(0, width - prefix.cell_len)
 
         metadata_text = _format_bottom_metadata_compact(

--- a/src/fast_agent/ui/prompt/command_help.py
+++ b/src/fast_agent/ui/prompt/command_help.py
@@ -33,7 +33,8 @@ def render_help_lines(*, show_webclear_help: bool) -> list[str]:
         "  /model aliases set [<token> [<model-spec>]] [--target env|project] [--dry-run]",
         "  /model aliases unset [<token>] [--target env|project] [--dry-run]",
         "  /model catalog <provider> [--all] - Show curated/all models for a provider",
-        "  /history [agent_name] - Show chat history overview",
+        "  /history [agent_name] - Show chat history overview (quote names that match subcommands)",
+        "  /history show [agent_name] - Show per-turn timing summaries",
         "  /history clear all [agent_name] - Clear conversation history (keeps templates)",
         "  /history clear last [agent_name] - Remove the most recent message from history",
         "  /markdown      - Show last assistant message without markdown formatting",
@@ -55,7 +56,7 @@ def render_help_lines(*, show_webclear_help: bool) -> list[str]:
         "      [dim]Default: Timestamped filename (e.g., 25_01_15_14_30-conversation.json)[/dim]",
         "  /history load <filename> - Load chat history from a file",
         "  /history rewind <turn> - Rewind to a prior user turn",
-        "  /history review <turn> - Review a prior user turn in full",
+        "  /history detail <turn> - Show a prior user turn in full",
         "  /history fix [agent_name] - Remove the last pending tool call",
     ]
     if show_webclear_help:

--- a/src/fast_agent/ui/prompt/completer.py
+++ b/src/fast_agent/ui/prompt/completer.py
@@ -67,7 +67,10 @@ class AgentCompleter(Completer):
         self.commands = {
             "mcp": "Manage MCP runtime servers (/mcp list|connect|disconnect|reconnect|session)",
             "connect": "Alias for /mcp connect with target auto-detection",
-            "history": "Show conversation history overview (or /history save|load|clear|rewind|review|fix)",
+            "history": (
+                "Show conversation history overview "
+                "(or /history show|detail|save|load|clear|rewind|fix)"
+            ),
             "tools": "List tools",
             "model": (
                 "Inspect/switch models and update runtime settings "

--- a/src/fast_agent/ui/prompt/completion_sources.py
+++ b/src/fast_agent/ui/prompt/completion_sources.py
@@ -100,6 +100,10 @@ def command_completions(
         partial = text[len("/history rewind ") :]
         return list(completer._complete_history_rewind(partial))
 
+    if text_lower.startswith("/history detail "):
+        partial = text[len("/history detail ") :]
+        return list(completer._complete_history_rewind(partial))
+
     if text_lower.startswith("/history review "):
         partial = text[len("/history review ") :]
         return list(completer._complete_history_rewind(partial))
@@ -787,12 +791,12 @@ def command_completions(
     if text_lower.startswith("/history "):
         partial = text[len("/history ") :]
         subcommands = {
-            "show": "Show history overview",
+            "show": "Show per-turn timing summaries",
+            "detail": "Show a previous user turn in full",
             "save": "Save history to a file",
             "load": "Load history from a file",
             "clear": "Clear history (all or last)",
             "rewind": "Rewind to a previous user turn",
-            "review": "Review a previous user turn in full",
             "fix": "Remove the last pending tool call",
         }
         if completer._current_agent_has_web_tools_enabled():

--- a/src/fast_agent/ui/prompt/parser.py
+++ b/src/fast_agent/ui/prompt/parser.py
@@ -20,6 +20,7 @@ from fast_agent.ui.command_payloads import (
     HistoryFixCommand,
     HistoryReviewCommand,
     HistoryRewindCommand,
+    HistoryShowCommand,
     HistoryWebClearCommand,
     ListSessionsCommand,
     ListToolsCommand,
@@ -103,6 +104,26 @@ def _rebuild_mcp_target_text(tokens: list[str]) -> str:
     return " ".join(rebuilt_parts)
 
 
+def _parse_quoted_history_target(text: str) -> str | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+
+    try:
+        tokens = shlex.split(stripped)
+    except ValueError:
+        return None
+
+    if len(tokens) != 1:
+        return None
+
+    # Allow explicit quoting/escaping to force agent-name parsing for values
+    # that would otherwise collide with /history subcommands.
+    if stripped == tokens[0]:
+        return None
+    return tokens[0]
+
+
 def _parse_mcp_single_server_name(tokens: list[str], *, usage: str) -> tuple[str | None, str | None]:
     name = tokens[1] if len(tokens) > 1 else None
     error = None if name else usage
@@ -144,6 +165,9 @@ def parse_special_input(text: str) -> str | CommandPayload:
             remainder = cmd_parts[1].strip() if len(cmd_parts) > 1 else ""
             if not remainder:
                 return ShowHistoryCommand(agent=None)
+            quoted_target = _parse_quoted_history_target(remainder)
+            if quoted_target is not None:
+                return ShowHistoryCommand(agent=quoted_target)
             try:
                 tokens = shlex.split(remainder)
             except ValueError:
@@ -154,7 +178,7 @@ def parse_special_input(text: str) -> str | CommandPayload:
             subcmd = tokens[0].lower()
             argument = " ".join(tokens[1:]).strip()
             if subcmd == "show":
-                return ShowHistoryCommand(agent=argument or None)
+                return HistoryShowCommand(agent=argument or None)
             if subcmd == "save":
                 return SaveHistoryCommand(filename=argument or None)
             if subcmd == "load":
@@ -164,16 +188,19 @@ def parse_special_input(text: str) -> str | CommandPayload:
                         error="Filename required for /history load",
                     )
                 return LoadHistoryCommand(filename=argument, error=None)
-            if subcmd == "review":
+            if subcmd in {"detail", "review"}:
                 if not argument:
                     return HistoryReviewCommand(
                         turn_index=None,
-                        error="Turn number required for /history review",
+                        error="Turn number required for /history detail",
                     )
                 try:
                     turn_index = int(argument)
                 except ValueError:
-                    return HistoryReviewCommand(turn_index=None, error="Turn number must be an integer")
+                    return HistoryReviewCommand(
+                        turn_index=None,
+                        error="Turn number must be an integer",
+                    )
                 return HistoryReviewCommand(turn_index=turn_index, error=None)
             if subcmd == "fix":
                 return HistoryFixCommand(agent=argument or None)

--- a/src/fast_agent/ui/refactor/history_utils.py
+++ b/src/fast_agent/ui/refactor/history_utils.py
@@ -1,9 +1,11 @@
 """History utilities for interactive prompt (wrapper for refactor utilities)."""
 
-from fast_agent.commands.handlers.history import (
-    _collect_user_turns,
-    _group_turns_for_history_actions,
-    _trim_history_for_rewind,
+from fast_agent.commands.handlers.history import _trim_history_for_rewind
+from fast_agent.commands.history_summaries import (
+    collect_user_turns as _collect_user_turns,
+)
+from fast_agent.commands.history_summaries import (
+    group_history_turns as _group_turns_for_history_actions,
 )
 from fast_agent.ui.history_actions import display_history_turn as _display_history_turn
 

--- a/tests/integration/acp/test_acp_slash_commands.py
+++ b/tests/integration/acp/test_acp_slash_commands.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
-from mcp.types import TextContent
+from mcp.types import CallToolRequest, CallToolRequestParams, CallToolResult, TextContent
 
 from fast_agent.acp.slash_commands import SlashCommandHandler
 from fast_agent.agents.agent_types import AgentType
@@ -21,6 +21,9 @@ from fast_agent.constants import (
     ANTHROPIC_CITATIONS_CHANNEL,
     ANTHROPIC_SERVER_TOOLS_CHANNEL,
     FAST_AGENT_ERROR_CHANNEL,
+    FAST_AGENT_TIMING,
+    FAST_AGENT_TOOL_TIMING,
+    FAST_AGENT_USAGE,
 )
 from fast_agent.llm.provider_types import Provider
 from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
@@ -669,7 +672,7 @@ async def test_slash_command_history_webclear_hidden_when_disabled() -> None:
     response = await handler.execute_command("history", "webclear")
 
     assert "unknown /history action: webclear" in response.lower()
-    assert "usage: /history [show|save|load]" in response.lower()
+    assert "usage: /history [show|detail <turn>|save|load]" in response.lower()
 
 
 @pytest.mark.integration
@@ -686,6 +689,118 @@ async def test_slash_command_history_available_in_commands() -> None:
     history_cmd = next(cmd for cmd in commands if cmd.name == "history")
     assert history_cmd.description
     assert history_cmd.input is not None  # Should have input hint
+    assert history_cmd.input.root.hint == "[show|detail <turn>|save|load] [args]"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_slash_command_history_show_turn_summary() -> None:
+    messages = [
+        PromptMessageExtended(
+            role="user",
+            content=[TextContent(type="text", text="first question")],
+        ),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="looking that up")],
+            tool_calls={
+                "call_1": CallToolRequest(
+                    method="tools/call",
+                    params=CallToolRequestParams(name="lookup", arguments={}),
+                )
+            },
+            channels={
+                FAST_AGENT_TIMING: [
+                    TextContent(
+                        type="text",
+                        text='{"start_time": 10.0, "end_time": 10.4, "duration_ms": 400, "ttft_ms": 120, "time_to_response_ms": 260}',
+                    )
+                ],
+                FAST_AGENT_USAGE: [
+                    TextContent(
+                        type="text",
+                        text='{"turn": {"output_tokens": 8}, "raw_usage": {}, "summary": {}}',
+                    )
+                ],
+            },
+        ),
+        PromptMessageExtended(
+            role="user",
+            tool_results={
+                "call_1": CallToolResult(
+                    content=[TextContent(type="text", text="result")],
+                    isError=False,
+                )
+            },
+            channels={
+                FAST_AGENT_TOOL_TIMING: [
+                    TextContent(
+                        type="text",
+                        text='{"call_1": {"timing_ms": 250, "transport_channel": "post-sse"}}',
+                    )
+                ]
+            },
+        ),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="final answer")],
+            channels={
+                FAST_AGENT_TIMING: [
+                    TextContent(
+                        type="text",
+                        text='{"start_time": 10.65, "end_time": 11.15, "duration_ms": 500}',
+                    )
+                ],
+                FAST_AGENT_USAGE: [
+                    TextContent(
+                        type="text",
+                        text='{"turn": {"output_tokens": 12}, "raw_usage": {}, "summary": {}}',
+                    )
+                ],
+            },
+        ),
+    ]
+    stub_agent = StubAgent(message_history=messages.copy())
+    instance = StubAgentInstance(agents={"test-agent": stub_agent})
+
+    handler = _handler(instance)
+
+    response = await handler.execute_command("history", "show")
+
+    assert "history show" in response.lower()
+    assert "| # | turn | time | tool | ttft | resp | tps |" in response.lower()
+    assert "first question" in response
+    assert "final answer" in response
+    assert "1.1s" in response
+    assert "250ms" in response
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_slash_command_history_detail_turn() -> None:
+    messages = [
+        PromptMessageExtended(role="user", content=[TextContent(type="text", text="first question")]),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="first answer")],
+        ),
+        PromptMessageExtended(role="user", content=[TextContent(type="text", text="second question")]),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="second answer")],
+        ),
+    ]
+    stub_agent = StubAgent(message_history=messages.copy())
+    instance = StubAgentInstance(agents={"test-agent": stub_agent})
+
+    handler = _handler(instance)
+
+    response = await handler.execute_command("history", "detail 2")
+
+    assert "history detail" in response.lower()
+    assert "turn 2" in response.lower()
+    assert "second question" in response
+    assert "second answer" in response
 
 
 @pytest.mark.integration

--- a/tests/unit/fast_agent/agents/test_mcp_agent_skills.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_skills.py
@@ -316,6 +316,10 @@ def test_format_skills_for_prompt_standard_format(tmp_path: Path) -> None:
     """Test that format_skills_for_prompt outputs Agent Skills standard format."""
     skills_root = tmp_path / "skills"
     create_skill(skills_root, "test-skill", description="Test description")
+    skill_dir = skills_root / "test-skill"
+    (skill_dir / "scripts").mkdir()
+    (skill_dir / "references").mkdir()
+    (skill_dir / "assets").mkdir()
 
     manifests = SkillRegistry.load_directory(skills_root)
     prompt = format_skills_for_prompt(manifests)
@@ -329,9 +333,19 @@ def test_format_skills_for_prompt_standard_format(tmp_path: Path) -> None:
     assert "<description>Test description</description>" in prompt
     assert "<location>" in prompt
     assert "</location>" in prompt
+    assert f"<directory>{skill_dir}</directory>" in prompt
+    assert f"<scripts>{skill_dir / 'scripts'}</scripts>" in prompt
+    assert f"<references>{skill_dir / 'references'}</references>" in prompt
+    assert f"<assets>{skill_dir / 'assets'}</assets>" in prompt
 
     # Check preamble mentions read_skill tool by default
     assert "read_skill" in prompt
+    assert "Prefer that file-reading tool over shell commands" in prompt
+    assert "<directory> is the resolved absolute path to the skill's root directory" in prompt
+    assert "<scripts>, <references>, and <assets>" in prompt
+    assert "resolve them against the skill's" in prompt
+    assert "directory (the parent of SKILL.md)" in prompt
+    assert "use absolute paths in tool calls" in prompt
 
 
 def test_format_skills_for_prompt_custom_read_tool(tmp_path: Path) -> None:

--- a/tests/unit/fast_agent/commands/test_history_summaries.py
+++ b/tests/unit/fast_agent/commands/test_history_summaries.py
@@ -1,0 +1,125 @@
+import json
+
+from mcp.types import CallToolRequest, CallToolRequestParams, CallToolResult, TextContent
+
+from fast_agent.commands.history_summaries import build_history_turn_report
+from fast_agent.constants import FAST_AGENT_TIMING, FAST_AGENT_TOOL_TIMING, FAST_AGENT_USAGE
+from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
+
+
+def _timing_payload(
+    *,
+    start_time: float,
+    end_time: float,
+    duration_ms: float,
+    ttft_ms: float | None = None,
+    time_to_response_ms: float | None = None,
+) -> dict[str, float]:
+    payload: dict[str, float] = {
+        "start_time": start_time,
+        "end_time": end_time,
+        "duration_ms": duration_ms,
+    }
+    if ttft_ms is not None:
+        payload["ttft_ms"] = ttft_ms
+    if time_to_response_ms is not None:
+        payload["time_to_response_ms"] = time_to_response_ms
+    return payload
+
+
+def _usage_payload(output_tokens: int) -> str:
+    return json.dumps({"turn": {"output_tokens": output_tokens}, "raw_usage": {}, "summary": {}})
+
+
+def test_build_history_turn_report_calculates_turn_metrics() -> None:
+    messages = [
+        PromptMessageExtended(
+            role="user",
+            content=[TextContent(type="text", text="Find the answer")],
+        ),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="Checking...")],
+            tool_calls={
+                "call_1": CallToolRequest(
+                    method="tools/call",
+                    params=CallToolRequestParams(name="lookup", arguments={}),
+                )
+            },
+            channels={
+                FAST_AGENT_TIMING: [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            _timing_payload(
+                                start_time=10.0,
+                                end_time=10.4,
+                                duration_ms=400,
+                                ttft_ms=100,
+                                time_to_response_ms=160,
+                            )
+                        ),
+                    )
+                ],
+                FAST_AGENT_USAGE: [TextContent(type="text", text=_usage_payload(8))],
+            },
+        ),
+        PromptMessageExtended(
+            role="user",
+            tool_results={
+                "call_1": CallToolResult(
+                    content=[TextContent(type="text", text="result")],
+                    isError=False,
+                )
+            },
+            channels={
+                FAST_AGENT_TOOL_TIMING: [
+                    TextContent(
+                        type="text",
+                        text='{"call_1": {"timing_ms": 250, "transport_channel": "post-sse"}}',
+                    )
+                ]
+            },
+        ),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="Done")],
+            channels={
+                FAST_AGENT_TIMING: [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            _timing_payload(
+                                start_time=10.65,
+                                end_time=11.15,
+                                duration_ms=500,
+                            )
+                        ),
+                    )
+                ],
+                FAST_AGENT_USAGE: [TextContent(type="text", text=_usage_payload(12))],
+            },
+        ),
+    ]
+
+    report = build_history_turn_report(messages)
+
+    assert report.turn_count == 1
+    assert report.total_tool_calls == 1
+    assert report.total_tool_errors == 0
+    assert report.total_llm_time_ms == 900
+    assert report.total_tool_time_ms == 250
+    assert report.total_turn_time_ms == 1150
+    assert report.average_ttft_ms == 100
+    assert report.average_response_ms == 160
+
+    turn = report.turns[0]
+    assert turn.user_snippet == "Find the answer"
+    assert turn.assistant_snippet == "Done"
+    assert turn.turn_time_ms == 1150
+    assert turn.tool_time_ms == 250
+    assert turn.ttft_ms == 100
+    assert turn.response_ms == 160
+    assert turn.output_tokens == 20
+    assert turn.tps is not None
+    assert round(turn.tps, 1) == 27.0

--- a/tests/unit/fast_agent/commands/test_skills_command.py
+++ b/tests/unit/fast_agent/commands/test_skills_command.py
@@ -357,6 +357,7 @@ def test_skills_update_applies_local_repo_changes(tmp_path: Path) -> None:
         check_result = runner.invoke(skills_command.app, ["update"], terminal_width=200)
         assert check_result.exit_code == 0, check_result.output
         assert "update available" in check_result.output
+        assert "▎•" not in check_result.output
 
         apply_result = runner.invoke(skills_command.app, ["update", "alpha"], terminal_width=200)
         assert apply_result.exit_code == 0, apply_result.output

--- a/tests/unit/fast_agent/llm/providers/test_responses_helpers.py
+++ b/tests/unit/fast_agent/llm/providers/test_responses_helpers.py
@@ -118,8 +118,6 @@ class _LoggerSpy:
         self.warning_calls.append((message, data))
 
 
-
-
 def test_convert_tool_calls_serializes_apply_patch_as_custom_tool_call() -> None:
     harness = _ContentHarness()
     harness._tool_kind_map["call_patch"] = "custom"
@@ -132,10 +130,7 @@ def test_convert_tool_calls_serializes_apply_patch_as_custom_tool_call() -> None
                     name="apply_patch",
                     arguments={
                         "input": (
-                            "*** Begin Patch\n"
-                            "*** Add File: hello.txt\n"
-                            "+hello\n"
-                            "*** End Patch\n"
+                            "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"
                         )
                     },
                 ),
@@ -148,12 +143,7 @@ def test_convert_tool_calls_serializes_apply_patch_as_custom_tool_call() -> None
             "type": "custom_tool_call",
             "call_id": "call_patch",
             "name": "apply_patch",
-            "input": (
-                "*** Begin Patch\n"
-                "*** Add File: hello.txt\n"
-                "+hello\n"
-                "*** End Patch"
-            ),
+            "input": ("*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch"),
         }
     ]
 
@@ -230,12 +220,7 @@ def test_extract_custom_tool_call_maps_apply_patch_input() -> None:
                 id="ctc_123",
                 call_id="call_patch",
                 name="apply_patch",
-                input=(
-                    "*** Begin Patch\n"
-                    "*** Add File: hello.txt\n"
-                    "+hello\n"
-                    "*** End Patch\n"
-                ),
+                input=("*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"),
             )
         ]
     )
@@ -245,12 +230,7 @@ def test_extract_custom_tool_call_maps_apply_patch_input() -> None:
     request = tool_calls["call_patch"]
     assert request.params.name == "apply_patch"
     assert request.params.arguments == {
-        "input": (
-            "*** Begin Patch\n"
-            "*** Add File: hello.txt\n"
-            "+hello\n"
-            "*** End Patch\n"
-        )
+        "input": ("*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n")
     }
 
 
@@ -518,8 +498,6 @@ def test_tool_fallback_notifications():
     assert events[0][1]["tool_name"] == "weather"
 
 
-
-
 def test_tool_fallback_notifications_for_custom_tool_call() -> None:
     harness = _StreamingHarness()
     tool_call = SimpleNamespace(
@@ -534,6 +512,7 @@ def test_tool_fallback_notifications_for_custom_tool_call() -> None:
     assert [event for event, _payload in events] == ["start", "stop"]
     assert events[0][1]["tool_use_id"] == "call_patch"
     assert events[0][1]["tool_name"] == "apply_patch"
+
 
 def test_dedupes_duplicate_reasoning_ids():
     harness = _ContentHarness()
@@ -561,9 +540,7 @@ def test_extract_raw_assistant_message_items_preserves_phase_metadata() -> None:
                 role="assistant",
                 status="completed",
                 phase="commentary",
-                content=[
-                    SimpleNamespace(type="output_text", text="Let me inspect that first.")
-                ],
+                content=[SimpleNamespace(type="output_text", text="Let me inspect that first.")],
             )
         ]
     )
@@ -613,9 +590,7 @@ def test_convert_extended_messages_to_provider_uses_raw_assistant_items_channel(
         role="assistant",
         content=[TextContent(type="text", text="Final answer")],
         channels={
-            OPENAI_ASSISTANT_MESSAGE_ITEMS: [
-                TextContent(type="text", text=json.dumps(raw_item))
-            ]
+            OPENAI_ASSISTANT_MESSAGE_ITEMS: [TextContent(type="text", text=json.dumps(raw_item))]
         },
     )
 
@@ -1008,6 +983,7 @@ def test_codexresponses_request_service_tier_rejects_flex() -> None:
             tools=None,
         )
 
+
 def test_responses_chatgpt_request_service_tier_rejects_flex() -> None:
     llm = _build_responses_family_llm(
         Provider.RESPONSES,
@@ -1224,9 +1200,7 @@ async def test_stream_process_emits_web_search_status_events() -> None:
     assert event_types.count("stop") >= 1
 
     first_start_payload = next(
-        payload
-        for event_type, payload in harness.events
-        if event_type == "start"
+        payload for event_type, payload in harness.events if event_type == "start"
     )
     assert first_start_payload["tool_name"] == "web_search"
     assert first_start_payload["tool_display_name"] == "Searching the web"

--- a/tests/unit/fast_agent/llm/providers/test_responses_websocket.py
+++ b/tests/unit/fast_agent/llm/providers/test_responses_websocket.py
@@ -23,10 +23,12 @@ from fast_agent.llm.provider.openai.responses_websocket import (
     WebSocketResponsesStream,
     _AttrObjectView,
     build_ws_headers,
+    connect_websocket,
     resolve_responses_ws_url,
     send_response_create,
     send_response_request,
 )
+from fast_agent.llm.provider.openai.streaming_utils import with_stream_idle_timeout
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.request_params import RequestParams
 
@@ -40,6 +42,23 @@ class _FakeSession:
 
     async def close(self) -> None:
         self.closed = True
+
+
+class _SlowConnectSession(_FakeSession):
+    def __init__(self, delay_seconds: float) -> None:
+        super().__init__()
+        self.delay_seconds = delay_seconds
+
+    async def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        autoping: bool,
+    ) -> _FakeWebSocket:
+        del url, headers, autoping
+        await asyncio.sleep(self.delay_seconds)
+        return _FakeWebSocket()
 
 
 class _FakeWebSocket:
@@ -73,6 +92,13 @@ class _FakeWebSocket:
 
     def exception(self) -> BaseException | None:
         return self._exception
+
+
+class _HangingWebSocket(_FakeWebSocket):
+    async def receive(self, timeout: float | None = None) -> SimpleNamespace:
+        del timeout
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
 
 
 class _FakeResponsesClient:
@@ -167,6 +193,34 @@ class _CapturingDisplay:
         self.status_messages.append(getattr(content, "plain", str(content)))
 
 
+class _DelayedStream:
+    def __init__(self, delays: list[float], values: list[str]) -> None:
+        self._delays = delays
+        self._values = values
+        self._index = 0
+
+    def __aiter__(self) -> _DelayedStream:
+        return self
+
+    async def __anext__(self) -> str:
+        if self._index >= len(self._values):
+            raise StopAsyncIteration
+        delay = self._delays[self._index]
+        value = self._values[self._index]
+        self._index += 1
+        await asyncio.sleep(delay)
+        return value
+
+
+class _FinalResponseDelayedStream(_DelayedStream):
+    def __init__(self, delays: list[float], values: list[str], final_response: object) -> None:
+        super().__init__(delays, values)
+        self._final_response = final_response
+
+    async def get_final_response(self) -> object:
+        return self._final_response
+
+
 @pytest.mark.asyncio
 async def test_send_response_create_envelope() -> None:
     websocket = _FakeWebSocket()
@@ -181,6 +235,80 @@ async def test_send_response_create_envelope() -> None:
     assert payload["type"] == "response.create"
     assert "stream" not in payload
     assert payload["model"] == "gpt-5.3-codex"
+
+
+@pytest.mark.asyncio
+async def test_connect_websocket_applies_timeout_during_handshake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_sessions: list[_SlowConnectSession] = []
+
+    def _client_session_factory(*, timeout: Any) -> _SlowConnectSession:
+        del timeout
+        session = _SlowConnectSession(delay_seconds=0.05)
+        created_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "fast_agent.llm.provider.openai.responses_websocket.aiohttp.ClientSession",
+        _client_session_factory,
+    )
+
+    with pytest.raises(TimeoutError):
+        await connect_websocket(
+            url="wss://api.openai.com/v1/responses",
+            headers={"Authorization": "Bearer test"},
+            timeout_seconds=0.01,
+        )
+
+    assert len(created_sessions) == 1
+    assert created_sessions[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_with_stream_idle_timeout_allows_long_active_stream() -> None:
+    timed_stream = with_stream_idle_timeout(
+        _DelayedStream(delays=[0.005, 0.005, 0.005], values=["a", "b", "c"]),
+        idle_timeout_seconds=0.01,
+        timeout_message="idle timeout",
+    )
+
+    observed = [event async for event in timed_stream]
+
+    assert observed == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_with_stream_idle_timeout_raises_when_stream_goes_idle() -> None:
+    timed_stream = with_stream_idle_timeout(
+        _DelayedStream(delays=[0.005, 0.02], values=["a", "b"]),
+        idle_timeout_seconds=0.01,
+        timeout_message="idle timeout",
+    )
+
+    iterator = timed_stream.__aiter__()
+    assert await iterator.__anext__() == "a"
+    with pytest.raises(TimeoutError, match="idle timeout"):
+        await iterator.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_with_stream_idle_timeout_preserves_get_final_response() -> None:
+    final_response = object()
+    timed_stream = with_stream_idle_timeout(
+        _FinalResponseDelayedStream(
+            delays=[0.005],
+            values=["a"],
+            final_response=final_response,
+        ),
+        idle_timeout_seconds=0.01,
+        timeout_message="idle timeout",
+    )
+
+    observed = [event async for event in timed_stream]
+
+    assert observed == ["a"]
+    assert await cast("Any", timed_stream).get_final_response() is final_response
 
 
 @pytest.mark.asyncio
@@ -788,14 +916,18 @@ class _ConnectionLifecycleHarness(ResponsesLLM):
 
 
 class _TimeoutLifecycleHarness(_ConnectionLifecycleHarness):
+    def __init__(self) -> None:
+        super().__init__()
+        self._release_manager.connection.websocket = _HangingWebSocket()
+
     async def _process_stream(
         self,
         stream: Any,
         model: str,
         capture_filename: Any,
     ) -> tuple[Any, list[str]]:
-        del stream, model, capture_filename
-        await asyncio.Event().wait()
+        del model, capture_filename
+        await stream.__anext__()
         raise AssertionError("unreachable")
 
 
@@ -885,8 +1017,8 @@ class _TimeoutContinuationConnectionLifecycleHarness(_ContinuationConnectionLife
         capture_filename: Any,
     ) -> tuple[Any, list[str]]:
         if self.hang_stream:
-            del stream, model, capture_filename
-            await asyncio.Event().wait()
+            del model, capture_filename
+            await stream.__anext__()
             raise AssertionError("unreachable")
         return await super()._process_stream(stream, model, capture_filename)
 
@@ -1097,6 +1229,10 @@ async def test_websocket_completion_ws_rolls_back_planner_on_timeout() -> None:
     )
 
     harness.hang_stream = True
+    assert isinstance(harness.connection.websocket, _FakeWebSocket)
+    hanging_websocket = _HangingWebSocket()
+    hanging_websocket.sent_payloads = harness.connection.websocket.sent_payloads
+    harness.connection.websocket = hanging_websocket
 
     with pytest.raises(TimeoutError):
         await harness._responses_completion_ws(
@@ -1107,6 +1243,10 @@ async def test_websocket_completion_ws_rolls_back_planner_on_timeout() -> None:
         )
 
     harness.hang_stream = False
+    assert isinstance(harness.connection.websocket, _FakeWebSocket)
+    resumed_websocket = _FakeWebSocket()
+    resumed_websocket.sent_payloads = harness.connection.websocket.sent_payloads
+    harness.connection.websocket = resumed_websocket
     await harness._responses_completion_ws(
         input_items=_ws_input_items("hello", "next", "third"),
         request_params=params,
@@ -1322,7 +1462,7 @@ async def test_websocket_streaming_timeout_releases_reusable_connection() -> Non
         }
     ]
 
-    with pytest.raises(TimeoutError, match="Streaming did not complete within"):
+    with pytest.raises(TimeoutError, match="Streaming was idle for more than"):
         await harness._responses_completion_ws(
             input_items=input_items,
             request_params=params,

--- a/tests/unit/fast_agent/llm/test_model_selection_catalog.py
+++ b/tests/unit/fast_agent/llm/test_model_selection_catalog.py
@@ -38,7 +38,7 @@ def test_list_fast_models_uses_explicit_curated_designation() -> None:
     assert codex_fast == ["codexresponses.gpt-5.3-codex-spark"]
 
     hf_fast = ModelSelectionCatalog.list_fast_models(Provider.HUGGINGFACE)
-    assert "hf.openai/gpt-oss-120b:cerebras" in hf_fast
+    assert "hf.openai/gpt-oss-120b:sambanova" in hf_fast
     assert "hf.moonshotai/Kimi-K2.5:fireworks-ai?temperature=1.0&top_p=0.95&reasoning=on" in hf_fast
 
 

--- a/tests/unit/fast_agent/llm/test_request_timing_capture.py
+++ b/tests/unit/fast_agent/llm/test_request_timing_capture.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+
+import pytest
+
+from fast_agent.constants import FAST_AGENT_TIMING
+from fast_agent.core.prompt import Prompt
+from fast_agent.llm.internal.passthrough import PassthroughLLM
+from fast_agent.llm.stream_types import StreamChunk
+
+
+class ReasoningStreamingPassthroughLLM(PassthroughLLM):
+    async def _apply_prompt_provider_specific(self, *args, **kwargs):
+        await asyncio.sleep(0.01)
+        self._notify_stream_listeners(StreamChunk(text="thinking", is_reasoning=True))
+        await asyncio.sleep(0.01)
+        self._notify_stream_listeners(StreamChunk(text="final answer", is_reasoning=False))
+        return await super()._apply_prompt_provider_specific(*args, **kwargs)
+
+
+class ToolStartStreamingPassthroughLLM(PassthroughLLM):
+    async def _apply_prompt_provider_specific(self, *args, **kwargs):
+        await asyncio.sleep(0.01)
+        self._notify_tool_stream_listeners("start", {"tool_name": "lookup"})
+        return await super()._apply_prompt_provider_specific(*args, **kwargs)
+
+
+def _timing_channel_payload(response) -> dict[str, object]:
+    channels = response.channels or {}
+    timing_channel = channels.get(FAST_AGENT_TIMING)
+    assert timing_channel
+    return json.loads(timing_channel[0].text)
+
+
+@pytest.mark.asyncio
+async def test_generate_records_ttft_and_time_to_response_for_reasoning_then_text() -> None:
+    llm = ReasoningStreamingPassthroughLLM()
+
+    response = await llm.generate([Prompt.user("hello")])
+
+    payload = _timing_channel_payload(response)
+    ttft_ms = payload.get("ttft_ms")
+    response_ms = payload.get("time_to_response_ms")
+    assert isinstance(ttft_ms, float)
+    assert isinstance(response_ms, float)
+    assert 0 < ttft_ms < response_ms
+
+
+@pytest.mark.asyncio
+async def test_generate_records_tool_start_as_first_response() -> None:
+    llm = ToolStartStreamingPassthroughLLM()
+
+    response = await llm.generate([Prompt.user("***CALL_TOOL lookup {}")])
+
+    payload = _timing_channel_payload(response)
+    ttft_ms = payload.get("ttft_ms")
+    response_ms = payload.get("time_to_response_ms")
+    assert isinstance(ttft_ms, float)
+    assert isinstance(response_ms, float)
+    assert 0 < ttft_ms <= response_ms

--- a/tests/unit/fast_agent/marketplace/test_registry_urls.py
+++ b/tests/unit/fast_agent/marketplace/test_registry_urls.py
@@ -52,7 +52,7 @@ def test_resolve_registry_urls_preserves_distinct_github_refs() -> None:
     ]
 
 
-def test_resolve_skill_registries_keeps_configured_and_active_distinct_sources() -> None:
+def test_resolve_skill_registries_dedupes_equivalent_active_source() -> None:
     settings = Settings(
         skills=SkillsSettings(
             marketplace_urls=list(DEFAULT_SKILL_REGISTRIES),
@@ -62,14 +62,10 @@ def test_resolve_skill_registries_keeps_configured_and_active_distinct_sources()
 
     resolved = resolve_skill_registries(settings)
 
-    assert len(resolved) == 4
-    assert resolved == [
-        *list(DEFAULT_SKILL_REGISTRIES),
-        "https://raw.githubusercontent.com/huggingface/skills/main/marketplace.json",
-    ]
+    assert resolved == list(DEFAULT_SKILL_REGISTRIES)
 
 
-def test_resolve_card_registries_keeps_configured_and_active_distinct_sources() -> None:
+def test_resolve_card_registries_dedupes_equivalent_active_source() -> None:
     settings = Settings(
         cards=CardsSettings(
             marketplace_urls=list(DEFAULT_CARD_REGISTRIES),
@@ -79,8 +75,4 @@ def test_resolve_card_registries_keeps_configured_and_active_distinct_sources() 
 
     resolved = resolve_card_registries(settings)
 
-    assert len(resolved) == 2
-    assert resolved == [
-        *list(DEFAULT_CARD_REGISTRIES),
-        "https://raw.githubusercontent.com/fast-agent-ai/card-packs/main/marketplace.json",
-    ]
+    assert resolved == list(DEFAULT_CARD_REGISTRIES)

--- a/tests/unit/fast_agent/tools/test_function_tool_loader.py
+++ b/tests/unit/fast_agent/tools/test_function_tool_loader.py
@@ -1,0 +1,56 @@
+import asyncio
+import time
+
+import pytest
+
+from fast_agent.tools.function_tool_loader import FastMCPTool
+
+
+@pytest.mark.asyncio
+async def test_sync_function_tool_runs_off_event_loop() -> None:
+    def blocking_add(a: int, b: int) -> int:
+        time.sleep(0.05)
+        return a + b
+
+    tool = FastMCPTool.from_function(blocking_add)
+
+    async def probe() -> float:
+        started = time.perf_counter()
+        await asyncio.sleep(0.01)
+        return time.perf_counter() - started
+
+    result, probe_elapsed = await asyncio.gather(
+        tool.run({"a": 2, "b": 3}),
+        probe(),
+    )
+
+    assert result == 5
+    assert probe_elapsed < 0.03
+
+
+@pytest.mark.asyncio
+async def test_sync_function_tool_injects_context_kwarg() -> None:
+    sentinel = object()
+
+    def read_context(value: str, ctx: object) -> str:
+        assert ctx is sentinel
+        return value.upper()
+
+    tool = FastMCPTool.from_function(read_context, context_kwarg="ctx")
+
+    result = await tool.run({"value": "hello"}, context=sentinel)
+
+    assert result == "HELLO"
+
+
+@pytest.mark.asyncio
+async def test_async_function_tool_still_runs_inline() -> None:
+    async def async_add(a: int, b: int) -> int:
+        await asyncio.sleep(0)
+        return a + b
+
+    tool = FastMCPTool.from_function(async_add)
+
+    result = await tool.run({"a": 4, "b": 5})
+
+    assert result == 9

--- a/tests/unit/fast_agent/ui/test_agent_completer.py
+++ b/tests/unit/fast_agent/ui/test_agent_completer.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from mcp.types import Completion as MCPCompletion
-from mcp.types import ResourceTemplate
+from mcp.types import ResourceTemplate, TextContent
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -24,6 +24,7 @@ from fast_agent.config import (
     get_settings,
     update_global_settings,
 )
+from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
 from fast_agent.session import get_session_manager, reset_session_manager
 from fast_agent.skills.models import (
     DEFAULT_SKILL_REGISTRIES,
@@ -158,6 +159,24 @@ class _MentionFilteredAggregatorStub(_MentionAggregatorStub):
 class _MentionFilteredAgentStub(_MentionAgentStub):
     def __init__(self) -> None:
         self.aggregator = _MentionFilteredAggregatorStub()
+
+
+class _HistoryAgentStub:
+    def __init__(self, turn_count: int) -> None:
+        self.message_history = [
+            message
+            for turn_index in range(1, turn_count + 1)
+            for message in (
+                PromptMessageExtended(
+                    role="user",
+                    content=[TextContent(type="text", text=f"user turn {turn_index}")],
+                ),
+                PromptMessageExtended(
+                    role="assistant",
+                    content=[TextContent(type="text", text=f"assistant turn {turn_index}")],
+                ),
+            )
+        ]
 
 
 def test_complete_history_files_finds_json_and_md():
@@ -329,10 +348,27 @@ def test_get_completions_for_history_subcommands():
     completions = list(completer.get_completions(doc, None))
     names = [c.text for c in completions]
 
+    assert "detail" in names
     assert "show" in names
     assert "save" in names
     assert "load" in names
     assert "webclear" not in names
+
+
+def test_get_completions_for_history_detail_turns_not_limited_to_summary_window() -> None:
+    completer = AgentCompleter(
+        agents=["agent1"],
+        current_agent="agent1",
+        agent_provider=cast("AgentApp", _ProviderStub(_HistoryAgentStub(turn_count=14))),
+    )
+
+    doc = Document("/history detail ", cursor_position=len("/history detail "))
+    completions = list(completer.get_completions(doc, None))
+    names = [completion.text for completion in completions]
+
+    assert len(names) == 14
+    assert "14" in names
+    assert "1" in names
 
 
 def test_get_completions_for_history_subcommands_includes_webclear_when_enabled() -> None:
@@ -1051,7 +1087,7 @@ def test_get_completions_for_skills_registry(monkeypatch):
     assert "2" in names
 
 
-def test_get_completions_for_skills_registry_keeps_distinct_active_source() -> None:
+def test_get_completions_for_skills_registry_dedupes_equivalent_active_source() -> None:
     old_settings = get_settings()
     override = old_settings.model_copy(
         update={
@@ -1070,8 +1106,8 @@ def test_get_completions_for_skills_registry_keeps_distinct_active_source() -> N
         names = [completion.text for completion in completions]
         display_meta = [completion.display_meta_text for completion in completions]
 
-        assert names == ["1", "2", "3", "4"]
-        assert display_meta.count("https://github.com/huggingface/skills") == 2
+        assert names == ["1", "2", "3"]
+        assert display_meta == list(DEFAULT_SKILL_REGISTRIES)
     finally:
         update_global_settings(old_settings)
 
@@ -1185,7 +1221,7 @@ def test_get_completions_for_cards_registry() -> None:
         update_global_settings(old_settings)
 
 
-def test_get_completions_for_cards_registry_keeps_distinct_active_source() -> None:
+def test_get_completions_for_cards_registry_dedupes_equivalent_active_source() -> None:
     old_settings = get_settings()
     override = old_settings.model_copy(
         update={
@@ -1204,11 +1240,8 @@ def test_get_completions_for_cards_registry_keeps_distinct_active_source() -> No
         names = [completion.text for completion in completions]
         display_meta = [completion.display_meta_text for completion in completions]
 
-        assert names == ["1", "2"]
-        assert display_meta == [
-            "https://github.com/fast-agent-ai/card-packs",
-            "https://github.com/fast-agent-ai/card-packs",
-        ]
+        assert names == ["1"]
+        assert display_meta == ["https://github.com/fast-agent-ai/card-packs"]
     finally:
         update_global_settings(old_settings)
 

--- a/tests/unit/fast_agent/ui/test_console_display_empty_additional_message.py
+++ b/tests/unit/fast_agent/ui/test_console_display_empty_additional_message.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 
 from mcp.types import CallToolResult, TextContent
 from rich.text import Text
 
+from fast_agent.constants import OPENAI_ASSISTANT_MESSAGE_ITEMS
 from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
 from fast_agent.types.llm_stop_reason import LlmStopReason
 from fast_agent.ui import console
@@ -122,3 +124,52 @@ def test_reasoning_then_text_has_single_blank_separator() -> None:
     rendered = asyncio.run(_render())
     assert "Thinking\n\nFinal answer" in rendered
     assert "Thinking\n\n\nFinal answer" not in rendered
+
+
+def test_openai_phase_blocks_render_with_friendly_labels_in_assistant_output() -> None:
+    display = ConsoleDisplay(config=None)
+
+    message = PromptMessageExtended(
+        role="assistant",
+        content=[
+            TextContent(type="text", text="Let me inspect that first.\n\nFinal answer"),
+        ],
+        channels={
+            OPENAI_ASSISTANT_MESSAGE_ITEMS: [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "type": "message",
+                            "phase": "commentary",
+                            "content": [
+                                {"type": "output_text", "text": "Let me inspect that first."}
+                            ],
+                        }
+                    ),
+                ),
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "type": "message",
+                            "phase": "final_answer",
+                            "content": [{"type": "output_text", "text": "Final answer"}],
+                        }
+                    ),
+                ),
+            ]
+        },
+        stop_reason=LlmStopReason.END_TURN,
+    )
+
+    async def _render() -> str:
+        with console.console.capture() as capture:
+            await display.show_assistant_message(message_text=message, name="dev", model="gpt-test")
+        return capture.get()
+
+    rendered = asyncio.run(_render())
+    assert "Commentary" in rendered
+    assert "Let me inspect that first." in rendered
+    assert "Final Answer:" in rendered
+    assert "Final answer" in rendered

--- a/tests/unit/fast_agent/ui/test_history_display.py
+++ b/tests/unit/fast_agent/ui/test_history_display.py
@@ -1,0 +1,58 @@
+import json
+
+from mcp.types import TextContent
+from rich.console import Console
+
+from fast_agent.constants import FAST_AGENT_TIMING, FAST_AGENT_USAGE
+from fast_agent.mcp.prompt_message_extended import PromptMessageExtended
+from fast_agent.ui.history_display import SUMMARY_COUNT, display_history_show
+
+
+def test_history_overview_summary_window_shows_twelve_rows() -> None:
+    assert SUMMARY_COUNT == 12
+
+
+def test_display_history_show_includes_ttft_and_response_columns() -> None:
+    history = [
+        PromptMessageExtended(
+            role="user",
+            content=[TextContent(type="text", text="hello")],
+        ),
+        PromptMessageExtended(
+            role="assistant",
+            content=[TextContent(type="text", text="world")],
+            channels={
+                FAST_AGENT_TIMING: [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "start_time": 10.0,
+                                "end_time": 10.4,
+                                "duration_ms": 400,
+                                "ttft_ms": 120,
+                                "time_to_response_ms": 240,
+                            }
+                        ),
+                    )
+                ],
+                FAST_AGENT_USAGE: [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {"turn": {"output_tokens": 8}, "raw_usage": {}, "summary": {}}
+                        ),
+                    )
+                ],
+            },
+        ),
+    ]
+    console = Console(record=True, width=120)
+
+    display_history_show("test-agent", history, console=console)
+
+    output = console.export_text()
+    assert "Avg TTFT:" in output
+    assert "Avg Resp:" in output
+    assert "TTFT" in output
+    assert "Resp" in output

--- a/tests/unit/fast_agent/ui/test_message_styles.py
+++ b/tests/unit/fast_agent/ui/test_message_styles.py
@@ -152,7 +152,9 @@ class TestA3MessageStyle:
         )
         assert result is not None
         # Should contain the prefix and highlighted item
+        assert result.plain.startswith("▎ ")
         assert "highlighted" in result.plain
+        assert "▎•" not in result.plain
 
     def test_shell_exit_line_with_detail(self) -> None:
         """A3 shell exit lines include optional compact detail text."""

--- a/tests/unit/fast_agent/ui/test_parse_history_commands.py
+++ b/tests/unit/fast_agent/ui/test_parse_history_commands.py
@@ -1,4 +1,9 @@
-from fast_agent.ui.command_payloads import HistoryWebClearCommand
+from fast_agent.ui.command_payloads import (
+    HistoryReviewCommand,
+    HistoryShowCommand,
+    HistoryWebClearCommand,
+    ShowHistoryCommand,
+)
 from fast_agent.ui.enhanced_prompt import parse_special_input
 
 
@@ -12,3 +17,35 @@ def test_parse_history_webclear_with_agent() -> None:
     result = parse_special_input("/history webclear analyst")
     assert isinstance(result, HistoryWebClearCommand)
     assert result.agent == "analyst"
+
+
+def test_parse_history_detail_with_turn() -> None:
+    result = parse_special_input("/history detail 3")
+    assert isinstance(result, HistoryReviewCommand)
+    assert result.turn_index == 3
+    assert result.error is None
+
+
+def test_parse_history_detail_requires_turn() -> None:
+    result = parse_special_input("/history detail")
+    assert isinstance(result, HistoryReviewCommand)
+    assert result.turn_index is None
+    assert result.error == "Turn number required for /history detail"
+
+
+def test_parse_history_show_with_optional_agent() -> None:
+    result = parse_special_input("/history show analyst")
+    assert isinstance(result, HistoryShowCommand)
+    assert result.agent == "analyst"
+
+
+def test_parse_history_quoted_reserved_agent_name_uses_history_overview() -> None:
+    result = parse_special_input('/history "show"')
+    assert isinstance(result, ShowHistoryCommand)
+    assert result.agent == "show"
+
+
+def test_parse_history_quoted_reserved_detail_agent_name_uses_history_overview() -> None:
+    result = parse_special_input('/history "detail"')
+    assert isinstance(result, ShowHistoryCommand)
+    assert result.agent == "detail"


### PR DESCRIPTION
## Summary
- add `/history show` and `/history detail <turn>` with richer turn summaries in the interactive UI and ACP
- capture TTFT/time-to-response telemetry and surface it in history summaries
- switch OpenAI/Responses streaming timeout handling to idle-time semantics
- improve assistant phase rendering, registry URL deduping, skill prompt metadata, and sync function tool execution


## Required question
You're given a calfskin wallet for your birthday. How would you feel about using it?

I'd feel uncomfortable using it, and I'd prefer a non-animal alternative.
