### PR TITLE
fix: fail fast when non-persistent MCP init fails

### DIFF
--- a/src/fast_agent/mcp/gen_client.py
+++ b/src/fast_agent/mcp/gen_client.py
@@ -1,12 +1,10 @@
 from contextlib import asynccontextmanager
-from datetime import timedelta
 from typing import AsyncGenerator, Callable
 
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import ClientSession
 
 from fast_agent.core.logging.logger import get_logger
-from fast_agent.mcp.interfaces import ServerRegistryProtocol
+from fast_agent.mcp.interfaces import ServerInitializerProtocol, ServerRegistryProtocol
 from fast_agent.mcp.mcp_agent_client_session import MCPAgentClientSession
 
 logger = get_logger(__name__)
@@ -15,11 +13,8 @@ logger = get_logger(__name__)
 @asynccontextmanager
 async def gen_client(
     server_name: str,
-    server_registry: ServerRegistryProtocol,
-    client_session_factory: Callable[
-        [MemoryObjectReceiveStream, MemoryObjectSendStream, timedelta | None],
-        ClientSession,
-    ] = MCPAgentClientSession,
+    server_registry: ServerInitializerProtocol,
+    client_session_factory: Callable[..., ClientSession] = MCPAgentClientSession,
 ) -> AsyncGenerator[ClientSession, None]:
     """
     Create a client session to the specified server.
@@ -42,10 +37,7 @@ async def gen_client(
 async def connect(
     server_name: str,
     server_registry: ServerRegistryProtocol,
-    client_session_factory: Callable[
-        [MemoryObjectReceiveStream, MemoryObjectSendStream, timedelta | None],
-        ClientSession,
-    ] = MCPAgentClientSession,
+    client_session_factory: Callable[..., ClientSession] = MCPAgentClientSession,
 ) -> ClientSession:
     """
     Create a persistent client session to the specified server.

