### PR TITLE
fix: include logo_uri in OAuth client metadata

### DIFF
--- a/src/fast_agent/mcp/oauth_client.py
+++ b/src/fast_agent/mcp/oauth_client.py
@@ -728,6 +728,7 @@ def build_oauth_provider(
 
     metadata_kwargs: dict[str, Any] = {
         "client_name": "fast-agent",
+        "logo_uri": "https://fast-agent.ai/logo.png",
         "redirect_uris": redirect_uris,
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],

--- a/tests/unit/fast_agent/mcp/test_cimd.py
+++ b/tests/unit/fast_agent/mcp/test_cimd.py
@@ -127,6 +127,31 @@ class TestCIMDOAuthProvider:
 
         assert captured_kwargs.get("client_metadata_url") == "https://fast-agent.ai/oauth/client.json"
 
+    def test_build_oauth_provider_includes_logo_uri_in_client_metadata(self, monkeypatch):
+        """build_oauth_provider should include logo_uri in generated client metadata."""
+        captured_kwargs = {}
+
+        class MockOAuthClientProvider:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+        monkeypatch.setattr(
+            "fast_agent.mcp.oauth_client.OAuthClientProvider",
+            MockOAuthClientProvider,
+        )
+
+        config = MCPServerSettings(
+            name="test",
+            transport="http",
+            url="https://example.com/mcp",
+        )
+
+        build_oauth_provider(config)
+
+        client_metadata = captured_kwargs.get("client_metadata")
+        assert client_metadata is not None
+        assert str(client_metadata.logo_uri) == "https://fast-agent.ai/logo.png"
+
     def test_build_oauth_provider_can_disable_default_cimd_with_env(self, monkeypatch):
         """Setting FAST_AGENT_OAUTH_CLIENT_METADATA_URL to empty should disable default CIMD."""
         captured_kwargs = {}


### PR DESCRIPTION
## Summary
- include logo_uri in default OAuth client metadata

Fixes #710

## Changes
- add logo_uri to OAuthClientMetadata defaults
