### PR TITLE
Update Skills-over-MCP host to current SEP-2640 schema + directory read

### DIFF
--- a/src/fast_agent/mcp/mcp_agent_client_session.py
+++ b/src/fast_agent/mcp/mcp_agent_client_session.py
@@ -724,12 +724,9 @@ class MCPAgentClientSession(ClientSession, ContextDependent):
 
         Sends ``resources/directory/read`` and reuses the ``resources/list``
         result shape (``resources`` + ``nextCursor``). Callers MUST only invoke
-        this against servers that declared ``directoryRead`` for the skills
-        extension. The method is not part of the closed ``ClientRequest`` union,
-        so the bare request is passed through our ``send_request`` override
-        (which only needs ``model_dump`` + tolerates a missing ``.root``);
-        wrapping it in ``ClientRequest`` would emit per-call union serializer
-        warnings.
+        this against servers that declared ``directoryRead``. The method is not in
+        the closed ``ClientRequest`` union, so the bare request goes through our
+        ``send_request`` override; wrapping it would emit union serializer warnings.
         """
         uri_obj: AnyUrl = uri if isinstance(uri, AnyUrl) else AnyUrl(uri)
         params = DirectoryReadRequestParams(uri=uri_obj, cursor=cursor)

--- a/src/fast_agent/mcp/mcp_agent_client_session.py
+++ b/src/fast_agent/mcp/mcp_agent_client_session.py
@@ -28,12 +28,15 @@ from mcp.types import (
     GetPromptRequestParams,
     GetPromptResult,
     Implementation,
+    ListResourcesResult,
     ListRootsResult,
+    PaginatedRequestParams,
     PingRequest,
     ProgressNotification,
     ReadResourceRequest,
     ReadResourceRequestParams,
     ReadResourceResult,
+    Request,
     RequestParams,
     Root,
     SamplingCapability,
@@ -41,6 +44,8 @@ from mcp.types import (
     ToolListChangedNotification,
 )
 from pydantic import AnyUrl, FileUrl
+from pydantic.networks import UrlConstraints
+from typing_extensions import Annotated, Literal
 
 from fast_agent.context_dependent import ContextDependent
 from fast_agent.core.logging.logger import get_logger
@@ -65,6 +70,21 @@ if TYPE_CHECKING:
     from fast_agent.mcp.transport_tracking import TransportChannelMetrics
 
 logger = get_logger(__name__)
+
+
+class DirectoryReadRequestParams(PaginatedRequestParams):
+    """Parameters for the SEP-2640 ``resources/directory/read`` method."""
+
+    uri: Annotated[AnyUrl, UrlConstraints(host_required=False)]
+
+
+class DirectoryReadRequest(
+    Request[DirectoryReadRequestParams, Literal["resources/directory/read"]]
+):
+    """List the direct children of a directory resource (SEP-2640)."""
+
+    method: Literal["resources/directory/read"] = "resources/directory/read"
+    params: DirectoryReadRequestParams
 
 
 def _progress_trace_enabled() -> bool:
@@ -693,6 +713,31 @@ class MCPAgentClientSession(ClientSession, ContextDependent):
 
         request = ReadResourceRequest(method="resources/read", params=params)
         return await self.send_request(ClientRequest(request), ReadResourceResult)
+
+    async def read_directory(
+        self,
+        uri: AnyUrl | str,
+        *,
+        cursor: str | None = None,
+    ) -> ListResourcesResult:
+        """List the direct children of a directory resource (SEP-2640).
+
+        Sends ``resources/directory/read`` and reuses the ``resources/list``
+        result shape (``resources`` + ``nextCursor``). Callers MUST only invoke
+        this against servers that declared ``directoryRead`` for the skills
+        extension. The method is not part of the closed ``ClientRequest`` union,
+        so the bare request is passed through our ``send_request`` override
+        (which only needs ``model_dump`` + tolerates a missing ``.root``);
+        wrapping it in ``ClientRequest`` would emit per-call union serializer
+        warnings.
+        """
+        uri_obj: AnyUrl = uri if isinstance(uri, AnyUrl) else AnyUrl(uri)
+        params = DirectoryReadRequestParams(uri=uri_obj, cursor=cursor)
+        request = DirectoryReadRequest(method="resources/directory/read", params=params)
+        return await self.send_request(
+            cast("ClientRequest", request),
+            ListResourcesResult,
+        )
 
     async def get_prompt(
         self,

--- a/src/fast_agent/mcp/mcp_aggregator.py
+++ b/src/fast_agent/mcp/mcp_aggregator.py
@@ -3209,15 +3209,11 @@ class MCPAggregator(ContextDependent):
         """List the direct children of a directory resource via SEP-2640.
 
         Routes ``resources/directory/read`` to the named server. Callers should
-        only invoke this against servers that declared ``directoryRead`` for the
-        ``io.modelcontextprotocol/skills`` extension.
+        only invoke this against servers that declared ``directoryRead``.
 
-        ``server_name`` is required: a directory walk is always scoped to the one
-        server that hosts the skill. We deliberately do not fan out across all
-        servers the way ``get_resource`` does -- a same-named directory URI could
-        exist on multiple servers, and silently returning the first one to answer
-        (or the first non-empty listing) would read off the wrong server and mask
-        real errors.
+        ``server_name`` is required: a walk is scoped to the one server hosting
+        the skill. Unlike ``get_resource`` we don't fan out, since a same-named
+        directory URI on another server would read off the wrong server.
         """
         if not self.initialized:
             await self.load_servers()

--- a/src/fast_agent/mcp/mcp_aggregator.py
+++ b/src/fast_agent/mcp/mcp_aggregator.py
@@ -3130,21 +3130,23 @@ class MCPAggregator(ContextDependent):
         # If we reach here, we couldn't find the resource on any server
         raise ValueError(f"Resource '{resource_uri}' not found on any server")
 
-    async def _get_resource_from_server(
-        self, server_name: str, resource_uri: str
-    ) -> ReadResourceResult:
-        """
-        Internal helper method to get a resource from a specific server.
+    async def _execute_resource_read(
+        self,
+        server_name: str,
+        *,
+        uri: str,
+        operation_type: str,
+        method_name: str,
+        noun: str,
+        extra_args: dict[str, Any] | None = None,
+    ) -> Any:
+        """Shared implementation behind ``get_resource`` and ``read_directory``.
 
-        Args:
-            server_name: Name of the server to get the resource from
-            resource_uri: URI of the resource to retrieve
-
-        Returns:
-            ReadResourceResult containing the resource
-
-        Raises:
-            Exception: If the resource couldn't be found or other error occurs
+        Both ``resources/read`` and ``resources/directory/read`` share the same
+        shape: verify the resources capability, emit a READING_RESOURCE progress
+        event, validate the URI, dispatch via ``_execute_on_server``, and treat a
+        ``None`` result as not-found. ``noun`` ("Resource"/"Directory") is woven
+        into the error messages.
         """
         # Check if server supports resources capability
         if not await self.server_supports_feature(server_name, "resources"):
@@ -3156,32 +3158,46 @@ class MCPAggregator(ContextDependent):
                 action=ProgressAction.READING_RESOURCE,
                 server_name=server_name,
                 agent_name=self.agent_name,
-                details=resource_uri,
-                extra={"resource_uri": resource_uri},
+                details=uri,
+                extra={"resource_uri": uri},
             ),
         )
 
         try:
-            uri = AnyUrl(resource_uri)
+            uri_obj = AnyUrl(uri)
         except Exception as e:
-            raise ValueError(f"Invalid resource URI: {resource_uri}. Error: {e}") from e
+            raise ValueError(f"Invalid {noun.lower()} URI: {uri}. Error: {e}") from e
 
-        # Use the _execute_on_server method to call read_resource on the server
+        method_args: dict[str, Any] = {"uri": uri_obj}
+        if extra_args:
+            method_args.update(extra_args)
+
         result = await self._execute_on_server(
             server_name=server_name,
-            operation_type="resources/read",
-            operation_name=resource_uri,
-            method_name="read_resource",
-            method_args={"uri": uri},
-            # Don't create ValueError, just return None on error so we can catch it
-            #            error_factory=lambda _: None,
+            operation_type=operation_type,
+            operation_name=uri,
+            method_name=method_name,
+            method_args=method_args,
+            # Don't create ValueError, just return None on error so we can catch it.
         )
 
         # If result is None, the resource was not found
         if result is None:
-            raise ValueError(f"Resource '{resource_uri}' not found on server '{server_name}'")
+            raise ValueError(f"{noun} '{uri}' not found on server '{server_name}'")
 
         return result