--- a/src/fast_agent/mcp/interfaces.py
+++ b/src/fast_agent/mcp/interfaces.py
@@ -3,7 +3,6 @@ Interface definitions to prevent circular imports.
 This module defines protocols (interfaces) that can be used to break circular dependencies.
 """
 
-from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     AsyncContextManager,
@@ -12,7 +11,6 @@ from typing import (
     runtime_checkable,
 )
 
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import ClientSession
 
 from fast_agent.interfaces import (
@@ -29,6 +27,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MCPConnectionManagerProtocol",
+    "ServerInitializerProtocol",
     "ServerRegistryProtocol",
     "ServerConnection",
     "FastAgentLLMProtocol",
@@ -47,16 +46,7 @@ class MCPConnectionManagerProtocol(Protocol):
     async def get_server(
         self,
         server_name: str,
-        client_session_factory: 
-            Callable[
-                [
-                    MemoryObjectReceiveStream,
-                    MemoryObjectSendStream,
-                    timedelta | None,
-                ],
-                ClientSession,
-            ]
-         | None = None,
+        client_session_factory: Callable[..., ClientSession] | None = None,
     ) -> "ServerConnection": ...
 
     async def disconnect_server(self, server_name: str) -> None: ...
@@ -65,8 +55,21 @@ class MCPConnectionManagerProtocol(Protocol):
 
 
 @runtime_checkable
+class ServerInitializerProtocol(Protocol):
+    """Protocol defining the interface required by temporary-session helpers."""
+
+    def initialize_server(
+        self,
+        server_name: str,
+        client_session_factory: Callable[..., ClientSession] | None = None,
+    ) -> AsyncContextManager[ClientSession]:
+        """Initialize a server and yield a client session."""
+        ...
+
+
+@runtime_checkable
 class ServerRegistryProtocol(Protocol):
-    """Protocol defining the minimal interface of ServerRegistry needed by gen_client."""
+    """Protocol defining the interface required by persistent-session helpers."""
 
     @property
     def registry(self) -> dict[str, "MCPServerSettings"]: ...
@@ -77,16 +80,7 @@ class ServerRegistryProtocol(Protocol):
     def initialize_server(
         self,
         server_name: str,
-        client_session_factory: 
-            Callable[
-                [
-                    MemoryObjectReceiveStream,
-                    MemoryObjectSendStream,
-                    timedelta | None,
-                ],
-                ClientSession,
-            ]
-         | None = None,
+        client_session_factory: Callable[..., ClientSession] | None = None,
     ) -> AsyncContextManager[ClientSession]:
         """Initialize a server and yield a client session."""
         ...

--- a/src/fast_agent/mcp/mcp_aggregator.py
+++ b/src/fast_agent/mcp/mcp_aggregator.py
@@ -12,7 +12,6 @@ from typing import (
     Mapping,
     TypeVar,
     Union,
-    cast,
 )
 
 from mcp import GetPromptResult, ReadResourceResult
@@ -43,7 +42,6 @@ from fast_agent.event_progress import ProgressAction
 from fast_agent.mcp.common import SEP, create_namespaced_name, is_namespaced_name
 from fast_agent.mcp.experimental_session_client import ExperimentalSessionClient
 from fast_agent.mcp.gen_client import gen_client
-from fast_agent.mcp.interfaces import ServerRegistryProtocol
 from fast_agent.mcp.mcp_agent_client_session import MCPAgentClientSession
 from fast_agent.mcp.mcp_connection_manager import MCPConnectionManager
 from fast_agent.mcp.skybridge import (
@@ -217,7 +215,7 @@ class MCPAggregator(ContextDependent):
             context = self._require_context()
             # Try to get existing connection manager from context
             if not hasattr(context, "_connection_manager") or context._connection_manager is None:
-                server_registry = cast("ServerRegistry", self._require_server_registry())
+                server_registry = self._require_server_registry()
                 manager = MCPConnectionManager(server_registry, context=context)
                 await manager.__aenter__()
                 context._connection_manager = manager
@@ -321,6 +319,9 @@ class MCPAggregator(ContextDependent):
         # Track discovered Skybridge configurations per server
         self._skybridge_configs: dict[str, SkybridgeServerConfig] = {}
 
+        # Cache for non-persistent mode capabilities, keyed by server name
+        self._nonpersistent_capabilities: dict[str, ServerCapabilities] = {}
+
         # Focused API for experimental data-layer session metadata controls.
         self.experimental_sessions = ExperimentalSessionClient(self)
 
@@ -329,7 +330,7 @@ class MCPAggregator(ContextDependent):
             raise RuntimeError("MCPAggregator requires a context")
         return self.context
 
-    def _require_server_registry(self) -> ServerRegistryProtocol:
+    def _require_server_registry(self) -> "ServerRegistry":
         context = self._require_context()
         server_registry = getattr(context, "server_registry", None)
         if server_registry is None:
@@ -567,7 +568,29 @@ class MCPAggregator(ContextDependent):
             self._prompt_cache.clear()
 
         self._skybridge_configs.clear()
+        self._nonpersistent_capabilities.clear()
         self._attached_server_names = []
+
+    @staticmethod
+    def _is_capability_probe_error(exc: Exception) -> bool:
+        if isinstance(exc, NotImplementedError):
+            return True
+
+        from mcp.shared.exceptions import McpError
+
+        if not isinstance(exc, McpError):
+            return False
+
+        error_data = getattr(exc, "error", None)
+        if error_data is None:
+            return False
+
+        code = getattr(error_data, "code", None)
+        if code == -32601:
+            return True
+
+        message = str(getattr(error_data, "message", "")).strip().lower()
+        return message == "method not found"
 
     async def _fetch_server_tools(self, server_name: str) -> list[Tool]:
         supports_tools = await self.server_supports_feature(server_name, "tools")
@@ -585,13 +608,12 @@ class MCPAggregator(ContextDependent):
                 method_args={},
             )
             return result.tools or []
-        except Exception as e:
-            if supports_tools:
+        except Exception as e:  # noqa: BLE001 - distinguish capability probes from infra failures
+            if supports_tools or not self._is_capability_probe_error(e):
                 logger.error(f"Error loading tools from server '{server_name}'", data=e)
-            else:
-                logger.debug(
-                    f"Server '{server_name}' does not provide tools (list_tools failed): {e}"
-                )
+                raise
+
+            logger.debug(f"Server '{server_name}' does not provide tools (list_tools failed): {e}")
             return []
 
     async def _fetch_server_prompts(self, server_name: str) -> list[Prompt]:
@@ -692,6 +714,7 @@ class MCPAggregator(ContextDependent):
         if server_name not in self.server_names:
             self.server_names.append(server_name)
 
+        self._nonpersistent_capabilities.pop(server_name, None)
         tools = await self._fetch_server_tools(server_name)
         prompts = await self._fetch_server_prompts(server_name)
 
@@ -770,6 +793,7 @@ class MCPAggregator(ContextDependent):
             self._prompt_cache.pop(server_name, None)
 
         self._skybridge_configs.pop(server_name, None)
+        self._nonpersistent_capabilities.pop(server_name, None)
         self._attached_server_names = [
             name for name in self._attached_server_names if name != server_name
         ]
@@ -973,11 +997,21 @@ class MCPAggregator(ContextDependent):
             },
         )
 
-    async def get_capabilities(self, server_name: str):
+    async def get_capabilities(self, server_name: str) -> ServerCapabilities | None:
         """Get server capabilities if available."""
         if not self.connection_persistence:
-            # For non-persistent connections, we can't easily check capabilities
-            return None
+            cached = self._nonpersistent_capabilities.get(server_name)
+            if cached is not None:
+                return cached
+
+            server_registry = self._require_server_registry()
+            capabilities = await server_registry.get_server_capabilities(
+                server_name=server_name,
+                client_session_factory=self._create_session_factory(server_name),
+            )
+            if capabilities is not None:
+                self._nonpersistent_capabilities[server_name] = capabilities
+            return capabilities
 
         try:
             manager = self._require_connection_manager()
@@ -1292,7 +1326,9 @@ class MCPAggregator(ContextDependent):
                             if session_title is None and isinstance(session_cookie, dict):
                                 cookie_data = session_cookie.get("data")
                                 if isinstance(cookie_data, dict):
-                                    cookie_title = cookie_data.get("title") or cookie_data.get("label")
+                                    cookie_title = cookie_data.get("title") or cookie_data.get(
+                                        "label"
+                                    )
                                     if isinstance(cookie_title, str) and cookie_title.strip():
                                         session_title = cookie_title.strip()
 
@@ -1516,7 +1552,9 @@ class MCPAggregator(ContextDependent):
                 # Let ServerSessionTerminatedError pass through for reconnection logic
                 raise
             except Exception as e:
-                self._maybe_mark_rejected_session_cookie(server_name=server_name, client=client, exc=e)
+                self._maybe_mark_rejected_session_cookie(
+                    server_name=server_name, client=client, exc=e
+                )
                 error_msg = (
                     f"Failed to {method_name} '{operation_name}' on server '{server_name}': {e}"
                 )

--- a/src/fast_agent/mcp/mcp_connection_manager.py
+++ b/src/fast_agent/mcp/mcp_connection_manager.py
@@ -147,6 +147,116 @@ def _build_transport_metrics_hook(
     return channel_hook
 
 
+def create_transport_context(
+    *,
+    server_name: str,
+    config: MCPServerSettings,
+    transport_metrics: TransportChannelMetrics | None = None,
+    trigger_oauth: bool = True,
+    oauth_event_handler: OAuthEventHandler | None = None,
+    emit_oauth_console_output: bool = True,
+    oauth_abort_event: threading.Event | None = None,
+    allow_oauth_paste_fallback: bool = True,
+) -> AbstractAsyncContextManager[
+    tuple[
+        MemoryObjectReceiveStream,
+        MemoryObjectSendStream,
+        GetSessionIdCallback | None,
+    ]
+]:
+    """Build a transport context manager for a single MCP server."""
+
+    def prepare_http_transport_auth() -> tuple[
+        dict[str, str],
+        Union["OAuthClientProvider", None],
+        Callable[[object], None] | None,
+    ]:
+        headers, oauth_auth, user_auth_keys = _prepare_headers_and_auth(
+            config,
+            trigger_oauth=trigger_oauth,
+            oauth_event_handler=oauth_event_handler,
+            emit_oauth_console_output=emit_oauth_console_output,
+            oauth_abort_event=oauth_abort_event,
+            allow_oauth_paste_fallback=allow_oauth_paste_fallback,
+        )
+        if user_auth_keys:
+            logger.debug(
+                f"{server_name}: Using user-specified auth header(s); skipping OAuth provider.",
+                user_auth_headers=sorted(user_auth_keys),
+            )
+        return (
+            headers,
+            oauth_auth,
+            _build_transport_metrics_hook(
+                server_name,
+                transport_metrics,
+            ),
+        )
+
+    if config.transport == "stdio":
+        if not config.command:
+            raise ValueError(
+                f"Server '{server_name}' uses stdio transport but no command is specified"
+            )
+        server_params = StdioServerParameters(
+            command=config.command,
+            args=config.args if config.args is not None else [],
+            env={**get_default_environment(), **(config.env or {})},
+            cwd=config.cwd,
+        )
+        error_handler = get_stderr_handler(server_name)
+        logger.debug(f"{server_name}: Creating stdio client with custom error handler")
+
+        channel_hook = transport_metrics.record_event if transport_metrics else None
+        return _add_none_to_context(
+            tracking_stdio_client(
+                server_params,
+                channel_hook=channel_hook,
+                errlog=error_handler,
+            )
+        )
+
+    if config.transport == "sse":
+        if not config.url:
+            raise ValueError(f"Server '{server_name}' uses sse transport but no url is specified")
+        headers, oauth_auth, channel_hook = prepare_http_transport_auth()
+        return tracking_sse_client(
+            config.url,
+            headers,
+            sse_read_timeout=config.read_transport_sse_timeout_seconds,
+            auth=oauth_auth,
+            channel_hook=channel_hook,
+        )
+
+    if config.transport == "http":
+        if not config.url:
+            raise ValueError(f"Server '{server_name}' uses http transport but no url is specified")
+        headers, oauth_auth, channel_hook = prepare_http_transport_auth()
+
+        timeout = None
+        if config.http_timeout_seconds is not None or config.http_read_timeout_seconds is not None:
+            timeout = httpx.Timeout(
+                config.http_timeout_seconds or MCP_DEFAULT_TIMEOUT,
+                read=config.http_read_timeout_seconds or MCP_DEFAULT_SSE_READ_TIMEOUT,
+            )
+
+        http_client = create_mcp_http_client(
+            headers=headers,
+            auth=oauth_auth,
+            timeout=timeout,
+        )
+        return cast(
+            "AbstractAsyncContextManager[tuple[MemoryObjectReceiveStream, MemoryObjectSendStream, GetSessionIdCallback | None]]",
+            tracking_streamablehttp_client(
+                config.url,
+                http_client=http_client,
+                channel_hook=channel_hook,
+            ),
+        )
+
+    raise ValueError(f"Unsupported transport: {config.transport}")
+
+
 class ServerConnection:
     """
     Represents a long-lived MCP server connection, including:
