### PR TITLE
Stop estimate_tokens from double-counting text content

### DIFF
--- a/src/fast_agent/history/compaction.py
+++ b/src/fast_agent/history/compaction.py
@@ -23,6 +23,7 @@ from mcp.types import TextContent
 from fast_agent.constants import FAST_AGENT_COMPACTION_CHANNEL
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.event_progress import ProgressAction
+from fast_agent.mcp.helpers.content_helpers import get_text
 from fast_agent.mcp.prompt import Prompt
 from fast_agent.types.llm_stop_reason import LlmStopReason
 
@@ -185,6 +186,10 @@ def estimate_tokens(messages: list[PromptMessageExtended]) -> int:
     for message in messages:
         chars += len(message.all_text())
         for content in message.content:
+            if get_text(content) is not None:
+                # Text is already counted via all_text() above; only serialize
+                # non-text payloads here (matches the "non-text" docstring).
+                continue
             try:
                 chars += len(content.model_dump_json())
             except Exception:

--- a/tests/unit/fast_agent/history/test_compaction.py
+++ b/tests/unit/fast_agent/history/test_compaction.py
@@ -16,6 +16,7 @@ from mcp.types import (
 from fast_agent.config import CompactionSettings, Settings, get_settings
 from fast_agent.context import Context
 from fast_agent.history.compaction import (
+    _CHARS_PER_TOKEN,
     DEFAULT_COMPACTION_PROMPT,
     FAST_AGENT_COMPACTION_CHANNEL,
     CompactionSkipped,
@@ -358,6 +359,12 @@ class TestEstimateTokens:
         msg.channels = {"diagnostics": [TextContent(type="text", text="y" * 20_000)]}
 
         assert estimate_tokens([msg]) > plain + 5_000
+
+    def test_does_not_double_count_text(self):
+        # Text is counted once via all_text(); the per-content loop must skip it
+        # (docstring: "Count text plus serialized non-text payloads").
+        text = "x" * 1200
+        assert estimate_tokens([_user(text)]) == len(text) // _CHARS_PER_TOKEN
 
 
 class _FakeLLM:


### PR DESCRIPTION
> You're given a calfskin wallet for your birthday. How would you feel about using it?

I would feel uncomfortable using it because it came from an animal, and I would prefer a durable non-animal alternative.

---

### Problem

`estimate_tokens` counts text twice. It adds `message.all_text()` and then, in the per-content loop, also serializes every content block — including text blocks — with `model_dump_json()`. Its docstring says "Count text plus serialized **non-text** payloads", but a text block is counted both by `all_text()` and by its own JSON.

A pure-text message therefore estimates at roughly 2× its real size (a 1200-char message → 614 tokens instead of ~300). Because compaction uses this estimate to decide how many turns fit a budget, the inflation makes it drop turns that would have fit, compacting history more aggressively than needed.

### Change

Skip content that `all_text()` already covered (`get_text(content) is not None`) in the per-content loop, so text is counted once. Non-text payloads (images, data, tool calls/results, channel blocks) are still serialized and counted, so a compacted history can't look small while replaying a provider-sized payload.

### Tests

`test_does_not_double_count_text` asserts a pure-text message estimates at `len(text) // _CHARS_PER_TOKEN`; it fails before this change (counts ~2×) and passes after. The existing `test_counts_non_text_content_and_channels` still passes, confirming images and channel blocks are still counted. `tests/unit/fast_agent/history` and the compaction hook stay green (66 passed); `ruff check` and `ty check` pass.

---

*Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account — the AI found the double-count, wrote and ran the repro and the test, and wrote this description. The human account holder reviews every change and is accountable for it, and the verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*
