### PR TITLE
Keep the first message of an assistant-first delimited document

### DIFF
--- a/src/fast_agent/mcp/prompt_serialization.py
+++ b/src/fast_agent/mcp/prompt_serialization.py
@@ -390,12 +390,7 @@ def delimited_format_to_extended_messages(
     state = _DelimitedParseState()
     legacy_format = resource_delimiter in content and '"type":' not in content
 
-    if lines and lines[0].strip() == user_delimiter:
-        state.reset_for_role("user")
-        state.collecting_text = True
-
-    remaining_lines = lines[1:] if lines else []
-    for line in remaining_lines:
+    for line in lines:
         line_stripped = line.strip()
 
         if line_stripped in (user_delimiter, assistant_delimiter):

--- a/tests/unit/fast_agent/mcp/test_prompt_format_utils.py
+++ b/tests/unit/fast_agent/mcp/test_prompt_format_utils.py
@@ -114,6 +114,39 @@ class TestPromptFormatUtils:
         assert "improved_code.py" in assistant_resource_json
         assert "def main()" in assistant_resource_json
 
+    def test_assistant_first_delimited_to_extended(self):
+        """A document opening with the assistant delimiter keeps its first message.
+
+        The parser special-cased only a leading ---USER line while skipping line 0
+        unconditionally, so a leading ---ASSISTANT never set a role and everything
+        up to the next delimiter was dropped.
+        """
+        messages = delimited_format_to_extended_messages(
+            "---ASSISTANT\nhello\n---USER\nhi back"
+        )
+
+        assert [m.role for m in messages] == ["assistant", "user"]
+        assert _text(messages[0].content[0]).text == "hello"
+        assert _text(messages[1].content[0]).text == "hi back"
+
+    def test_assistant_first_round_trip(self):
+        """Saving then reloading an assistant-first conversation preserves it."""
+        original = [
+            PromptMessageExtended(
+                role="assistant", content=[TextContent(type="text", text="hello")]
+            ),
+            PromptMessageExtended(
+                role="user", content=[TextContent(type="text", text="hi back")]
+            ),
+        ]
+
+        reloaded = delimited_format_to_extended_messages(
+            "\n".join(multipart_messages_to_delimited_format(original))
+        )
+
+        assert [m.role for m in reloaded] == [m.role for m in original]
+        assert [_text(m.content[0]).text for m in reloaded] == ["hello", "hi back"]
+
     def test_delimited_with_resources_to_extended(self):
         """Test converting delimited format with resources to multipart messages."""
         # Create delimited content with resources in JSON format


### PR DESCRIPTION
## What

`delimited_format_to_extended_messages` special-cases line 0 only when it is the **user** delimiter, but then skips it unconditionally via `lines[1:]`. A document opening with `---ASSISTANT` therefore never sets a role, and everything up to the next delimiter is discarded:

```python
parse("---ASSISTANT\nhello\n---USER\nhi")   # -> [user: "hi"]   — "hello" is gone
parse("---ASSISTANT\na")                    # -> []             — total loss
parse("---USER\nhi\n---ASSISTANT\nhello")   # -> fine (only an assistant-first doc breaks)
```

The clearest evidence that the skip — not the delimiter handling — is at fault: **the same document parses correctly with one extra leading newline**, because line 0 becomes `""` and `---ASSISTANT` then reaches the loop:

```python
parse("\n---ASSISTANT\nhello\n---USER\nhi")  # -> [assistant: "hello", user: "hi"]
```

It also isn't by design: the sibling parser of the same on-disk format, `PromptTemplate` (which iterates from index 0), reads that document correctly as `assistant: "hello"` / `user: "hi back"`. Two parsers of one format disagreed.

## How

The loop already handles **both** delimiters, so the special case was redundant — feed it every line and drop it (-6/+1). `append_message()` returns early while `current_role is None`, so the first iteration landing on a delimiter line cannot emit an empty message; I verified the empty-string and user-first inputs are unchanged.

## Scope

I want to be straight about reachability rather than oversell it: I traced the callers, and the production paths reach this function only via `load_messages(path)` with a non-`.json` suffix — every call site I found (`harness_startup.py:91`, `token_accounting_validation.py:174`, `trace_exporter.py:302`, `session_manager.py:221`) passes `history_*.json`/`compacted_*.json`, and the `***SAVE_HISTORY x.txt` reload path routes through `PromptTemplateLoader` instead. So this is a fix to directly-unit-tested public API surface, not a live data-loss path today.

## Tests

Two contract-level cases: parsing an assistant-first document, and a save→reload round trip. Both fail on `main` and pass here. No existing test fed an assistant-first document, which is why this survived.

- `pytest tests/unit/fast_agent/mcp/test_prompt_format_utils.py` — 8 passed
- `pytest tests/unit` — **5956 passed** (5954 baseline + 2 new), no regressions. The one pre-existing failure (`test_input.py::test_cli_duckdb_sql_rejects_multiple_statements_before_execution`, missing `rows.parquet`) fails identically on a clean tree.
- `uv run scripts/lint.py` and `uv run scripts/typecheck.py` — both clean.

## Calfskin wallet

I would not use it. It came from an animal, and I would rather have a wallet made of something else.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the full unit suite locally and reviewed the diff before opening.