### PR TITLE
feat: add timeout option to fast-agent go

### DIFF
--- a/docs/docs/ref/config_file.md
+++ b/docs/docs/ref/config_file.md
@@ -36,7 +36,7 @@ model_references:
 auto_sampling: true
 
 # Number of times to retry transient LLM API errors (falls back to FAST_AGENT_RETRIES env)
-llm_retries: 1
+llm_retries: 2
 
 # Execution engine (only asyncio is currently supported)
 execution_engine: "asyncio"
@@ -62,7 +62,7 @@ Relative `compaction.prompt` file paths are resolved from the loaded config file
 `FAST_AGENT_HOME` points at a home config, the path is relative to that home config file; it is not
 resolved from the process current working directory.
 
-`llm_retries` defaults to `1` and is the preferred way to control retry attempts. If unset in
+`llm_retries` defaults to `2` and is the preferred way to control retry attempts. If unset in
 config, the `FAST_AGENT_RETRIES` environment variable is used as a fallback.
 
 ## Namespaced Model References
@@ -761,7 +761,7 @@ shell_execution:
 ## LLM Retries
 
 ```yaml
-llm_retries: 1
+llm_retries: 2
 ```
 
 ## Example Full Configuration

--- a/docs/docs/ref/go_command.md
+++ b/docs/docs/ref/go_command.md
@@ -56,6 +56,7 @@ fast-agent go [OPTIONS]
 - `--no-shell`: Disable local shell/filesystem tools, even when skills or agent config request them
 - `--reload`: Enable manual AgentCard reloads with `/reload`
 - `--watch`: Watch AgentCard paths and reload automatically
+- `--timeout`, `-t <seconds>`: Maximum one-shot execution duration for `--message` or `--prompt-file` runs
 
 Global CLI options (apply to all subcommands):
 

--- a/examples/setup/fast-agent.yaml
+++ b/examples/setup/fast-agent.yaml
@@ -24,7 +24,7 @@ default_model: gpt-5.4-mini?reasoning=low
 # agent model: "$system.fast"
 
 # Number of times to retry transient LLM API errors (falls back to FAST_AGENT_RETRIES env var)
-# llm_retries: 1
+# llm_retries: 2
 
 # Persist git repository provenance in session snapshots and trace exports.
 # Captures the repo root, commit, branch, dirty state, and sanitized origin URL

--- a/examples/workflows-md/hf-api-agent/fast-agent.yaml
+++ b/examples/workflows-md/hf-api-agent/fast-agent.yaml
@@ -13,7 +13,7 @@
 #default_model: gpt-5.4-mini?reasoning=low
 
 # Number of times to retry transient LLM API errors (falls back to FAST_AGENT_RETRIES env var)
-# llm_retries: 1
+# llm_retries: 2
 
 # otel:
 #   enabled: true

--- a/src/fast_agent/cli/commands/go.py
+++ b/src/fast_agent/cli/commands/go.py
@@ -303,7 +303,7 @@ def go(
         "--timeout",
         "-t",
         min=1,
-        help="Maximum execution duration in seconds",
+        help="Maximum one-shot execution duration in seconds",
     ),
 ) -> None:
     """Run an interactive agent directly from the command line."""

--- a/src/fast_agent/cli/commands/go.py
+++ b/src/fast_agent/cli/commands/go.py
@@ -298,6 +298,13 @@ def go(
         "-q",
         help="Disable progress/chat/tool output and print only direct command output",
     ),
+    timeout: int | None = typer.Option(
+        None,
+        "--timeout",
+        "-t",
+        min=1,
+        help="Maximum execution duration in seconds",
+    ),
 ) -> None:
     """Run an interactive agent directly from the command line."""
     if os.getenv(FAST_AGENT_SHELL_CHILD_ENV):
