### PR TITLE
fix: use max_completion_tokens for Azure OpenAI

### DIFF
--- a/src/fast_agent/llm/provider/openai/llm_openai.py
+++ b/src/fast_agent/llm/provider/openai/llm_openai.py
@@ -1208,7 +1208,10 @@ class OpenAILLM(
                 }
             )
         else:
-            base_args["max_tokens"] = request_params.maxTokens
+            if self.provider is Provider.AZURE:
+                base_args["max_completion_tokens"] = request_params.maxTokens
+            else:
+                base_args["max_tokens"] = request_params.maxTokens
             if tools:
                 base_args["parallel_tool_calls"] = request_params.parallel_tool_calls
 

--- a/tests/unit/fast_agent/llm/test_prepare_arguments.py
+++ b/tests/unit/fast_agent/llm/test_prepare_arguments.py
@@ -159,6 +159,16 @@ class TestRequestParamsInLLM:
         assert "max_iterations" not in result  # Should be excluded
         assert "parallel_tool_calls" not in result  # Should be excluded
 
+    def test_openai_azure_uses_max_completion_tokens(self):
+        """Azure OpenAI should use max_completion_tokens instead of max_tokens."""
+        llm = OpenAILLM(provider=Provider.AZURE)
+        params = RequestParams(model="gpt-4.1", maxTokens=123)
+
+        result = llm._prepare_api_request(messages=[], tools=None, request_params=params)
+
+        assert result["max_completion_tokens"] == 123
+        assert "max_tokens" not in result
+
     def test_anthropic_provider_arguments(self):
         """Test prepare_provider_arguments with Anthropic provider"""
         # Create an Anthropic LLM instance without initializing provider connections

--- a/tests/unit/fast_agent/llm/test_prepare_arguments.py
+++ b/tests/unit/fast_agent/llm/test_prepare_arguments.py
@@ -161,8 +161,10 @@ class TestRequestParamsInLLM:
 
     def test_openai_azure_uses_max_completion_tokens(self):
         """Azure OpenAI should use max_completion_tokens instead of max_tokens."""
-        llm = OpenAILLM(provider=Provider.AZURE)
+        llm = OpenAILLM(provider=Provider.AZURE, request_params=RequestParams(model="gpt-4.1"))
         params = RequestParams(model="gpt-4.1", maxTokens=123)
+
+        assert llm._reasoning is False
 
         result = llm._prepare_api_request(messages=[], tools=None, request_params=params)
 


### PR DESCRIPTION
## Summary
Fixes #461

- send max_completion_tokens instead of max_tokens for Azure OpenAI chat completions
- add a unit test covering Azure request args

## Testing
- not run (unit test added)