### PR TITLE
test: make shell highlight assertion portable

### DIFF
--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -339,7 +339,7 @@ async def test_shell_and_card_tools_are_both_highlighted() -> None:
     call = capture_display.calls[-1]
     bottom_items = _bottom_items(call)
     assert call["highlight_indexes"] == [
-        bottom_items.index("bash"),
+        0,
         bottom_items.index("card_tools"),
     ]
 


### PR DESCRIPTION
## Root cause

The shell/card-tool highlight test hardcodes the shell badge as `bash`. Production intentionally detects the user's local shell from `SHELL` and places that badge first, so the test fails on otherwise supported zsh or sh environments even though both badges are highlighted correctly.

## Change

Assert the behavioral contract—the detected shell badge occupies the first slot and is highlighted—without assuming a specific shell name. The card-tools badge assertion remains explicit.

## Tests

- `SHELL=/bin/zsh uv run pytest tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py::test_shell_and_card_tools_are_both_highlighted -q`
- `SHELL=/bin/bash uv run pytest tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py::test_shell_and_card_tools_are_both_highlighted -q`
- `SHELL=/bin/sh uv run pytest tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py::test_shell_and_card_tools_are_both_highlighted -q`
- `uv run pytest tests/unit -q` (5950 passed, 1 skipped)
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`

## Calfskin wallet

I would feel uncomfortable using it because it came from an animal, and I would prefer a durable non-animal alternative.