@@ -419,14 +529,10 @@ async def _run_ping_loop(server_conn: ServerConnection) -> None:
             server_conn._ping_last_fail_at = datetime.now(timezone.utc)
             server_conn._ping_last_error = str(exc)
             server_conn.record_ping_event("error")
-            logger.warning(
-                f"{server_conn.server_name}: Ping failed ({missed}/{max_missed}): {exc}"
-            )
+            logger.warning(f"{server_conn.server_name}: Ping failed ({missed}/{max_missed}): {exc}")
             if missed >= max_missed:
                 server_conn._error_occurred = True
-                server_conn._error_message = (
-                    f"Ping failed {missed} time(s); last error: {exc}"
-                )
+                server_conn._error_message = f"Ping failed {missed} time(s); last error: {exc}"
                 server_conn.request_shutdown()
                 break
 
@@ -501,9 +607,13 @@ async def _server_lifecycle_task(server_conn: ServerConnection) -> None:
 
                         if get_session_id_cb is not None:
                             try:
-                                server_conn.session_id = get_session_id_cb() or server_conn.session_id
+                                server_conn.session_id = (
+                                    get_session_id_cb() or server_conn.session_id
+                                )
                             except Exception:
-                                logger.debug(f"{server_name}: Unable to refresh session id after init")
+                                logger.debug(
+                                    f"{server_name}: Unable to refresh session id after init"
+                                )
                         elif server_conn.server_config.transport == "stdio":
                             server_conn.session_id = "local"
 