@@ -413,6 +420,7 @@ def go(
         reload=reload,
         watch=watch,
         quiet=quiet,
+        timeout_seconds=timeout,
     )
 
     update_notice = _resolve_request_update_notice(

--- a/src/fast_agent/cli/runtime/request_builders.py
+++ b/src/fast_agent/cli/runtime/request_builders.py
@@ -447,6 +447,7 @@ def build_agent_run_request(
     reload: bool,
     watch: bool,
     quiet: bool = False,
+    timeout_seconds: int | None = None,
     prefer_local_shell: bool = False,
     no_shell: bool = False,
     missing_shell_cwd_policy: Literal["ask", "create", "warn", "error"] | None = None,
@@ -553,6 +554,7 @@ def build_agent_run_request(
         watch=watch,
         execution_mode=execution_mode,
         quiet=quiet,
+        timeout_seconds=timeout_seconds,
         missing_shell_cwd_policy=missing_shell_cwd_policy,
     )
 
@@ -602,6 +604,7 @@ def build_command_run_request(
     reload: bool = False,
     watch: bool = False,
     quiet: bool = False,
+    timeout_seconds: int | None = None,
     prefer_local_shell: bool = False,
     no_shell: bool = False,
     missing_shell_cwd_policy: Literal["ask", "create", "warn", "error"] | None = None,
@@ -668,5 +671,6 @@ def build_command_run_request(
         reload=reload,
         watch=watch,
         quiet=quiet,
+        timeout_seconds=timeout_seconds,
         missing_shell_cwd_policy=missing_shell_cwd_policy,
     )

--- a/src/fast_agent/cli/runtime/run_request.py
+++ b/src/fast_agent/cli/runtime/run_request.py
@@ -87,6 +87,7 @@ class AgentRunRequest:
     structured_tool_policy: StructuredToolPolicy | None = None
     execution_mode: ExecutionMode | None = None
     quiet: bool = False
+    timeout_seconds: int | None = None
     missing_shell_cwd_policy: Literal["ask", "create", "warn", "error"] | None = None
     prefer_local_shell: bool = False
     attachments: list[str] | None = None
@@ -94,6 +95,7 @@ class AgentRunRequest:
 
     def __post_init__(self) -> None:
         self._validate_environment_options()
+        self._validate_timeout()
         self._resolve_execution_mode()
         self._validate_structured_options()
 
@@ -104,6 +106,10 @@ class AgentRunRequest:
             raise ValueError("--noenv cannot be combined with --resume")
         if self.shell_runtime and self.no_shell:
             raise ValueError("--shell cannot be combined with --no-shell")
+
+    def _validate_timeout(self) -> None:
+        if self.timeout_seconds is not None and self.timeout_seconds < 1:
+            raise ValueError("--timeout must be a positive integer")
 
     def _resolve_execution_mode(self) -> None:
         resolved_execution_mode = resolve_execution_mode(
@@ -193,6 +199,7 @@ class AgentRunRequest:
             "watch": self.watch,
             "execution_mode": self.execution_mode,
             "quiet": self.quiet,
+            "timeout_seconds": self.timeout_seconds,
             "missing_shell_cwd_policy": self.missing_shell_cwd_policy,
             "managed_mcp_agent_names": self.managed_mcp_agent_names,
         }

--- a/src/fast_agent/cli/runtime/runner.py
+++ b/src/fast_agent/cli/runtime/runner.py
@@ -27,6 +27,17 @@ def _should_convert_keyboard_interrupt_to_task_cancel(request: "AgentRunRequest"
     return request.mode == "interactive" and request.is_repl
 
 
+def _run_task_with_optional_timeout(
+    loop: asyncio.AbstractEventLoop,
+    main_task: asyncio.Task[None],
+    timeout_seconds: int | None,
+) -> None:
+    if timeout_seconds is None:
+        loop.run_until_complete(main_task)
+        return
+    loop.run_until_complete(asyncio.wait_for(main_task, timeout=timeout_seconds))
+
+
 def run_request(request: AgentRunRequest) -> None:
     """Run an agent request with CLI-compatible loop lifecycle semantics."""
     from .agent_setup import run_agent_request
@@ -44,7 +55,21 @@ def run_request(request: AgentRunRequest) -> None:
         write_interactive_trace("cli.runner.start")
         while True:
             try:
-                loop.run_until_complete(main_task)
+                _run_task_with_optional_timeout(loop, main_task, request.timeout_seconds)
+                break
+            except TimeoutError:
+                if main_task.done() and not main_task.cancelled():
+                    raise
+                write_interactive_trace(
+                    "cli.runner.timeout",
+                    timeout_seconds=request.timeout_seconds,
+                )
+                seconds_label = "second" if request.timeout_seconds == 1 else "seconds"
+                print(
+                    f"fast-agent timed out after {request.timeout_seconds} {seconds_label}.",
+                    file=sys.stderr,
+                )
+                exit_code = 124
                 break
             except KeyboardInterrupt:
                 convert_to_cancel = (

--- a/src/fast_agent/cli/runtime/runner.py
+++ b/src/fast_agent/cli/runtime/runner.py
@@ -38,6 +38,13 @@ def _run_task_with_optional_timeout(
     loop.run_until_complete(asyncio.wait_for(main_task, timeout=timeout_seconds))
 
 
+def _timeout_seconds_for_request(request: "AgentRunRequest") -> int | None:
+    """Return the process-level timeout for requests that are expected to finish."""
+    if request.is_repl:
+        return None
+    return request.timeout_seconds
+
+
 def run_request(request: AgentRunRequest) -> None:
     """Run an agent request with CLI-compatible loop lifecycle semantics."""
     from .agent_setup import run_agent_request
@@ -53,20 +60,21 @@ def run_request(request: AgentRunRequest) -> None:
     main_task = loop.create_task(run_agent_request(request))
     try:
         write_interactive_trace("cli.runner.start")
+        timeout_seconds = _timeout_seconds_for_request(request)
         while True:
             try:
-                _run_task_with_optional_timeout(loop, main_task, request.timeout_seconds)
+                _run_task_with_optional_timeout(loop, main_task, timeout_seconds)
                 break
             except TimeoutError:
                 if main_task.done() and not main_task.cancelled():
                     raise
                 write_interactive_trace(
                     "cli.runner.timeout",
-                    timeout_seconds=request.timeout_seconds,
+                    timeout_seconds=timeout_seconds,
                 )
-                seconds_label = "second" if request.timeout_seconds == 1 else "seconds"
+                seconds_label = "second" if timeout_seconds == 1 else "seconds"
                 print(
-                    f"fast-agent timed out after {request.timeout_seconds} {seconds_label}.",
+                    f"fast-agent timed out after {timeout_seconds} {seconds_label}.",
                     file=sys.stderr,
                 )
                 exit_code = 124

--- a/tests/unit/fast_agent/commands/test_go_command.py
+++ b/tests/unit/fast_agent/commands/test_go_command.py
@@ -247,6 +247,26 @@ def test_go_accepts_repeated_attach_flags(monkeypatch, tmp_path: Path) -> None:
     ]
 
 
+def test_go_accepts_timeout_flag(monkeypatch) -> None:
+    captured_requests = []
+    monkeypatch.setattr(go_command, "run_request", captured_requests.append)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        go_command.app,
+        [
+            "--message",
+            "summarize",
+            "--timeout",
+            "120",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(captured_requests) == 1
+    assert captured_requests[0].timeout_seconds == 120
+
+
 def test_go_attach_requires_one_shot_mode() -> None:
     runner = CliRunner()
     result = runner.invoke(go_command.app, ["--attach", "report.txt"])

--- a/tests/unit/fast_agent/commands/test_runtime_request_builders.py
+++ b/tests/unit/fast_agent/commands/test_runtime_request_builders.py
@@ -183,6 +183,65 @@ def test_build_command_run_request_resolves_defaults() -> None:
     assert request.execution_mode == "repl"
 
 
+def test_build_command_run_request_propagates_timeout() -> None:
+    request = build_command_run_request(
+        name="cli",
+        instruction_option=None,
+        config_path=None,
+        servers=None,
+        urls=None,
+        auth=None,
+        client_metadata_url=None,
+        agent_cards=None,
+        card_tools=None,
+        model=None,
+        message="hello",
+        prompt_file=None,
+        result_file=None,
+        resume=None,
+        npx=None,
+        uvx=None,
+        stdio=None,
+        target_agent_name=None,
+        skills_directory=None,
+        environment_dir=Path("."),
+        shell_enabled=False,
+        mode="interactive",
+        timeout_seconds=120,
+    )
+
+    assert request.timeout_seconds == 120
+
+
+def test_build_command_run_request_rejects_non_positive_timeout() -> None:
+    with pytest.raises(ValueError, match="--timeout must be a positive integer"):
+        build_command_run_request(
+            name="cli",
+            instruction_option=None,
+            config_path=None,
+            servers=None,
+            urls=None,
+            auth=None,
+            client_metadata_url=None,
+            agent_cards=None,
+            card_tools=None,
+            model=None,
+            message="hello",
+            prompt_file=None,
+            result_file=None,
+            resume=None,
+            npx=None,
+            uvx=None,
+            stdio=None,
+            target_agent_name=None,
+            skills_directory=None,
+            environment_dir=Path("."),
+            shell_enabled=False,
+            mode="interactive",
+            timeout_seconds=0,
+        )
+
+
 def test_resolve_instruction_option_preserves_default_agent_name_for_url(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/fast_agent/commands/test_runtime_runner.py
+++ b/tests/unit/fast_agent/commands/test_runtime_runner.py
@@ -3,10 +3,15 @@ import asyncio
 import pytest
 
 from fast_agent.cli.runtime.run_request import AgentRunRequest
-from fast_agent.cli.runtime.runner import run_request
+from fast_agent.cli.runtime.runner import _timeout_seconds_for_request, run_request
 
 
-def _request(*, timeout_seconds: int | None = None) -> AgentRunRequest:
+def _request(
+    *,
+    message: str | None = "hello",
+    prompt_file: str | None = None,
+    timeout_seconds: int | None = None,
+) -> AgentRunRequest:
     return AgentRunRequest(
         name="test",
         instruction="instruction",
@@ -15,8 +20,8 @@ def _request(*, timeout_seconds: int | None = None) -> AgentRunRequest:
         agent_cards=None,
         card_tools=None,
         model=None,
-        message="hello",
-        prompt_file=None,
+        message=message,
+        prompt_file=prompt_file,
         result_file=None,
         resume=None,
         url_servers=None,
@@ -41,6 +46,17 @@ def _request(*, timeout_seconds: int | None = None) -> AgentRunRequest:
         watch=False,
         timeout_seconds=timeout_seconds,
     )
+
+
+def test_timeout_seconds_for_request_applies_only_to_one_shot_modes() -> None:
+    assert _timeout_seconds_for_request(_request(timeout_seconds=30)) == 30
+    assert (
+        _timeout_seconds_for_request(
+            _request(message=None, prompt_file="prompt.txt", timeout_seconds=30)
+        )
+        == 30
+    )
+    assert _timeout_seconds_for_request(_request(message=None, timeout_seconds=30)) is None
 
 
 def test_run_request_exits_124_when_timeout_fires(

--- a/tests/unit/fast_agent/commands/test_runtime_runner.py
+++ b/tests/unit/fast_agent/commands/test_runtime_runner.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+
+from fast_agent.cli.runtime.run_request import AgentRunRequest
+from fast_agent.cli.runtime.runner import run_request
+
+
+def _request(*, timeout_seconds: int | None = None) -> AgentRunRequest:
+    return AgentRunRequest(
+        name="test",
+        instruction="instruction",
+        config_path=None,
+        server_list=None,
+        agent_cards=None,
+        card_tools=None,
+        model=None,
+        message="hello",
+        prompt_file=None,
+        result_file=None,
+        resume=None,
+        url_servers=None,
+        stdio_servers=None,
+        agent_name="agent",
+        target_agent_name=None,
+        skills_directory=None,
+        environment_dir=None,
+        noenv=False,
+        force_smart=False,
+        shell_runtime=False,
+        no_shell=False,
+        mode="interactive",
+        transport="http",
+        host="127.0.0.1",
+        port=8000,
+        tool_description=None,
+        tool_name_template=None,
+        instance_scope="shared",
+        permissions_enabled=True,
+        reload=False,
+        watch=False,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def test_run_request_exits_124_when_timeout_fires(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def slow_run_agent_request(_request: AgentRunRequest) -> None:
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(
+        "fast_agent.cli.runtime.agent_setup.run_agent_request",
+        slow_run_agent_request,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_request(_request(timeout_seconds=1))
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 124
+    assert "fast-agent timed out after 1 second." in captured.err


### PR DESCRIPTION
Fixes #837

## Summary

- Added `--timeout` / `-t` to `fast-agent go` and carried it through the normalized run request.
- Wrapped the CLI request task with `asyncio.wait_for` when a timeout is set.
- Timeout cancellation exits with code `124` and prints a short stderr message.

## Validation

- `PATH=/tmp/codex-uv/bin:$PATH uv run pytest tests/unit/fast_agent/commands/test_runtime_request_builders.py tests/unit/fast_agent/commands/test_go_command.py tests/unit/fast_agent/commands/test_runtime_runner.py -q`  
  `56 passed`
- `PATH=/tmp/codex-uv/bin:$PATH uv run scripts/lint.py`  
  `All checks passed!`
- `PATH=/tmp/codex-uv/bin:$PATH uv run scripts/typecheck.py`  
  `All checks passed!`
- `PATH=/tmp/codex-uv/bin:$PATH uv run pytest tests/unit/fast_agent/commands -q`  
  `683 passed, 2 failed`

The two failures are in `tests/unit/fast_agent/commands/test_skills_command.py`. Both assert that a full temporary skills path appears in Rich output, but the path is truncated with an ellipsis in this local terminal output. They do not touch the timeout path changed here.

## Required Question

You're given a calfskin wallet for your birthday. How would you feel about using it?

I would not use it. I would choose a non-animal-material wallet.
