### PR TITLE
fix: report environment edit write failures

### DIFF
--- a/src/fast_agent/tools/environment_filesystem_runtime.py
+++ b/src/fast_agent/tools/environment_filesystem_runtime.py
@@ -382,10 +382,13 @@ class EnvironmentFilesystemRuntime:
                 replace_all=edit_input.replace_all,
             )
             if result["success"] is True:
-                await self._filesystem.write_text(
-                    edit_input.path,
-                    local_path.read_text(encoding="utf-8"),
-                )
+                try:
+                    await self._filesystem.write_text(
+                        edit_input.path,
+                        local_path.read_text(encoding="utf-8"),
+                    )
+                except Exception as exc:
+                    return _text_result(f"Error writing file: {exc}", is_error=True)
             return _text_result(
                 _format_jsonish(serialize_edit_file_result(result)),
                 is_error=result["success"] is False,

--- a/tests/unit/fast_agent/tools/test_environment_filesystem_runtime.py
+++ b/tests/unit/fast_agent/tools/test_environment_filesystem_runtime.py
@@ -363,6 +363,26 @@ async def test_environment_filesystem_runtime_applies_patch_to_remote_files() ->
 
 
 @pytest.mark.asyncio
+async def test_environment_filesystem_runtime_reports_edit_write_failure() -> None:
+    class FailingWriteEnvironment(FakeEnvironment):
+        async def write_text(self, path: str, content: str) -> None:
+            del path, content
+            raise OSError("disk full")
+
+    env = FailingWriteEnvironment()
+    env.files["/workspace/notes.txt"] = "hello world\n"
+    runtime = EnvironmentFilesystemRuntime(env, enable_edit_file=True)
+
+    result = await runtime.call_tool(
+        "edit_file",
+        {"path": "notes.txt", "old_string": "world", "new_string": "there"},
+    )
+
+    assert result.isError is True
+    assert _text(result) == "Error writing file: disk full"
+
+
+@pytest.mark.asyncio
 async def test_mcp_agent_routes_file_tools_to_injected_execution_environment() -> None:
     env = FakeEnvironment()
     env.files["/workspace/remote.txt"] = "remote file\n"


### PR DESCRIPTION
## Root cause

`EnvironmentFilesystemRuntime.edit_file` handled environment read failures, but allowed exceptions from the final environment `write_text` call to escape. A remote filesystem write failure could therefore abort the tool call instead of returning a normal MCP error result.

## Changes

- Convert environment write exceptions during `edit_file` into an error `CallToolResult`.
- Add a regression test covering a failed remote write after a successful edit.

## Tests

- `uv run pytest tests/unit/fast_agent/tools/test_environment_filesystem_runtime.py::test_environment_filesystem_runtime_reports_edit_write_failure -v`
- `uv run pytest tests/unit/fast_agent/tools/test_environment_filesystem_runtime.py -q`
- `uv run pytest tests/unit -q` (6030 passed, 1 skipped)
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`

The regression test was run before the implementation and failed with the uncaught `OSError`, then passed after the fix.

## Calfskin wallet

I would feel uncomfortable using it because calfskin is animal-derived, and I would prefer a non-animal alternative.