### PR TITLE
mcp: report lower-layer startup errors accurately

### DIFF
--- a/src/fast_agent/mcp/mcp_connection_manager.py
+++ b/src/fast_agent/mcp/mcp_connection_manager.py
@@ -588,16 +588,16 @@ async def _server_lifecycle_task(server_conn: ServerConnection) -> None:
 def _is_oauth_timeout_message(message: str | None) -> bool:
     if not message:
         return False
-    normalized = message.lower()
-    if "oauth" not in normalized:
-        return False
+    normalized = " ".join(str(message).lower().split())
 
-    timeout_markers = (
-        "timed out",
-        "timeout",
-        "not completed in time",
+    oauth_timeout_phrases = (
+        "oauth authorization timed out",
+        "oauth authorization was not completed in time",
+        "oauth callback timeout",
+        "oauth callback timed out",
+        "oauth flow timed out",
     )
-    return any(marker in normalized for marker in timeout_markers)
+    return any(phrase in normalized for phrase in oauth_timeout_phrases)
 
 
 def _is_oauth_registration_404_message(message: str | None) -> bool:

--- a/tests/unit/fast_agent/mcp/test_mcp_connection_manager.py
+++ b/tests/unit/fast_agent/mcp/test_mcp_connection_manager.py
@@ -267,6 +267,15 @@ def test_is_oauth_timeout_message_requires_real_timeout_markers() -> None:
         is False
     )
 
+    # Guard against traceback text that mentions oauth variable names and timeout kwargs
+    # without any real OAuth timeout happening.
+    assert (
+        _is_oauth_timeout_message(
+            "ImportError: Using SOCKS proxy, but the 'socksio' package is not installed. auth=oauth_auth timeout=10"
+        )
+        is False
+    )
+
 
 def test_is_oauth_registration_404_message_detects_registration_failures() -> None:
     assert (


### PR DESCRIPTION
## Summary
- avoid misclassifying non-OAuth startup failures as OAuth timeouts
- keep real lower-layer exceptions visible in MCP startup errors
- add regression coverage for traceback text containing `oauth_auth` and `timeout`

## Problem
In the `StratoProject` CLI flow, connecting to the non-OAuth `fs` MCP server failed because `httpx` was configured to use a SOCKS proxy without `socksio` installed.

The raw lower-layer exception was:

```text
ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
```

But `fast-agent` surfaced it as:

```text
MCP Server: 'fs': OAuth authorization timed out.
```

This happened because `_is_oauth_timeout_message()` matched traceback text that happened to contain both:
- `oauth_auth`
- `timeout=...`

That is a false positive.

## Change
- narrow `_is_oauth_timeout_message()` to explicit OAuth-timeout phrases
- add a regression test covering traceback text with `oauth_auth` + `timeout`

## Verification
- `uv run pytest tests/unit/fast_agent/mcp/test_mcp_connection_manager.py -q`
- reproduced the original `StratoProject` case after the patch
- now the CLI surfaces the real `ImportError` instead of a fake OAuth timeout