@@ -931,9 +1041,13 @@ class MCPConnectionManager(ContextDependent):
                         f"{server_name}: Using user-specified auth header(s); skipping OAuth provider.",
                         user_auth_headers=sorted(user_auth_keys),
                     )
-                return headers, oauth_auth, _build_transport_metrics_hook(
-                    server_name,
-                    transport_metrics,
+                return (
+                    headers,
+                    oauth_auth,
+                    _build_transport_metrics_hook(
+                        server_name,
+                        transport_metrics,
+                    ),
                 )
 
             if config.transport == "stdio":
@@ -1136,7 +1250,9 @@ class MCPConnectionManager(ContextDependent):
             if _is_oauth_registration_404_message(formatted_error):
                 raise ServerInitializationError(
                     f"MCP Server: '{server_name}': OAuth client registration failed.",
-                    _format_oauth_registration_404_details(formatted_error, server_conn.server_config.url),
+                    _format_oauth_registration_404_details(
+                        formatted_error, server_conn.server_config.url
+                    ),
                 )
 
             if _is_stdio_startup_error(server_conn, formatted_error):
@@ -1236,7 +1352,9 @@ class MCPConnectionManager(ContextDependent):
             if _is_oauth_registration_404_message(formatted_error):
                 raise ServerInitializationError(
                     f"MCP Server: '{server_name}': OAuth client registration failed during reconnect.",
-                    _format_oauth_registration_404_details(formatted_error, server_conn.server_config.url),
+                    _format_oauth_registration_404_details(
+                        formatted_error, server_conn.server_config.url
+                    ),
                 )
 
             if _is_stdio_startup_error(server_conn, formatted_error):

--- a/src/fast_agent/mcp_server_registry.py
+++ b/src/fast_agent/mcp_server_registry.py
@@ -7,6 +7,12 @@ supports dynamic registration of initialization hooks, and provides methods for
 server initialization.
 """
 
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import AsyncGenerator, Callable
+
+from mcp import ClientSession
+from mcp.types import ServerCapabilities
 
 from fast_agent.config import (
     MCPServerSettings,
@@ -87,3 +93,65 @@ class ServerRegistry:
         elif server_config.name is None:
             server_config.name = server_name
         return server_config
+
+    @asynccontextmanager
+    async def _initialize_server_session(
+        self,
+        server_name: str,
+        client_session_factory: Callable[..., ClientSession] | None = None,
+    ) -> AsyncGenerator[tuple[ClientSession, ServerCapabilities | None], None]:
+        """
+        Create a temporary connection to a server and yield an initialized session.
+        """
+        config = self.get_server_config(server_name)
+        if config is None:
+            raise ValueError(f"Server '{server_name}' not found in registry.")
+
+        from fast_agent.mcp.mcp_agent_client_session import MCPAgentClientSession
+        from fast_agent.mcp.mcp_connection_manager import create_transport_context
+
+        factory = client_session_factory or MCPAgentClientSession
+        transport_ctx = create_transport_context(server_name=server_name, config=config)
+
+        async with transport_ctx as (read_stream, write_stream, _get_session_id):
+            read_timeout = (
+                timedelta(seconds=config.read_timeout_seconds)
+                if config.read_timeout_seconds
+                else None
+            )
+            session = factory(
+                read_stream,
+                write_stream,
+                read_timeout,
+                server_config=config,
+            )
+            async with session:
+                result = await session.initialize()
+                yield session, result.capabilities
+
+    @asynccontextmanager
+    async def initialize_server(
+        self,
+        server_name: str,
+        client_session_factory: Callable[..., ClientSession] | None = None,
+    ) -> AsyncGenerator[ClientSession, None]:
+        """Create a temporary connection to a server, initialize the session, and yield it."""
+
+        async with self._initialize_server_session(
+            server_name=server_name,
+            client_session_factory=client_session_factory,
+        ) as (session, _):
+            yield session
+
+    async def get_server_capabilities(
+        self,
+        server_name: str,
+        client_session_factory: Callable[..., ClientSession] | None = None,
+    ) -> ServerCapabilities | None:
+        """Create a temporary connection and return the server capabilities."""
+
+        async with self._initialize_server_session(
+            server_name=server_name,
+            client_session_factory=client_session_factory,
+        ) as (_, capabilities):
+            return capabilities

--- a/tests/unit/fast_agent/mcp/test_mcp_aggregator_nonpersistent.py
+++ b/tests/unit/fast_agent/mcp/test_mcp_aggregator_nonpersistent.py
@@ -1,0 +1,193 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from mcp import ClientSession
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
+
+from fast_agent.config import MCPServerSettings
+from fast_agent.context import Context
+from fast_agent.mcp.gen_client import gen_client
+from fast_agent.mcp.interfaces import ServerInitializerProtocol
+from fast_agent.mcp.mcp_aggregator import MCPAggregator
+from fast_agent.mcp_server_registry import ServerRegistry
+
+
+def _build_context(configs: dict[str, MCPServerSettings]) -> Context:
+    registry = ServerRegistry()
+    registry.registry = configs
+    return Context(server_registry=registry)
+
+
+def _stdio_server(name: str) -> MCPServerSettings:
+    return MCPServerSettings(name=name, transport="stdio", command="echo")
+
+
+@pytest.mark.asyncio
+async def test_gen_client_accepts_initializer_protocol() -> None:
+    session = object()
+
+    class StubRegistry:
+        @asynccontextmanager
+        async def initialize_server(self, server_name: str, client_session_factory=None):
+            del client_session_factory
+            assert server_name == "alpha"
+            yield session
+
+    registry = StubRegistry()
+
+    assert isinstance(registry, ServerInitializerProtocol)
+
+    async with gen_client("alpha", registry) as client:
+        assert client is session
+
+
+@pytest.mark.asyncio
+async def test_server_registry_initialize_server_initializes_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ServerRegistry()
+    registry.registry = {"alpha": _stdio_server("alpha")}
+    sentinel_capabilities = object()
+    init_calls: list[str] = []
+
+    @asynccontextmanager
+    async def fake_transport_context(**kwargs):
+        assert kwargs["server_name"] == "alpha"
+        yield object(), object(), None
+
+    class DummySession:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            del exc_type, exc, tb
+            return None
+
+        async def initialize(self):
+            init_calls.append("initialize")
+            return SimpleNamespace(capabilities=sentinel_capabilities)
+
+    monkeypatch.setattr(
+        "fast_agent.mcp.mcp_connection_manager.create_transport_context",
+        fake_transport_context,
+    )
+
+    def session_factory(*args, **kwargs) -> ClientSession:
+        return cast("ClientSession", DummySession(*args, **kwargs))
+
+    async with registry.initialize_server("alpha", session_factory) as session:
+        assert isinstance(session, DummySession)
+        assert session.kwargs["server_config"].name == "alpha"
+
+    assert init_calls == ["initialize"]
+    capabilities = await registry.get_server_capabilities("alpha", session_factory)
+    assert capabilities is sentinel_capabilities
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_nonpersistent_caches_result() -> None:
+    context = _build_context({"alpha": _stdio_server("alpha")})
+    aggregator = MCPAggregator(
+        server_names=["alpha"],
+        connection_persistence=False,
+        context=context,
+    )
+    sentinel_capabilities = object()
+    calls: list[str] = []
+
+    async def fake_get_server_capabilities(server_name: str, client_session_factory=None):
+        del client_session_factory
+        calls.append(server_name)
+        return sentinel_capabilities
+
+    context.server_registry.get_server_capabilities = fake_get_server_capabilities  # type: ignore[method-assign]
+
+    assert await aggregator.get_capabilities("alpha") is sentinel_capabilities
+    assert await aggregator.get_capabilities("alpha") is sentinel_capabilities
+    assert calls == ["alpha"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_server_tools_re_raises_infrastructure_failure() -> None:
+    context = _build_context({"alpha": _stdio_server("alpha")})
+
+    class InfraAggregator(MCPAggregator):
+        async def server_supports_feature(self, server_name: str, feature: str) -> bool:
+            del server_name, feature
+            return False
+
+        async def _execute_on_server(
+            self,
+            server_name: str,
+            operation_type: str,
+            operation_name: str,
+            method_name: str,
+            method_args=None,
+            error_factory=None,
+            progress_callback=None,
+        ):
+            del (
+                server_name,
+                operation_type,
+                operation_name,
+                method_name,
+                method_args,
+                error_factory,
+                progress_callback,
+            )
+            raise AttributeError("'ServerRegistry' object has no attribute 'initialize_server'")
+
+    aggregator = InfraAggregator(
+        server_names=["alpha"],
+        connection_persistence=False,
+        context=context,
+    )
+
+    with pytest.raises(AttributeError):
+        await aggregator._fetch_server_tools("alpha")
+
+
+@pytest.mark.asyncio
+async def test_fetch_server_tools_returns_empty_for_method_not_found() -> None:
+    context = _build_context({"alpha": _stdio_server("alpha")})
+
+    class NoToolsAggregator(MCPAggregator):
+        async def server_supports_feature(self, server_name: str, feature: str) -> bool:
+            del server_name, feature
+            return False
+
+        async def _execute_on_server(
+            self,
+            server_name: str,
+            operation_type: str,
+            operation_name: str,
+            method_name: str,
+            method_args=None,
+            error_factory=None,
+            progress_callback=None,
+        ):
+            del (
+                server_name,
+                operation_type,
+                operation_name,
+                method_name,
+                method_args,
+                error_factory,
+                progress_callback,
+            )
+            raise McpError(ErrorData(code=-32601, message="Method not found"))
+
+    aggregator = NoToolsAggregator(
+        server_names=["alpha"],
+        connection_persistence=False,
+        context=context,
+    )
+
+    assert await aggregator._fetch_server_tools("alpha") == []

--- a/tests/unit/fast_agent/mcp/test_transport_factory_validation.py
+++ b/tests/unit/fast_agent/mcp/test_transport_factory_validation.py
@@ -3,71 +3,31 @@
 import pytest
 
 from fast_agent.config import MCPServerSettings
+from fast_agent.mcp.mcp_connection_manager import create_transport_context
 
 
 def test_transport_factory_validation_stdio_without_command():
     """Test that stdio transport without command raises appropriate error."""
-    from fast_agent.config import MCPSettings, Settings
-    from fast_agent.mcp_server_registry import ServerRegistry
-
-    # Create a server config with stdio transport but no command
     server_config = MCPServerSettings(transport="stdio")
 
-    # Create settings with this server
-    settings = Settings(mcp=MCPSettings(servers={"test_server": server_config}))
-
-    registry = ServerRegistry(settings)
-
-    # Should raise error when trying to create transport context
     with pytest.raises(ValueError, match="uses stdio transport but no command is specified"):
-        # We need to access the internal transport_context_factory
-        # This is a bit of a hack but necessary for unit testing
-        config = registry.get_server_config("test_server")
-        assert config is not None
-
-        # Simulate what happens inside launch_server
-        def transport_context_factory():
-            if config.transport == "stdio":
-                if not config.command:
-                    raise ValueError(
-                        "Server 'test_server' uses stdio transport but no command is specified"
-                    )
-
-        transport_context_factory()
+        create_transport_context(server_name="test_server", config=server_config)
 
 
 def test_transport_factory_validation_http_without_url():
     """Test that http transport without URL raises appropriate error."""
-    from fast_agent.config import MCPServerSettings
-
-    # Create a server config with http transport but no url
     server_config = MCPServerSettings(transport="http")
 
-    # Simulate what happens inside launch_server
-    def transport_context_factory():
-        if server_config.transport == "http":
-            if not server_config.url:
-                raise ValueError("Server 'test_server' uses http transport but no url is specified")
-
     with pytest.raises(ValueError, match="uses http transport but no url is specified"):
-        transport_context_factory()
+        create_transport_context(server_name="test_server", config=server_config)
 
 
 def test_transport_factory_validation_sse_without_url():
     """Test that sse transport without URL raises appropriate error."""
-    from fast_agent.config import MCPServerSettings
-
-    # Create a server config with sse transport but no url
     server_config = MCPServerSettings(transport="sse")
 
-    # Simulate what happens inside launch_server
-    def transport_context_factory():
-        if server_config.transport == "sse":
-            if not server_config.url:
-                raise ValueError("Server 'test_server' uses sse transport but no url is specified")
-
     with pytest.raises(ValueError, match="uses sse transport but no url is specified"):
-        transport_context_factory()
+        create_transport_context(server_name="test_server", config=server_config)
 
 
 def test_inferred_http_transport_has_url():


### PR DESCRIPTION
## Summary
- split temporary-session initialization from the persistent `ServerRegistry` contract used by `connect()`
- reuse shared transport bootstrap for one-shot server initialization so non-persistent capability/tool discovery follows the same startup path
- cache non-persistent capabilities and re-raise infrastructure failures instead of degrading them into an empty tool list
- add focused tests for the non-persistent registry/capability/error paths

## Validation
- `uv run ruff check .`
- `uv run ruff format --check src/fast_agent/mcp/gen_client.py src/fast_agent/mcp/interfaces.py src/fast_agent/mcp/mcp_aggregator.py src/fast_agent/mcp/mcp_connection_manager.py src/fast_agent/mcp_server_registry.py tests/unit/fast_agent/mcp/test_transport_factory_validation.py tests/unit/fast_agent/mcp/test_mcp_aggregator_nonpersistent.py`
- `uv run pytest tests/unit/fast_agent/mcp/test_mcp_aggregator_nonpersistent.py tests/unit/fast_agent/mcp/test_transport_factory_validation.py -q`
- `uv run pytest tests/unit/fast_agent/mcp -q` (`tests/unit/fast_agent/mcp/test_cimd.py::TestCallbackServerPortFallback::test_callback_server_port_fallback` still fails on this Windows environment)
- `uv run ty check ./tests ./src` (remaining diagnostics are pre-existing Windows/platform attribute checks in `oauth_client.py`, `shell_runtime.py`, `console.py`, and `interactive_shell.py`)