+
+    async def _get_resource_from_server(
+        self, server_name: str, resource_uri: str
+    ) -> ReadResourceResult:
+        """Internal helper method to get a resource from a specific server."""
+        return await self._execute_resource_read(
+            server_name,
+            uri=resource_uri,
+            operation_type="resources/read",
+            method_name="read_resource",
+            noun="Resource",
+        )
 
     async def read_directory(
         self,
@@ -3195,54 +3211,35 @@ class MCPAggregator(ContextDependent):
         Routes ``resources/directory/read`` to the named server. Callers should
         only invoke this against servers that declared ``directoryRead`` for the
         ``io.modelcontextprotocol/skills`` extension.
+
+        ``server_name`` is required: a directory walk is always scoped to the one
+        server that hosts the skill. We deliberately do not fan out across all
+        servers the way ``get_resource`` does -- a same-named directory URI could
+        exist on multiple servers, and silently returning the first one to answer
+        (or the first non-empty listing) would read off the wrong server and mask
+        real errors.
         """
         if not self.initialized:
             await self.load_servers()
 
-        if server_name is not None:
-            if server_name not in self.server_names:
-                raise ValueError(f"Server '{server_name}' not found")
-            return await self._read_directory_from_server(server_name, uri, cursor=cursor)
-
-        if not self.server_names:
-            raise ValueError("No servers available to read directory from")
-
-        for s_name in self.server_names:
-            try:
-                return await self._read_directory_from_server(s_name, uri, cursor=cursor)
-            except Exception:
-                continue
-
-        raise ValueError(f"Directory '{uri}' not found on any server")
+        if server_name is None:
+            raise ValueError("read_directory requires an explicit server_name")
+        if server_name not in self.server_names:
+            raise ValueError(f"Server '{server_name}' not found")
+        return await self._read_directory_from_server(server_name, uri, cursor=cursor)
 
     async def _read_directory_from_server(
         self, server_name: str, uri: str, *, cursor: str | None = None
     ) -> ListResourcesResult:
         """Internal helper to call ``resources/directory/read`` on a server."""
-        if not await self.server_supports_feature(server_name, "resources"):
-            raise ValueError(f"Server '{server_name}' does not support resources")
-
-        try:
-            uri_obj = AnyUrl(uri)
-        except Exception as e:
-            raise ValueError(f"Invalid directory URI: {uri}. Error: {e}") from e
-
-        method_args: dict[str, Any] = {"uri": uri_obj}
-        if cursor is not None:
-            method_args["cursor"] = cursor
-
-        result = await self._execute_on_server(
-            server_name=server_name,
+        return await self._execute_resource_read(
+            server_name,
+            uri=uri,
             operation_type="resources/directory/read",
-            operation_name=uri,
             method_name="read_directory",
-            method_args=method_args,
+            noun="Directory",
+            extra_args={"cursor": cursor} if cursor is not None else None,
         )
-
-        if result is None:
-            raise ValueError(f"Directory '{uri}' not found on server '{server_name}'")
-
-        return result
 
     async def _list_resources_from_server(
         self, server_name: str, *, check_support: bool = True

--- a/src/fast_agent/mcp/mcp_aggregator.py
+++ b/src/fast_agent/mcp/mcp_aggregator.py
@@ -3183,6 +3183,67 @@ class MCPAggregator(ContextDependent):
 
         return result
 
+    async def read_directory(
+        self,
+        uri: str,
+        *,
+        server_name: str | None = None,
+        cursor: str | None = None,
+    ) -> ListResourcesResult:
+        """List the direct children of a directory resource via SEP-2640.
+
+        Routes ``resources/directory/read`` to the named server. Callers should
+        only invoke this against servers that declared ``directoryRead`` for the
+        ``io.modelcontextprotocol/skills`` extension.
+        """
+        if not self.initialized:
+            await self.load_servers()
+
+        if server_name is not None:
+            if server_name not in self.server_names:
+                raise ValueError(f"Server '{server_name}' not found")
+            return await self._read_directory_from_server(server_name, uri, cursor=cursor)
+
+        if not self.server_names:
+            raise ValueError("No servers available to read directory from")
+
+        for s_name in self.server_names:
+            try:
+                return await self._read_directory_from_server(s_name, uri, cursor=cursor)
+            except Exception:
+                continue
+
+        raise ValueError(f"Directory '{uri}' not found on any server")
+
+    async def _read_directory_from_server(
+        self, server_name: str, uri: str, *, cursor: str | None = None
+    ) -> ListResourcesResult:
+        """Internal helper to call ``resources/directory/read`` on a server."""
+        if not await self.server_supports_feature(server_name, "resources"):
+            raise ValueError(f"Server '{server_name}' does not support resources")
+
+        try:
+            uri_obj = AnyUrl(uri)
+        except Exception as e:
+            raise ValueError(f"Invalid directory URI: {uri}. Error: {e}") from e
+
+        method_args: dict[str, Any] = {"uri": uri_obj}
+        if cursor is not None:
+            method_args["cursor"] = cursor
+
+        result = await self._execute_on_server(
+            server_name=server_name,
+            operation_type="resources/directory/read",
+            operation_name=uri,
+            method_name="read_directory",
+            method_args=method_args,
+        )
+
+        if result is None:
+            raise ValueError(f"Directory '{uri}' not found on server '{server_name}'")
+
+        return result
+
     async def _list_resources_from_server(
         self, server_name: str, *, check_support: bool = True
     ) -> list[Any]:

--- a/src/fast_agent/skills/mcp_registry.py
+++ b/src/fast_agent/skills/mcp_registry.py
@@ -1,9 +1,15 @@
 """SEP-2640 Skills over MCP registry support.
 
-This module intentionally implements the registry/install/update portion of the
-draft SEP: servers that advertise ``io.modelcontextprotocol/skills`` can be
-used as a source for installing SHA256-verified ``skill-md`` or archive entries
-into the normal managed skills directory.
+This module implements the registry/install/update portion of the Skills
+Extension SEP (SEP-2640): servers that advertise ``io.modelcontextprotocol/skills``
+can be used as a source for installing SHA256-verified skills into the normal
+managed skills directory.
+
+The index format follows the current SEP: each ``skills[]`` entry carries a
+verbatim ``frontmatter`` object (the skill's ``SKILL.md`` YAML rendered as JSON)
+plus an optional direct ``url``/``digest`` for ``SKILL.md`` and/or an
+``archives[]`` array of pre-packed forms. There is no ``type`` field; an entry
+must supply a usable ``url``, a non-empty ``archives``, or both.
 """
 
 from __future__ import annotations
@@ -18,7 +24,7 @@ import stat
 import tarfile
 import tempfile
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, Protocol
 from urllib.parse import urlparse
@@ -36,7 +42,7 @@ from fast_agent.skills.registry import SkillRegistry
 from fast_agent.utils.async_utils import run_coroutine
 
 if TYPE_CHECKING:
-    from mcp.types import ReadResourceResult
+    from mcp.types import ListResourcesResult, ReadResourceResult
 
 
 class McpSkillRegistryClient(Protocol):
@@ -45,6 +51,14 @@ class McpSkillRegistryClient(Protocol):
     async def get_resource(
         self, resource_uri: str, *, server_name: str | None = None
     ) -> "ReadResourceResult": ...
+
+
+class McpSkillInstallClient(McpSkillRegistryClient, Protocol):
+    """Client used to install skills; also walks directories for supporting files."""
+
+    async def read_directory(
+        self, uri: str, *, server_name: str | None = None, cursor: str | None = None
+    ) -> "ListResourcesResult": ...
 
 
 class McpSkillRegistryStatusClient(McpSkillRegistryClient, Protocol):
@@ -59,8 +73,26 @@ MAX_INDEX_BYTES = 1_048_576
 MAX_SKILL_MD_BYTES = 262_144
 MAX_ARCHIVE_BYTES = 10 * 1_048_576
 MAX_UNPACKED_ARCHIVE_BYTES = 50 * 1_048_576
+DIRECTORY_MIME_TYPE = "inode/directory"
 ArtifactType = Literal["skill-md", "archive"]
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+# Supported archive media types mapped to the extraction strategy.
+ARCHIVE_MEDIA_TYPES: dict[str, Literal["tar", "zip"]] = {
+    "application/gzip": "tar",
+    "application/x-gzip": "tar",
+    "application/x-tar": "tar",
+    "application/x-gtar": "tar",
+    "application/zip": "zip",
+    "application/x-zip-compressed": "zip",
+}
+
+
+@dataclass(frozen=True)
+class McpRegistryArchive:
+    url: str
+    mime_type: str
+    digest: str
 
 
 @dataclass(frozen=True)
@@ -72,6 +104,9 @@ class McpRegistrySkill:
     digest: str
     artifact_type: ArtifactType = "skill-md"
     server_version: str | None = None
+    frontmatter: dict[str, Any] = field(default_factory=dict)
+    archives: tuple[McpRegistryArchive, ...] = ()
+    artifact_mime_type: str | None = None
 
     @property
     def install_dir_name(self) -> str:
@@ -90,6 +125,17 @@ class McpSkillRegistry:
         return f"mcp-server {self.server_name}{version}"
 
 
+def _extension_settings(capabilities: ServerCapabilities | None) -> Mapping[str, Any] | None:
+    if capabilities is None:
+        return None
+    extras = capabilities.model_extra or {}
+    extensions = extras.get("extensions")
+    if not isinstance(extensions, Mapping):
+        return None
+    settings = extensions.get(SKILLS_EXTENSION)
+    return settings if isinstance(settings, Mapping) else None
+
+
 def server_supports_mcp_skills(capabilities: ServerCapabilities | None) -> bool:
     if capabilities is None:
         return False
@@ -98,6 +144,14 @@ def server_supports_mcp_skills(capabilities: ServerCapabilities | None) -> bool:
     if not isinstance(extensions, Mapping):
         return False
     return SKILLS_EXTENSION in extensions
+
+
+def server_supports_directory_read(capabilities: ServerCapabilities | None) -> bool:
+    """Whether the server declared ``directoryRead`` for the skills extension."""
+    settings = _extension_settings(capabilities)
+    if settings is None:
+        return False
+    return settings.get("directoryRead") is True
 
 
 async def scan_mcp_skill_registry(
@@ -122,49 +176,131 @@ async def scan_mcp_skill_registry(
     entries = _parse_index(result, server_name)
     skills: list[McpRegistrySkill] = []
     for entry in entries:
-        entry_type = entry.get("type")
-        if entry_type not in {"skill-md", "archive"}:
+        skill = _build_registry_skill(entry, server_name=server_name, server_version=server_version)
+        if skill is not None:
+            skills.append(skill)
+    return McpSkillRegistry(server_name=server_name, server_version=server_version, skills=skills)
+
+
+def _build_registry_skill(
+    entry: dict[str, Any],
+    *,
+    server_name: str,
+    server_version: str | None,
+) -> McpRegistrySkill | None:
+    frontmatter = entry.get("frontmatter")
+    if not isinstance(frontmatter, Mapping):
+        logger.warning("MCP skill entry missing frontmatter", data={"server": server_name})
+        return None
+    name = frontmatter.get("name")
+    if not isinstance(name, str) or not name.strip():
+        logger.warning("MCP skill entry frontmatter missing name", data={"server": server_name})
+        return None
+    name = name.strip()
+    description = frontmatter.get("description")
+    description = description.strip() if isinstance(description, str) else None
+
+    direct_url, direct_digest = _parse_direct_entry(entry, server_name=server_name, name=name)
+    archives = _parse_archives(entry, server_name=server_name, name=name)
+
+    # Prefer an archive (atomic, complete multi-file skill) when one is offered;
+    # otherwise fall back to the direct SKILL.md entry.
+    if archives:
+        chosen = archives[0]
+        artifact_type: ArtifactType = "archive"
+        source_url = chosen.url
+        digest = chosen.digest
+        artifact_mime_type: str | None = chosen.mime_type
+    elif direct_url is not None and direct_digest is not None:
+        artifact_type = "skill-md"
+        source_url = direct_url
+        digest = direct_digest
+        artifact_mime_type = None
+    else:
+        logger.warning(
+            "MCP skill entry has no usable url or archives",
+            data={"server": server_name, "name": name},
+        )
+        return None
+
+    return McpRegistrySkill(
+        name=name,
+        description=description,
+        source_url=source_url,
+        server_name=server_name,
+        digest=digest,
+        artifact_type=artifact_type,
+        server_version=server_version,
+        frontmatter=dict(frontmatter),
+        archives=tuple(archives),
+        artifact_mime_type=artifact_mime_type,
+    )
+
+
+def _parse_direct_entry(
+    entry: Mapping[str, Any], *, server_name: str, name: str
+) -> tuple[str | None, str | None]:
+    url = entry.get("url")
+    if not isinstance(url, str) or not url.strip():
+        return None, None
+    source_url = url.strip()
+    if source_url.lower().startswith("file://"):
+        logger.warning(
+            "Rejecting file:// MCP skill URL",
+            data={"server": server_name, "url": source_url},
+        )
+        return None, None
+    digest = entry.get("digest")
+    if not isinstance(digest, str) or not _is_valid_sha256_digest(digest):
+        logger.warning(
+            "MCP skill entry url missing valid sha256 digest",
+            data={"server": server_name, "name": name},
+        )
+        return None, None
+    return _resolve_entry_url(source_url), digest.strip()
+
+
+def _parse_archives(
+    entry: Mapping[str, Any], *, server_name: str, name: str
+) -> list[McpRegistryArchive]:
+    raw_archives = entry.get("archives")
+    if not isinstance(raw_archives, list):
+        return []
+    archives: list[McpRegistryArchive] = []
+    for raw in raw_archives:
+        if not isinstance(raw, Mapping):
+            continue
+        url = raw.get("url")
+        mime_type = raw.get("mimeType")
+        digest = raw.get("digest")
+        if not isinstance(url, str) or not url.strip():
+            continue
+        if url.strip().lower().startswith("file://"):
             logger.warning(
-                "Skipping unsupported MCP skill entry type",
-                data={"server": server_name, "type": entry_type},
+                "Rejecting file:// MCP skill archive URL",
+                data={"server": server_name, "name": name},
             )
             continue
-        name = entry.get("name")
-        url = entry.get("url")
-        digest = entry.get("digest")
-        description = entry.get("description")
-        if not isinstance(name, str) or not name.strip():
-            logger.warning("MCP skill entry missing name", data={"server": server_name})
-            continue
-        if not isinstance(url, str) or not url.strip():
-            logger.warning("MCP skill entry missing url", data={"server": server_name})
-            continue
-        source_url = url.strip()
-        if source_url.lower().startswith("file://"):
+        if not isinstance(mime_type, str) or mime_type.strip() not in ARCHIVE_MEDIA_TYPES:
             logger.warning(
-                "Rejecting file:// MCP skill URL",
-                data={"server": server_name, "url": source_url},
+                "Skipping MCP skill archive with unsupported media type",
+                data={"server": server_name, "name": name, "mimeType": mime_type},
             )
             continue
         if not isinstance(digest, str) or not _is_valid_sha256_digest(digest):
             logger.warning(
-                "MCP skill entry missing valid sha256 digest",
+                "MCP skill archive missing valid sha256 digest",
                 data={"server": server_name, "name": name},
             )
             continue
-        artifact_type: ArtifactType = "archive" if entry_type == "archive" else "skill-md"
-        skills.append(
-            McpRegistrySkill(
-                name=name.strip(),
-                description=description.strip() if isinstance(description, str) else None,
-                source_url=_resolve_entry_url(source_url),
-                server_name=server_name,
+        archives.append(
+            McpRegistryArchive(
+                url=_resolve_entry_url(url.strip()),
+                mime_type=mime_type.strip(),
                 digest=digest.strip(),
-                artifact_type=artifact_type,
-                server_version=server_version,
             )
         )
-    return McpSkillRegistry(server_name=server_name, server_version=server_version, skills=skills)
+    return archives
 
 
 async def list_mcp_skill_registries(
@@ -182,7 +318,7 @@ async def list_mcp_skill_registries(
 
 
 async def install_mcp_registry_skill(
-    aggregator: McpSkillRegistryClient,
+    aggregator: McpSkillInstallClient,
     skill: McpRegistrySkill,
     *,
     destination_root: Path,
@@ -201,7 +337,7 @@ async def install_mcp_registry_skill(
 
 
 async def update_mcp_registry_skill(
-    aggregator: McpSkillRegistryClient,
+    aggregator: McpSkillInstallClient,
     skill: McpRegistrySkill,
     *,
     skill_dir: Path,
@@ -290,7 +426,7 @@ def _first_bytes(result: "ReadResourceResult") -> bytes | None:
 
 
 async def _write_verified_mcp_skill(
-    aggregator: McpSkillRegistryClient,
+    aggregator: McpSkillInstallClient,
     skill: McpRegistrySkill,
     install_dir: Path,
 ) -> None:
@@ -302,6 +438,7 @@ async def _write_verified_mcp_skill(
 
     if skill.artifact_type == "skill-md":
         _write_skill_md_artifact(skill, artifact, install_dir)
+        await _materialize_supporting_files(aggregator, skill, install_dir)
     else:
         _write_archive_artifact(skill, artifact, install_dir)
 
@@ -340,7 +477,7 @@ def _write_archive_artifact(skill: McpRegistrySkill, artifact: bytes, install_di
         raise ValueError(f"MCP skill archive exceeds size limit: {skill.source_url}")
     install_dir.mkdir(parents=True, exist_ok=False)
     try:
-        if skill.source_url.lower().endswith(".zip"):
+        if _archive_strategy(skill) == "zip":
             _extract_zip_safely(artifact, install_dir)
         else:
             _extract_tar_safely(artifact, install_dir)
@@ -360,6 +497,118 @@ def _write_archive_artifact(skill: McpRegistrySkill, artifact: bytes, install_di
         if install_dir.exists():
             shutil.rmtree(install_dir)
         raise
+
+
+def _archive_strategy(skill: McpRegistrySkill) -> Literal["tar", "zip"]:
+    if skill.artifact_mime_type is not None:
+        strategy = ARCHIVE_MEDIA_TYPES.get(skill.artifact_mime_type)
+        if strategy is not None:
+            return strategy
+    # Fall back to the URL suffix when no (recognized) media type is available.
+    return "zip" if skill.source_url.lower().endswith(".zip") else "tar"
+
+
+async def _materialize_supporting_files(
+    aggregator: McpSkillInstallClient,
+    skill: McpRegistrySkill,
+    install_dir: Path,
+) -> None:
+    """Fetch a direct-entry skill's supporting files via ``resources/directory/read``.
+
+    A direct ``url`` entry only addresses ``SKILL.md``; its supporting files are
+    sibling resources. When the server advertises the ``directoryRead`` capability,
+    walk the skill root and materialize each child into ``install_dir``. Best-effort:
+    a failure leaves the (valid) single-file skill in place.
+    """
+    capabilities = await aggregator.get_capabilities(skill.server_name)
+    if not server_supports_directory_read(capabilities):
+        return
+    root_uri = _skill_root_uri(skill.source_url)
+    if root_uri is None:
+        return
+    try:
+        await _walk_skill_directory(
+            aggregator,
+            server_name=skill.server_name,
+            root_uri=root_uri,
+            dir_uri=root_uri,
+            install_dir=install_dir,
+            budget=_ByteBudget(MAX_UNPACKED_ARCHIVE_BYTES),
+        )
+    except Exception as exc:  # noqa: BLE001 - supporting files are best-effort.
+        logger.warning(
+            "Failed to materialize MCP skill supporting files",
+            data={"server": skill.server_name, "skill": skill.name, "error": str(exc)},
+        )
+
+
+class _ByteBudget:
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._used = 0
+
+    def add(self, size: int) -> None:
+        self._used += size
+        if self._used > self._limit:
+            raise ValueError("MCP skill supporting files exceed unpacked size limit")
+
+
+async def _walk_skill_directory(
+    aggregator: McpSkillInstallClient,
+    *,
+    server_name: str,
+    root_uri: str,
+    dir_uri: str,
+    install_dir: Path,
+    budget: _ByteBudget,
+) -> None:
+    cursor: str | None = None
+    while True:
+        listing = await aggregator.read_directory(dir_uri, server_name=server_name, cursor=cursor)
+        for resource in listing.resources:
+            child_uri = str(resource.uri)
+            relative = _relative_uri_path(root_uri, child_uri)
+            if relative is None:
+                continue
+            if resource.mimeType == DIRECTORY_MIME_TYPE:
+                await _walk_skill_directory(
+                    aggregator,
+                    server_name=server_name,
+                    root_uri=root_uri,
+                    dir_uri=child_uri,
+                    install_dir=install_dir,
+                    budget=budget,
+                )
+                continue
+            if relative == "SKILL.md":
+                continue  # already written from the direct entry
+            _validate_archive_name(relative)
+            content = await aggregator.get_resource(child_uri, server_name=server_name)
+            data = _first_bytes(content)
+            if data is None:
+                continue
+            budget.add(len(data))
+            destination = install_dir / PurePosixPath(relative)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(data)
+        cursor = listing.nextCursor
+        if not cursor:
+            break
+
+
+def _skill_root_uri(source_url: str) -> str | None:
+    suffix = "/SKILL.md"
+    if source_url.endswith(suffix):
+        return source_url[: -len(suffix)]
+    return None
+
+
+def _relative_uri_path(root_uri: str, child_uri: str) -> str | None:
+    prefix = root_uri.rstrip("/") + "/"
+    if not child_uri.startswith(prefix):
+        return None
+    relative = child_uri[len(prefix) :]
+    return relative or None
 
 
 def _extract_tar_safely(artifact: bytes, destination: Path) -> None:

--- a/src/fast_agent/skills/mcp_registry.py
+++ b/src/fast_agent/skills/mcp_registry.py
@@ -207,7 +207,13 @@ def _build_registry_skill(
     description = frontmatter.get("description")
     description = description.strip() if isinstance(description, str) else None
 
-    direct_url, direct_digest = _parse_direct_entry(entry, server_name=server_name, name=name)
+    direct = _validate_url_and_digest(
+        url=entry.get("url"),
+        digest=entry.get("digest"),
+        server_name=server_name,
+        name=name,
+        label="url",
+    )
     archives = _parse_archives(entry, server_name=server_name, name=name)
 
     # Prefer an archive (atomic, complete multi-file skill) when one is offered;
@@ -218,10 +224,9 @@ def _build_registry_skill(
         source_url = chosen.url
         digest = chosen.digest
         artifact_mime_type: str | None = chosen.mime_type
-    elif direct_url is not None and direct_digest is not None:
+    elif direct is not None:
         artifact_type = "skill-md"
-        source_url = direct_url
-        digest = direct_digest
+        source_url, digest = direct
         artifact_mime_type = None
     else:
         logger.warning(
@@ -244,26 +249,30 @@ def _build_registry_skill(
     )
 
 
-def _parse_direct_entry(
-    entry: Mapping[str, Any], *, server_name: str, name: str
-) -> tuple[str | None, str | None]:
-    url = entry.get("url")
+def _validate_url_and_digest(
+    *, url: Any, digest: Any, server_name: str, name: str, label: str
+) -> tuple[str, str] | None:
+    """Validate an artifact's ``url``/``digest`` pair, shared by direct entries and archives.
+
+    Returns ``(resolved_url, stripped_digest)`` or ``None`` when the url is
+    missing/empty (silently), points at ``file://``, or the digest is not a valid
+    sha256. ``label`` ("url" / "archive") is woven into the rejection warnings.
+    """
     if not isinstance(url, str) or not url.strip():
-        return None, None
+        return None
     source_url = url.strip()
     if source_url.lower().startswith("file://"):
         logger.warning(
-            "Rejecting file:// MCP skill URL",
-            data={"server": server_name, "url": source_url},
+            f"Rejecting file:// MCP skill {label}",
+            data={"server": server_name, "name": name, "url": source_url},
         )
-        return None, None
-    digest = entry.get("digest")
+        return None
     if not isinstance(digest, str) or not _is_valid_sha256_digest(digest):
         logger.warning(
-            "MCP skill entry url missing valid sha256 digest",
+            f"MCP skill {label} missing valid sha256 digest",
             data={"server": server_name, "name": name},
         )
-        return None, None
+        return None
     return _resolve_entry_url(source_url), digest.strip()
 
 
@@ -277,35 +286,25 @@ def _parse_archives(
     for raw in raw_archives:
         if not isinstance(raw, Mapping):
             continue
-        url = raw.get("url")
         mime_type = raw.get("mimeType")
-        digest = raw.get("digest")
-        if not isinstance(url, str) or not url.strip():
-            continue
-        if url.strip().lower().startswith("file://"):
-            logger.warning(
-                "Rejecting file:// MCP skill archive URL",
-                data={"server": server_name, "name": name},
-            )
-            continue
         if not isinstance(mime_type, str) or mime_type.strip() not in ARCHIVE_MEDIA_TYPES:
             logger.warning(
                 "Skipping MCP skill archive with unsupported media type",
                 data={"server": server_name, "name": name, "mimeType": mime_type},
             )
             continue
-        if not isinstance(digest, str) or not _is_valid_sha256_digest(digest):
-            logger.warning(
-                "MCP skill archive missing valid sha256 digest",
-                data={"server": server_name, "name": name},
-            )
+        validated = _validate_url_and_digest(
+            url=raw.get("url"),
+            digest=raw.get("digest"),
+            server_name=server_name,
+            name=name,
+            label="archive",
+        )
+        if validated is None:
             continue
+        url, digest = validated
         archives.append(
-            McpRegistryArchive(
-                url=_resolve_entry_url(url.strip()),
-                mime_type=mime_type.strip(),
-                digest=digest.strip(),
-            )
+            McpRegistryArchive(url=url, mime_type=mime_type.strip(), digest=digest)
         )
     return archives
 
@@ -524,8 +523,11 @@ async def _materialize_supporting_files(
 
     A direct ``url`` entry only addresses ``SKILL.md``; its supporting files are
     sibling resources. When the server advertises the ``directoryRead`` capability,
-    walk the skill root and materialize each child into ``install_dir``. Best-effort:
-    a failure leaves the (valid) single-file skill in place.
+    walk the skill root and materialize each child into ``install_dir``. Best-effort
+    and all-or-nothing: the walk writes into a staging directory and is merged into
+    ``install_dir`` only on full success, so a mid-walk failure (size budget, walk
+    limits, an unsafe path, or a transport error) leaves the (valid) single-file
+    skill in place rather than a half-written tree.
 
     Trust note: unlike the verified ``SKILL.md`` (digest-checked) and archive
     artifacts (whole bundle digest-checked), supporting files carry no digests in
@@ -539,22 +541,32 @@ async def _materialize_supporting_files(
     root_uri = _skill_root_uri(skill.source_url)
     if root_uri is None:
         return
-    try:
-        await _walk_skill_directory(
-            aggregator,
-            server_name=skill.server_name,
-            root_uri=root_uri,
-            dir_uri=root_uri,
-            install_dir=install_dir,
-            budget=_ByteBudget(MAX_UNPACKED_ARCHIVE_BYTES),
-            limits=_WalkLimits(),
-            depth=0,
-        )
-    except Exception as exc:  # noqa: BLE001 - supporting files are best-effort.
-        logger.warning(
-            "Failed to materialize MCP skill supporting files",
-            data={"server": skill.server_name, "skill": skill.name, "error": str(exc)},
-        )
+    with tempfile.TemporaryDirectory(
+        dir=install_dir.parent, prefix=f".{install_dir.name}.support-"
+    ) as staging_str:
+        staging = Path(staging_str)
+        try:
+            await _walk_skill_directory(
+                aggregator,
+                server_name=skill.server_name,
+                root_uri=root_uri,
+                dir_uri=root_uri,
+                dest_dir=staging,
+                budget=_ByteBudget(MAX_UNPACKED_ARCHIVE_BYTES),
+                limits=_WalkLimits(),
+                depth=0,
+            )
+        except Exception as exc:  # noqa: BLE001 - supporting files are best-effort.
+            # Staging is discarded on exit, so the partial tree never reaches
+            # install_dir; the verified single-file skill remains intact.
+            logger.warning(
+                "Failed to materialize MCP skill supporting files",
+                data={"server": skill.server_name, "skill": skill.name, "error": str(exc)},
+            )
+            return
+        # Full walk succeeded: merge the staged tree alongside the verified
+        # SKILL.md already present in install_dir.
+        shutil.copytree(staging, install_dir, dirs_exist_ok=True)
 
 
 class _ByteBudget:
@@ -592,7 +604,7 @@ async def _walk_skill_directory(
     server_name: str,
     root_uri: str,
     dir_uri: str,
-    install_dir: Path,
+    dest_dir: Path,
     budget: _ByteBudget,
     limits: _WalkLimits,
     depth: int,
@@ -608,6 +620,10 @@ async def _walk_skill_directory(
             child_uri = str(resource.uri)
             relative = _relative_uri_path(root_uri, child_uri)
             if relative is None:
+                logger.debug(
+                    "Skipping MCP skill resource outside skill root",
+                    data={"server": server_name, "root": root_uri, "uri": child_uri},
+                )
                 continue
             if resource.mimeType == DIRECTORY_MIME_TYPE:
                 await _walk_skill_directory(
@@ -615,21 +631,38 @@ async def _walk_skill_directory(
                     server_name=server_name,
                     root_uri=root_uri,
                     dir_uri=child_uri,
-                    install_dir=install_dir,
+                    dest_dir=dest_dir,
                     budget=budget,
                     limits=limits,
                     depth=depth + 1,
                 )
                 continue
-            if relative == "SKILL.md":
-                continue  # already written from the direct entry
+            if relative.casefold() == "skill.md":
+                # Already written (digest-verified) from the direct entry. The
+                # compare is case-insensitive so an unverified sibling named
+                # "skill.md"/"SKILL.MD" cannot clobber the verified SKILL.md on
+                # case-insensitive filesystems (Windows, macOS).
+                continue
             _validate_archive_name(relative)
             content = await aggregator.get_resource(child_uri, server_name=server_name)
             data = _first_bytes(content)
             if data is None:
+                # Reached the file branch but the resource carried no bytes. The
+                # common cause is a directory the server did not tag with the
+                # ``inode/directory`` mime type (so it was not recursed into) and
+                # whose children are therefore silently dropped. Log it so an
+                # incomplete install is diagnosable rather than invisible.
+                logger.debug(
+                    "MCP skill supporting resource returned no content; skipping",
+                    data={
+                        "server": server_name,
+                        "uri": child_uri,
+                        "mimeType": resource.mimeType,
+                    },
+                )
                 continue
             budget.add(len(data))
-            destination = install_dir / PurePosixPath(relative)
+            destination = dest_dir / PurePosixPath(relative)
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(data)
         cursor = listing.nextCursor
@@ -680,9 +713,22 @@ def _extract_zip_safely(artifact: bytes, destination: Path) -> None:
         archive.extractall(destination)
 
 
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
 def _validate_archive_name(name: str) -> None:
+    # These names are later joined with the OS path API. On Windows a backslash
+    # is a separator and "C:" is a drive anchor -- neither of which
+    # PurePosixPath treats specially -- so a POSIX-only check would let
+    # "..\\.." or "C:\\..." escape the install directory. Reject Windows
+    # separators and drive components in addition to POSIX absolute paths
+    # and "..".
+    if "\\" in name:
+        raise ValueError(f"Unsafe path in MCP skill archive: {name}")
     path = PurePosixPath(name)
     if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"Unsafe path in MCP skill archive: {name}")
+    if any(_WINDOWS_DRIVE_RE.match(part) for part in path.parts):
         raise ValueError(f"Unsafe path in MCP skill archive: {name}")
 
 

--- a/src/fast_agent/skills/mcp_registry.py
+++ b/src/fast_agent/skills/mcp_registry.py
@@ -73,6 +73,13 @@ MAX_INDEX_BYTES = 1_048_576
 MAX_SKILL_MD_BYTES = 262_144
 MAX_ARCHIVE_BYTES = 10 * 1_048_576
 MAX_UNPACKED_ARCHIVE_BYTES = 50 * 1_048_576
+# Bounds on a ``resources/directory/read`` walk so a buggy or hostile server
+# cannot hang the install. MAX_WALK_PAGES caps total ``read_directory`` calls
+# (guarding against a server that returns a never-terminating ``nextCursor``);
+# MAX_WALK_ENTRIES caps files+directories seen; MAX_WALK_DEPTH caps nesting.
+MAX_WALK_PAGES = 1_000
+MAX_WALK_ENTRIES = 10_000
+MAX_WALK_DEPTH = 32
 DIRECTORY_MIME_TYPE = "inode/directory"
 ArtifactType = Literal["skill-md", "archive"]
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -519,6 +526,12 @@ async def _materialize_supporting_files(
     sibling resources. When the server advertises the ``directoryRead`` capability,
     walk the skill root and materialize each child into ``install_dir``. Best-effort:
     a failure leaves the (valid) single-file skill in place.
+
+    Trust note: unlike the verified ``SKILL.md`` (digest-checked) and archive
+    artifacts (whole bundle digest-checked), supporting files carry no digests in
+    the index, so they are written on the server's word alone. Integrity here rests
+    on the transport and on having chosen to trust this MCP server; path traversal
+    is still blocked (``_validate_archive_name``) and total size is bounded.
     """
     capabilities = await aggregator.get_capabilities(skill.server_name)
     if not server_supports_directory_read(capabilities):
@@ -534,6 +547,8 @@ async def _materialize_supporting_files(
             dir_uri=root_uri,
             install_dir=install_dir,
             budget=_ByteBudget(MAX_UNPACKED_ARCHIVE_BYTES),
+            limits=_WalkLimits(),
+            depth=0,
         )
     except Exception as exc:  # noqa: BLE001 - supporting files are best-effort.
         logger.warning(
@@ -553,6 +568,24 @@ class _ByteBudget:
             raise ValueError("MCP skill supporting files exceed unpacked size limit")
 
 
+class _WalkLimits:
+    """Shared counters bounding a directory walk across all recursion branches."""
+
+    def __init__(self) -> None:
+        self._pages = 0
+        self._entries = 0
+
+    def count_page(self) -> None:
+        self._pages += 1
+        if self._pages > MAX_WALK_PAGES:
+            raise ValueError("MCP skill directory walk exceeded page limit")
+
+    def count_entry(self) -> None:
+        self._entries += 1
+        if self._entries > MAX_WALK_ENTRIES:
+            raise ValueError("MCP skill directory walk exceeded entry limit")
+
+
 async def _walk_skill_directory(
     aggregator: McpSkillInstallClient,
     *,
@@ -561,11 +594,17 @@ async def _walk_skill_directory(
     dir_uri: str,
     install_dir: Path,
     budget: _ByteBudget,
+    limits: _WalkLimits,
+    depth: int,
 ) -> None:
+    if depth > MAX_WALK_DEPTH:
+        raise ValueError("MCP skill directory walk exceeded depth limit")
     cursor: str | None = None
     while True:
+        limits.count_page()
         listing = await aggregator.read_directory(dir_uri, server_name=server_name, cursor=cursor)
         for resource in listing.resources:
+            limits.count_entry()
             child_uri = str(resource.uri)
             relative = _relative_uri_path(root_uri, child_uri)
             if relative is None:
@@ -578,6 +617,8 @@ async def _walk_skill_directory(
                     dir_uri=child_uri,
                     install_dir=install_dir,
                     budget=budget,
+                    limits=limits,
+                    depth=depth + 1,
                 )
                 continue
             if relative == "SKILL.md":

--- a/src/fast_agent/skills/mcp_registry.py
+++ b/src/fast_agent/skills/mcp_registry.py
@@ -74,15 +74,11 @@ MAX_INDEX_BYTES = 1_048_576
 MAX_SKILL_MD_BYTES = 262_144
 MAX_ARCHIVE_BYTES = 10 * 1_048_576
 MAX_UNPACKED_ARCHIVE_BYTES = 50 * 1_048_576
-# Per-resource cap for a supporting file fetched during a directory walk. The
-# cumulative ``MAX_UNPACKED_ARCHIVE_BYTES`` budget is only charged *after* a
-# resource is fetched, so without this a single oversized file would be fully
-# decoded into memory before the budget could reject it.
+# Per-resource cap for a supporting file, bounding any single file under the
+# cumulative ``MAX_UNPACKED_ARCHIVE_BYTES`` budget.
 MAX_SUPPORTING_FILE_BYTES = 10 * 1_048_576
 # Bounds on a ``resources/directory/read`` walk so a buggy or hostile server
-# cannot hang the install. MAX_WALK_PAGES caps total ``read_directory`` calls
-# (guarding against a server that returns a never-terminating ``nextCursor``);
-# MAX_WALK_ENTRIES caps files+directories seen; MAX_WALK_DEPTH caps nesting.
+# cannot hang the install: total pages (never-terminating cursor), entries, depth.
 MAX_WALK_PAGES = 1_000
 MAX_WALK_ENTRIES = 10_000
 MAX_WALK_DEPTH = 32
@@ -512,9 +508,8 @@ def _write_archive_artifact(skill: McpRegistrySkill, artifact: bytes, install_di
 
 
 def _archive_strategy(skill: McpRegistrySkill) -> Literal["tar", "zip"]:
-    # ``_parse_archives`` only accepts archives whose ``mimeType`` is in
-    # ``ARCHIVE_MEDIA_TYPES``, so an index-sourced archive always carries a
-    # recognized media type and the lookup is authoritative.
+    # ``_parse_archives`` only admits archives whose ``mimeType`` is known, so
+    # an index-sourced archive always resolves here.
     mime_type = skill.artifact_mime_type
     if mime_type is None or mime_type not in ARCHIVE_MEDIA_TYPES:
         raise ValueError(f"MCP skill archive has no recognized media type: {skill.source_url}")
@@ -528,19 +523,15 @@ async def _materialize_supporting_files(
 ) -> None:
     """Fetch a direct-entry skill's supporting files via ``resources/directory/read``.
 
-    A direct ``url`` entry only addresses ``SKILL.md``; its supporting files are
-    sibling resources. When the server advertises the ``directoryRead`` capability,
-    walk the skill root and materialize each child into ``install_dir``. Best-effort
-    and all-or-nothing: the walk writes into a staging directory and is merged into
-    ``install_dir`` only on full success, so a mid-walk failure (size budget, walk
-    limits, an unsafe path, or a transport error) leaves the (valid) single-file
-    skill in place rather than a half-written tree.
+    A direct ``url`` entry only addresses ``SKILL.md``; supporting files are
+    sibling resources. When the server advertises ``directoryRead``, walk the
+    skill root and materialize each child. All-or-nothing: the walk stages into a
+    temp dir and merges only on full success, so a mid-walk failure leaves the
+    verified single-file skill intact rather than a half-written tree.
 
-    Trust note: unlike the verified ``SKILL.md`` (digest-checked) and archive
-    artifacts (whole bundle digest-checked), supporting files carry no digests in
-    the index, so they are written on the server's word alone. Integrity here rests
-    on the transport and on having chosen to trust this MCP server; path traversal
-    is still blocked (``_validate_archive_name``) and total size is bounded.
+    Unlike the digest-checked ``SKILL.md`` and archive artifacts, supporting
+    files carry no digests, so they rest on trusting this server and the
+    transport; path traversal is still blocked and total size bounded.
     """
     capabilities = await aggregator.get_capabilities(skill.server_name)
     if not server_supports_directory_read(capabilities):
@@ -564,15 +555,13 @@ async def _materialize_supporting_files(
                 depth=0,
             )
         except Exception as exc:  # noqa: BLE001 - supporting files are best-effort.
-            # Staging is discarded on exit, so the partial tree never reaches
-            # install_dir; the verified single-file skill remains intact.
+            # Staging is discarded on exit; the verified skill remains intact.
             logger.warning(
                 "Failed to materialize MCP skill supporting files",
                 data={"server": skill.server_name, "skill": skill.name, "error": str(exc)},
             )
             return
-        # Full walk succeeded: merge the staged tree alongside the verified
-        # SKILL.md already present in install_dir.
+        # Walk succeeded: merge the staged tree alongside the verified SKILL.md.
         shutil.copytree(staging, install_dir, dirs_exist_ok=True)
 
 
@@ -645,21 +634,16 @@ async def _walk_skill_directory(
                 )
                 continue
             if relative.casefold() == "skill.md":
-                # Already written (digest-verified) from the direct entry. The
-                # compare is case-insensitive so an unverified sibling named
-                # "skill.md"/"SKILL.MD" cannot clobber the verified SKILL.md on
-                # case-insensitive filesystems (Windows, macOS).
+                # Already written (digest-verified) from the direct entry; skip
+                # case-insensitively so a sibling can't clobber it on Windows/macOS.
                 continue
             _validate_archive_name(relative)
             content = await aggregator.get_resource(child_uri, server_name=server_name)
             data = _first_bytes(content)
             if data is None:
-                # Reached the file branch but the resource carried no bytes. The
-                # common cause is a directory the server did not tag with the
-                # ``inode/directory`` mime type (so it was not recursed into) and
-                # whose children are therefore silently dropped, leaving an
-                # incomplete-but-"successful" install. Warn (not debug) so the
-                # gap is visible rather than invisible.
+                # No bytes -- often a directory the server failed to tag with
+                # ``inode/directory``, so its children are silently dropped. Warn
+                # so the gap is visible.
                 logger.warning(
                     "MCP skill supporting resource returned no content; skipping "
                     "(its children, if it is an untagged directory, are not installed)",
@@ -684,8 +668,7 @@ async def _walk_skill_directory(
 
 
 def _skill_root_uri(source_url: str) -> str | None:
-    # Case-insensitive: a server may legitimately address the manifest as
-    # ``/skill.md``; we still strip a fixed-length ``/SKILL.md`` suffix.
+    # Case-insensitive: the manifest may be addressed as ``/skill.md``.
     suffix = "/SKILL.md"
     if source_url.lower().endswith(suffix.lower()):
         return _normalize_uri(source_url[: -len(suffix)])
@@ -693,12 +676,11 @@ def _skill_root_uri(source_url: str) -> str | None:
 
 
 def _normalize_uri(uri: str) -> str:
-    """Best-effort RFC-3986 normalization matching ``AnyUrl`` (used for resource URIs).
+    """Normalize a URI through ``AnyUrl`` to match directory children.
 
-    Directory children arrive as ``str(resource.uri)`` where ``resource.uri`` is a
-    pydantic ``AnyUrl`` (dot-segments resolved, etc.). The skill root is sliced from
-    the raw index ``url`` string, so it must be normalized the same way or a prefix
-    comparison can spuriously fail and silently drop every child.
+    Children arrive as ``str(resource.uri)`` (an ``AnyUrl``); the root is sliced
+    from the raw index ``url``, so it must be normalized the same way or the
+    prefix comparison spuriously fails and drops every child.
     """
     try:
         return str(AnyUrl(uri))
@@ -746,12 +728,9 @@ _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 
 
 def _validate_archive_name(name: str) -> None:
-    # These names are later joined with the OS path API. On Windows a backslash
-    # is a separator and "C:" is a drive anchor -- neither of which
-    # PurePosixPath treats specially -- so a POSIX-only check would let
-    # "..\\.." or "C:\\..." escape the install directory. Reject Windows
-    # separators and drive components in addition to POSIX absolute paths
-    # and "..".
+    # Names are later joined with the OS path API. PurePosixPath ignores Windows
+    # separators and drive anchors, so reject those too or "..\\.." / "C:\\..."
+    # could escape the install dir on Windows.
     if "\\" in name:
         raise ValueError(f"Unsafe path in MCP skill archive: {name}")
     path = PurePosixPath(name)

--- a/src/fast_agent/skills/mcp_registry.py
+++ b/src/fast_agent/skills/mcp_registry.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, Protocol
 from urllib.parse import urlparse
 
 from mcp.types import BlobResourceContents, ServerCapabilities, TextResourceContents
+from pydantic import AnyUrl
 
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.marketplace import git_sources as marketplace_git_sources
@@ -73,6 +74,11 @@ MAX_INDEX_BYTES = 1_048_576
 MAX_SKILL_MD_BYTES = 262_144
 MAX_ARCHIVE_BYTES = 10 * 1_048_576
 MAX_UNPACKED_ARCHIVE_BYTES = 50 * 1_048_576
+# Per-resource cap for a supporting file fetched during a directory walk. The
+# cumulative ``MAX_UNPACKED_ARCHIVE_BYTES`` budget is only charged *after* a
+# resource is fetched, so without this a single oversized file would be fully
+# decoded into memory before the budget could reject it.
+MAX_SUPPORTING_FILE_BYTES = 10 * 1_048_576
 # Bounds on a ``resources/directory/read`` walk so a buggy or hostile server
 # cannot hang the install. MAX_WALK_PAGES caps total ``read_directory`` calls
 # (guarding against a server that returns a never-terminating ``nextCursor``);
@@ -506,12 +512,13 @@ def _write_archive_artifact(skill: McpRegistrySkill, artifact: bytes, install_di
 
 
 def _archive_strategy(skill: McpRegistrySkill) -> Literal["tar", "zip"]:
-    if skill.artifact_mime_type is not None:
-        strategy = ARCHIVE_MEDIA_TYPES.get(skill.artifact_mime_type)
-        if strategy is not None:
-            return strategy
-    # Fall back to the URL suffix when no (recognized) media type is available.
-    return "zip" if skill.source_url.lower().endswith(".zip") else "tar"
+    # ``_parse_archives`` only accepts archives whose ``mimeType`` is in
+    # ``ARCHIVE_MEDIA_TYPES``, so an index-sourced archive always carries a
+    # recognized media type and the lookup is authoritative.
+    mime_type = skill.artifact_mime_type
+    if mime_type is None or mime_type not in ARCHIVE_MEDIA_TYPES:
+        raise ValueError(f"MCP skill archive has no recognized media type: {skill.source_url}")
+    return ARCHIVE_MEDIA_TYPES[mime_type]
 
 
 async def _materialize_supporting_files(
@@ -650,10 +657,12 @@ async def _walk_skill_directory(
                 # Reached the file branch but the resource carried no bytes. The
                 # common cause is a directory the server did not tag with the
                 # ``inode/directory`` mime type (so it was not recursed into) and
-                # whose children are therefore silently dropped. Log it so an
-                # incomplete install is diagnosable rather than invisible.
-                logger.debug(
-                    "MCP skill supporting resource returned no content; skipping",
+                # whose children are therefore silently dropped, leaving an
+                # incomplete-but-"successful" install. Warn (not debug) so the
+                # gap is visible rather than invisible.
+                logger.warning(
+                    "MCP skill supporting resource returned no content; skipping "
+                    "(its children, if it is an untagged directory, are not installed)",
                     data={
                         "server": server_name,
                         "uri": child_uri,
@@ -661,6 +670,10 @@ async def _walk_skill_directory(
                     },
                 )
                 continue
+            if len(data) > MAX_SUPPORTING_FILE_BYTES:
+                raise ValueError(
+                    f"MCP skill supporting file exceeds size limit: {child_uri}"
+                )
             budget.add(len(data))
             destination = dest_dir / PurePosixPath(relative)
             destination.parent.mkdir(parents=True, exist_ok=True)
@@ -671,10 +684,26 @@ async def _walk_skill_directory(
 
 
 def _skill_root_uri(source_url: str) -> str | None:
+    # Case-insensitive: a server may legitimately address the manifest as
+    # ``/skill.md``; we still strip a fixed-length ``/SKILL.md`` suffix.
     suffix = "/SKILL.md"
-    if source_url.endswith(suffix):
-        return source_url[: -len(suffix)]
+    if source_url.lower().endswith(suffix.lower()):
+        return _normalize_uri(source_url[: -len(suffix)])
     return None
+
+
+def _normalize_uri(uri: str) -> str:
+    """Best-effort RFC-3986 normalization matching ``AnyUrl`` (used for resource URIs).
+
+    Directory children arrive as ``str(resource.uri)`` where ``resource.uri`` is a
+    pydantic ``AnyUrl`` (dot-segments resolved, etc.). The skill root is sliced from
+    the raw index ``url`` string, so it must be normalized the same way or a prefix
+    comparison can spuriously fail and silently drop every child.
+    """
+    try:
+        return str(AnyUrl(uri))
+    except Exception:  # noqa: BLE001 - fall back to the raw string if unparseable.
+        return uri
 
 
 def _relative_uri_path(root_uri: str, child_uri: str) -> str | None:

--- a/src/fast_agent/skills/mcp_source.py
+++ b/src/fast_agent/skills/mcp_source.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 from fast_agent.skills.mcp_registry import (
     McpRegistrySkill,
+    McpSkillInstallClient,
     McpSkillRegistry,
-    McpSkillRegistryClient,
     install_mcp_registry_skill,
     select_mcp_registry_skill,
     update_mcp_registry_skill,
@@ -29,7 +29,7 @@ class McpSkillSource:
     def __init__(
         self,
         *,
-        aggregator: McpSkillRegistryClient,
+        aggregator: McpSkillInstallClient,
         registry: McpSkillRegistry,
     ) -> None:
         self._aggregator = aggregator

--- a/src/fast_agent/skills/source_resolver.py
+++ b/src/fast_agent/skills/source_resolver.py
@@ -11,7 +11,7 @@ from fast_agent.skills.mcp_source import McpSkillSource, UnavailableMcpSkillSour
 
 if TYPE_CHECKING:
     from fast_agent.commands.context import CommandContext
-    from fast_agent.skills.mcp_registry import McpSkillRegistry, McpSkillRegistryClient
+    from fast_agent.skills.mcp_registry import McpSkillInstallClient, McpSkillRegistry
     from fast_agent.skills.models import SkillUpdateInfo
     from fast_agent.skills.sources import SkillInstallSource
 
@@ -111,7 +111,7 @@ class SkillSourceResolver:
                 source=None,
                 error="This agent does not expose MCP skill registries.",
             )
-        registry_client = cast("McpSkillRegistryClient", agent.aggregator)
+        registry_client = cast("McpSkillInstallClient", agent.aggregator)
         return SkillSourceResolution(
             source=McpSkillSource(aggregator=registry_client, registry=registry)
         )
@@ -167,7 +167,7 @@ class SkillSourceResolver:
         except KeyError:
             agent = None
         registry_client = (
-            cast("McpSkillRegistryClient", agent.aggregator)
+            cast("McpSkillInstallClient", agent.aggregator)
             if isinstance(agent, McpSkillRegistryAgent)
             else None
         )

--- a/tests/unit/fast_agent/mcp/test_mcp_aggregator_runtime_attach.py
+++ b/tests/unit/fast_agent/mcp/test_mcp_aggregator_runtime_attach.py
@@ -287,7 +287,7 @@ async def test_refresh_attached_server_cache_discovers_mcp_skill_registry() -> N
     index_uri = "skill://index.json"
     skill_uri = "skill://demo/SKILL.md"
     index_text = (
-        '{"skills":[{"name":"demo","description":"Demo skill","type":"skill-md",'
+        '{"skills":[{"frontmatter":{"name":"demo","description":"Demo skill"},'
         f'"url":"{skill_uri}","digest":"sha256:'
         '0000000000000000000000000000000000000000000000000000000000000000"}]}'
     )

--- a/tests/unit/fast_agent/skills/test_mcp_registry.py
+++ b/tests/unit/fast_agent/skills/test_mcp_registry.py
@@ -19,6 +19,7 @@ from pydantic import AnyUrl
 
 from fast_agent.skills.mcp_registry import (
     INDEX_URI,
+    MAX_WALK_PAGES,
     McpRegistrySkill,
     install_mcp_registry_skill,
     scan_mcp_skill_registry,
@@ -347,6 +348,40 @@ async def test_install_direct_skill_materializes_supporting_files(tmp_path) -> N
 
     assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
     assert (install_dir / "references" / "GUIDE.md").read_text(encoding="utf-8") == guide_text
+
+
+@pytest.mark.asyncio
+async def test_install_direct_skill_bounds_infinite_pagination(tmp_path) -> None:
+    """A server returning a never-terminating cursor must not hang the install."""
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nBody\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/SKILL.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+
+    class _InfinitePagerAggregator(_Aggregator):
+        def __init__(self) -> None:
+            super().__init__(
+                capabilities=_skills_capabilities(directory_read=True),
+                responses={"skill://demo/SKILL.md": skill_text},
+            )
+            self.calls = 0
+
+        async def read_directory(self, uri, *, server_name=None, cursor=None):
+            del uri, server_name, cursor
+            self.calls += 1
+            return ListResourcesResult(resources=[], nextCursor="more")
+
+    aggregator = _InfinitePagerAggregator()
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    # Walk is best-effort: it aborts at the page cap and leaves the valid skill.
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+    assert aggregator.calls <= MAX_WALK_PAGES + 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/fast_agent/skills/test_mcp_registry.py
+++ b/tests/unit/fast_agent/skills/test_mcp_registry.py
@@ -17,6 +17,7 @@ from mcp.types import (
 )
 from pydantic import AnyUrl
 
+from fast_agent.skills import mcp_registry
 from fast_agent.skills.mcp_registry import (
     INDEX_URI,
     MAX_WALK_PAGES,
@@ -349,6 +350,75 @@ async def test_install_direct_skill_materializes_supporting_files(tmp_path) -> N
 
     assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
     assert (install_dir / "references" / "GUIDE.md").read_text(encoding="utf-8") == guide_text
+
+
+@pytest.mark.asyncio
+async def test_install_direct_skill_walks_lowercase_skill_md_url(tmp_path) -> None:
+    """A url addressing the manifest as '/skill.md' still triggers the directory walk.
+
+    The skill root is derived by stripping the manifest suffix case-insensitively;
+    a case-sensitive check would silently disable supporting-file materialization.
+    """
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nSee GUIDE.md\n"
+    guide_text = "# Guide\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/skill.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+    aggregator = _Aggregator(
+        capabilities=_skills_capabilities(directory_read=True),
+        responses={
+            "skill://demo/skill.md": skill_text,
+            "skill://demo/GUIDE.md": guide_text,
+        },
+        directories={
+            "skill://demo": [
+                Resource(uri=AnyUrl("skill://demo/GUIDE.md"), name="GUIDE.md"),
+            ],
+        },
+    )
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+    assert (install_dir / "GUIDE.md").read_text(encoding="utf-8") == guide_text
+
+
+@pytest.mark.asyncio
+async def test_install_direct_skill_rejects_oversized_supporting_file(
+    tmp_path, monkeypatch
+) -> None:
+    """A supporting file over the per-resource cap aborts the (best-effort) walk."""
+    monkeypatch.setattr(mcp_registry, "MAX_SUPPORTING_FILE_BYTES", 16)
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nBody\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/SKILL.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+    aggregator = _Aggregator(
+        capabilities=_skills_capabilities(directory_read=True),
+        responses={
+            "skill://demo/SKILL.md": skill_text,
+            "skill://demo/BIG.md": "x" * 1024,  # exceeds the patched 16-byte cap
+        },
+        directories={
+            "skill://demo": [
+                Resource(uri=AnyUrl("skill://demo/BIG.md"), name="BIG.md"),
+            ],
+        },
+    )
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    # Verified single-file skill survives; the oversized sibling is not written.
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+    assert not (install_dir / "BIG.md").exists()
 
 
 def test_validate_archive_name_rejects_windows_traversal() -> None:

--- a/tests/unit/fast_agent/skills/test_mcp_registry.py
+++ b/tests/unit/fast_agent/skills/test_mcp_registry.py
@@ -21,6 +21,7 @@ from fast_agent.skills.mcp_registry import (
     INDEX_URI,
     MAX_WALK_PAGES,
     McpRegistrySkill,
+    _validate_archive_name,
     install_mcp_registry_skill,
     scan_mcp_skill_registry,
     server_supports_directory_read,
@@ -348,6 +349,89 @@ async def test_install_direct_skill_materializes_supporting_files(tmp_path) -> N
 
     assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
     assert (install_dir / "references" / "GUIDE.md").read_text(encoding="utf-8") == guide_text
+
+
+def test_validate_archive_name_rejects_windows_traversal() -> None:
+    # Forward-slash traversal and POSIX absolute paths (pre-existing guard).
+    for bad in ("../evil.md", "/etc/passwd", "a/../../b"):
+        with pytest.raises(ValueError):
+            _validate_archive_name(bad)
+    # Windows separators and drive anchors: a PurePosixPath-only check would
+    # let these escape install_dir when later joined with the OS path API.
+    for bad in ("..\\..\\evil.md", "sub\\evil.md", "C:\\Windows\\evil", "C:/Windows/evil"):
+        with pytest.raises(ValueError):
+            _validate_archive_name(bad)
+    # Legitimate nested names still pass.
+    _validate_archive_name("references/GUIDE.md")
+    _validate_archive_name("a/b/c.txt")
+
+
+@pytest.mark.asyncio
+async def test_install_direct_skill_does_not_overwrite_verified_skill_md(tmp_path) -> None:
+    """A sibling named 'skill.md' must not clobber the digest-verified SKILL.md.
+
+    On case-insensitive filesystems (Windows, macOS) an unverified sibling whose
+    name differs only in case would otherwise overwrite the verified SKILL.md.
+    """
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nVerified body\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/SKILL.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+    aggregator = _Aggregator(
+        capabilities=_skills_capabilities(directory_read=True),
+        responses={
+            "skill://demo/SKILL.md": skill_text,
+            "skill://demo/skill.md": "UNVERIFIED OVERWRITE",
+        },
+        directories={
+            "skill://demo": [
+                Resource(uri=AnyUrl("skill://demo/SKILL.md"), name="SKILL.md"),
+                Resource(uri=AnyUrl("skill://demo/skill.md"), name="skill.md"),
+            ],
+        },
+    )
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+
+
+@pytest.mark.asyncio
+async def test_install_direct_skill_rolls_back_partial_supporting_files(tmp_path) -> None:
+    """A mid-walk failure leaves only the verified SKILL.md, not a half-written tree."""
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nBody\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/SKILL.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+    aggregator = _Aggregator(
+        capabilities=_skills_capabilities(directory_read=True),
+        responses={
+            "skill://demo/SKILL.md": skill_text,
+            "skill://demo/GUIDE.md": "# Guide\n",
+        },
+        directories={
+            # GUIDE.md is staged first, then the unsafe backslash sibling raises
+            # mid-walk (validated by _validate_archive_name).
+            "skill://demo": [
+                Resource(uri=AnyUrl("skill://demo/GUIDE.md"), name="GUIDE.md"),
+                Resource(uri=AnyUrl(r"skill://demo/..\..\evil.md"), name="evil.md"),
+            ],
+        },
+    )
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+    # The walk failed after staging GUIDE.md, so nothing is merged in.
+    assert not (install_dir / "GUIDE.md").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/fast_agent/skills/test_mcp_registry.py
+++ b/tests/unit/fast_agent/skills/test_mcp_registry.py
@@ -9,7 +9,9 @@ from io import BytesIO
 import pytest
 from mcp.types import (
     BlobResourceContents,
+    ListResourcesResult,
     ReadResourceResult,
+    Resource,
     ServerCapabilities,
     TextResourceContents,
 )
@@ -20,6 +22,7 @@ from fast_agent.skills.mcp_registry import (
     McpRegistrySkill,
     install_mcp_registry_skill,
     scan_mcp_skill_registry,
+    server_supports_directory_read,
     server_supports_mcp_skills,
 )
 from fast_agent.skills.provenance import read_installed_skill_source
@@ -54,9 +57,11 @@ class _Aggregator:
         *,
         capabilities: ServerCapabilities,
         responses: dict[str, str | bytes],
+        directories: dict[str, list[Resource]] | None = None,
     ) -> None:
         self.capabilities = capabilities
         self.responses = responses
+        self.directories = directories or {}
 
     async def get_capabilities(self, server_name: str) -> ServerCapabilities:
         del server_name
@@ -71,9 +76,18 @@ class _Aggregator:
             return _blob(resource_uri, response)
         return _text(resource_uri, response)
 
+    async def read_directory(
+        self, uri: str, *, server_name: str | None = None, cursor: str | None = None
+    ) -> ListResourcesResult:
+        del server_name, cursor
+        return ListResourcesResult(resources=self.directories.get(uri, []))
 
-def _skills_capabilities() -> ServerCapabilities:
-    return ServerCapabilities.model_validate({"extensions": {"io.modelcontextprotocol/skills": {}}})
+
+def _skills_capabilities(*, directory_read: bool = False) -> ServerCapabilities:
+    settings: dict[str, object] = {"directoryRead": True} if directory_read else {}
+    return ServerCapabilities.model_validate(
+        {"extensions": {"io.modelcontextprotocol/skills": settings}}
+    )
 
 
 def _tar_gz(files: dict[str, bytes]) -> bytes:
@@ -91,15 +105,20 @@ def test_server_supports_mcp_skills_from_extensions_extra() -> None:
     assert not server_supports_mcp_skills(ServerCapabilities())
 
 
+def test_server_supports_directory_read() -> None:
+    assert server_supports_directory_read(_skills_capabilities(directory_read=True))
+    # An empty extension object means supported but without directoryRead.
+    assert not server_supports_directory_read(_skills_capabilities(directory_read=False))
+    assert not server_supports_directory_read(ServerCapabilities())
+
+
 @pytest.mark.asyncio
 async def test_scan_mcp_skill_registry_requires_capability() -> None:
     index = json.dumps(
         {
             "skills": [
                 {
-                    "type": "skill-md",
-                    "name": "demo",
-                    "description": "Demo skill",
+                    "frontmatter": {"name": "demo", "description": "Demo skill"},
                     "url": "skill://demo/SKILL.md",
                     "digest": "sha256:" + "0" * 64,
                 }
@@ -119,23 +138,23 @@ async def test_scan_mcp_skill_registry_reads_verified_skill_entries() -> None:
         {
             "skills": [
                 {
-                    "type": "skill-md",
-                    "name": "demo",
-                    "description": "Demo skill",
+                    "frontmatter": {"name": "demo", "description": "Demo skill"},
                     "url": "skill://demo/SKILL.md",
                     "digest": _digest(skill_text),
                 },
                 {
-                    "type": "archive",
-                    "name": "bundle",
-                    "description": "Bundled skill",
-                    "url": "bundle/bundle.tar.gz",
-                    "digest": _digest(archive),
+                    "frontmatter": {"name": "bundle", "description": "Bundled skill"},
+                    "archives": [
+                        {
+                            "url": "bundle/bundle.tar.gz",
+                            "mimeType": "application/gzip",
+                            "digest": _digest(archive),
+                        }
+                    ],
                 },
                 {
-                    "type": "mcp-resource-template",
-                    "description": "Template",
-                    "url": "skill://docs/{product}/SKILL.md",
+                    # No url and no archives -> not installable, skipped.
+                    "frontmatter": {"name": "broken", "description": "Missing artifacts"},
                 },
             ]
         }
@@ -148,10 +167,71 @@ async def test_scan_mcp_skill_registry_reads_verified_skill_entries() -> None:
     assert registry.server_name == "hf"
     assert registry.server_version == "1.2.3"
     assert [skill.name for skill in registry.skills] == ["demo", "bundle"]
+    assert registry.skills[0].artifact_type == "skill-md"
     assert registry.skills[0].source_url == "skill://demo/SKILL.md"
     assert registry.skills[0].digest == _digest(skill_text)
+    assert registry.skills[0].description == "Demo skill"
+    assert registry.skills[0].frontmatter == {"name": "demo", "description": "Demo skill"}
     assert registry.skills[1].artifact_type == "archive"
     assert registry.skills[1].source_url == "skill://bundle/bundle.tar.gz"
+    assert registry.skills[1].artifact_mime_type == "application/gzip"
+
+
+@pytest.mark.asyncio
+async def test_scan_prefers_archive_when_entry_has_both() -> None:
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nBody\n"
+    archive = _tar_gz({"SKILL.md": skill_text.encode("utf-8")})
+    index = json.dumps(
+        {
+            "skills": [
+                {
+                    "frontmatter": {"name": "demo", "description": "Demo skill"},
+                    "url": "skill://demo/SKILL.md",
+                    "digest": _digest(skill_text),
+                    "archives": [
+                        {
+                            "url": "skill://demo.tar.gz",
+                            "mimeType": "application/gzip",
+                            "digest": _digest(archive),
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    aggregator = _Aggregator(capabilities=_skills_capabilities(), responses={INDEX_URI: index})
+
+    registry = await scan_mcp_skill_registry(aggregator, "hf")
+
+    assert registry is not None
+    assert registry.skills[0].artifact_type == "archive"
+    assert registry.skills[0].source_url == "skill://demo.tar.gz"
+
+
+@pytest.mark.asyncio
+async def test_scan_ignores_unsupported_archive_media_type() -> None:
+    index = json.dumps(
+        {
+            "skills": [
+                {
+                    "frontmatter": {"name": "demo", "description": "Demo skill"},
+                    "archives": [
+                        {
+                            "url": "skill://demo.7z",
+                            "mimeType": "application/x-7z-compressed",
+                            "digest": "sha256:" + "0" * 64,
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    aggregator = _Aggregator(capabilities=_skills_capabilities(), responses={INDEX_URI: index})
+
+    registry = await scan_mcp_skill_registry(aggregator, "hf")
+
+    assert registry is not None
+    assert registry.skills == []
 
 
 @pytest.mark.asyncio
@@ -160,9 +240,7 @@ async def test_scan_mcp_skill_registry_rejects_padded_file_urls() -> None:
         {
             "skills": [
                 {
-                    "type": "skill-md",
-                    "name": "local",
-                    "description": "Local skill",
+                    "frontmatter": {"name": "local", "description": "Local skill"},
                     "url": " file:///tmp/SKILL.md",
                     "digest": "sha256:" + "0" * 64,
                 }
@@ -183,9 +261,7 @@ async def test_scan_mcp_skill_registry_skips_entries_without_sha256() -> None:
         {
             "skills": [
                 {
-                    "type": "skill-md",
-                    "name": "demo",
-                    "description": "Demo skill",
+                    "frontmatter": {"name": "demo", "description": "Demo skill"},
                     "url": "skill://demo/SKILL.md",
                 }
             ]
@@ -236,6 +312,70 @@ async def test_install_mcp_registry_skill_writes_provenance(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_install_direct_skill_materializes_supporting_files(tmp_path) -> None:
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nSee references/GUIDE.md\n"
+    guide_text = "# Guide\nbody\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/SKILL.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+    aggregator = _Aggregator(
+        capabilities=_skills_capabilities(directory_read=True),
+        responses={
+            "skill://demo/SKILL.md": skill_text,
+            "skill://demo/references/GUIDE.md": guide_text,
+        },
+        directories={
+            "skill://demo": [
+                Resource(uri=AnyUrl("skill://demo/SKILL.md"), name="SKILL.md"),
+                Resource(
+                    uri=AnyUrl("skill://demo/references"),
+                    name="references",
+                    mimeType="inode/directory",
+                ),
+            ],
+            "skill://demo/references": [
+                Resource(uri=AnyUrl("skill://demo/references/GUIDE.md"), name="GUIDE.md"),
+            ],
+        },
+    )
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+    assert (install_dir / "references" / "GUIDE.md").read_text(encoding="utf-8") == guide_text
+
+
+@pytest.mark.asyncio
+async def test_install_direct_skill_skips_walk_without_capability(tmp_path) -> None:
+    skill_text = "---\nname: demo\ndescription: Demo skill\n---\nBody\n"
+    skill = McpRegistrySkill(
+        name="demo",
+        description="Demo skill",
+        source_url="skill://demo/SKILL.md",
+        server_name="hf",
+        digest=_digest(skill_text),
+    )
+    aggregator = _Aggregator(
+        capabilities=_skills_capabilities(directory_read=False),
+        responses={"skill://demo/SKILL.md": skill_text},
+        directories={
+            "skill://demo": [
+                Resource(uri=AnyUrl("skill://demo/extra.md"), name="extra.md"),
+            ]
+        },
+    )
+
+    install_dir = await install_mcp_registry_skill(aggregator, skill, destination_root=tmp_path)
+
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == skill_text
+    assert not (install_dir / "extra.md").exists()
+
+
+@pytest.mark.asyncio
 async def test_install_mcp_registry_skill_rejects_digest_mismatch(tmp_path) -> None:
     skill_text = "---\nname: demo\ndescription: Demo skill\n---\nBody\n"
     skill = McpRegistrySkill(
@@ -272,6 +412,7 @@ async def test_install_mcp_registry_archive_skill(tmp_path) -> None:
         server_name="hf",
         digest=_digest(artifact),
         artifact_type="archive",
+        artifact_mime_type="application/gzip",
     )
     aggregator = _Aggregator(
         capabilities=_skills_capabilities(),


### PR DESCRIPTION
Updates the SEP-2640 Skills-over-MCP host to the current spec.

## What
- Index parsing moves to the **frontmatter-object + per-skill `archives[]`** schema (drops the old `type`/flat fields). An entry needs a usable `url` or non-empty `archives`; archive is preferred over the direct `SKILL.md` when both are present.
- Adds **`resources/directory/read`** (`directoryRead` capability) to materialize a direct-entry skill's supporting files. The walk is bounded (pages/entries/depth/per-file/total bytes), stages all-or-nothing so a mid-walk failure leaves the digest-verified `SKILL.md` intact, and guards Windows path traversal.
- `read_directory` requires an explicit `server_name` (no fan-out).

## Testing
- `uv run scripts/lint.py` clean; `uv run scripts/typecheck.py` shows only pre-existing diagnostics in unrelated files.
- 29 unit tests pass (schema, archive/direct selection, walk bounds, traversal, rollback).
- Verified live end-to-end against forked HF Space MCP server - see: https://github.com/huggingface/hf-mcp-server/pull/174 (deployed to personal HF space)


🤖 Generated with [Claude Code](https://claude.com/claude-code) - edited