### PR TITLE
fix(scheduler): propagate signal wait timeout

### DIFF
--- a/src/fast_agent/core/executor/executor.py
+++ b/src/fast_agent/core/executor/executor.py
@@ -167,7 +167,7 @@ class Executor(ABC, ContextDependent):
         sig: Signal[Any] = Signal(
             name=signal_name, description=signal_description, workflow_id=workflow_id
         )
-        return await self.signal_bus.wait_for_signal(sig)
+        return await self.signal_bus.wait_for_signal(sig, timeout_seconds=timeout_seconds)
 
 
 class AsyncioExecutor(Executor):

--- a/tests/unit/fast_agent/core/test_asyncio_executor.py
+++ b/tests/unit/fast_agent/core/test_asyncio_executor.py
@@ -104,6 +104,14 @@ async def test_execute_timeout_returns_timeout_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_for_signal_uses_timeout() -> None:
+    executor = AsyncioExecutor()
+
+    with pytest.raises(TimeoutError):
+        await executor.wait_for_signal("never-fired", timeout_seconds=1)
+
+
+@pytest.mark.asyncio
 async def test_execute_limits_concurrent_activities() -> None:
     executor = AsyncioExecutor(ExecutorConfig(max_concurrent_activities=1))
     active = 0


### PR DESCRIPTION
timeout values are not propagated correctly when waiting for signals 