### PR TITLE
Decode A2A resource filenames

### DIFF
--- a/src/fast_agent/a2a/remote_agent.py
+++ b/src/fast_agent/a2a/remote_agent.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import unquote
 
 import httpx
 from a2a.client import A2ACardResolver, ClientConfig, create_client
@@ -583,7 +584,7 @@ def _parts_from_messages(messages: Sequence[PromptMessageExtended]) -> list[Part
 
 
 def _filename_from_uri(uri: str) -> str:
-    path = PurePosixPath(uri.split("?", 1)[0])
+    path = PurePosixPath(unquote(uri.split("?", 1)[0]))
     return path.name or "attachment"
 
 

--- a/tests/unit/fast_agent/test_a2a_remote_agent_events.py
+++ b/tests/unit/fast_agent/test_a2a_remote_agent_events.py
@@ -20,7 +20,7 @@ from mcp.types import EmbeddedResource, TextContent, TextResourceContents
 from pydantic import AnyUrl
 
 from fast_agent.a2a.config import A2AAgentConfig
-from fast_agent.a2a.remote_agent import A2ARemoteAgent, _parts_from_messages
+from fast_agent.a2a.remote_agent import A2ARemoteAgent, _filename_from_uri, _parts_from_messages
 from fast_agent.agents.agent_types import AgentConfig, AgentType
 from fast_agent.types import PromptMessageExtended
 
@@ -107,6 +107,10 @@ def _artifact_update(
             last_chunk=last_chunk,
         )
     )
+
+
+def test_filename_from_uri_decodes_percent_encoded_names() -> None:
+    assert _filename_from_uri("resource:///reports/final%20summary.txt?version=1") == "final summary.txt"
 
 
 def test_a2a_remote_agent_starts_without_client_generated_context_id() -> None:


### PR DESCRIPTION
## What changed

Remote A2A resource filenames are now percent-decoded before being attached to A2A `Part` objects.

## Why

The server-side URI filename helper already decodes URL-encoded path segments. The remote-agent helper did not, so a resource URI such as `resource:///reports/final%20summary.txt` produced `final%20summary.txt` instead of the expected `final summary.txt`.

## Validation

- `python -m ruff check src\fast_agent\a2a\remote_agent.py tests\unit\fast_agent\test_a2a_remote_agent_events.py`
- `python -m py_compile src\fast_agent\a2a\remote_agent.py`

I could not run the targeted pytest locally because this Windows environment is missing the full project test dependency set (`opentelemetry.instrumentation.mcp`).