### PR TITLE
fix(shell): recognize escaped heredoc delimiters

### DIFF
--- a/src/fast_agent/tools/shell_command.py
+++ b/src/fast_agent/tools/shell_command.py
@@ -8,7 +8,7 @@ from typing import Literal
 type ShellDetachmentKind = Literal["none", "ambiguous", "service_detach"]
 
 _HEREDOC_PATTERN = re.compile(
-    r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|\\([A-Za-z_][A-Za-z0-9_]*)|([A-Za-z_][A-Za-z0-9_]*))"
 )
 
 

--- a/tests/unit/fast_agent/tools/test_shell_command.py
+++ b/tests/unit/fast_agent/tools/test_shell_command.py
@@ -29,6 +29,7 @@ from fast_agent.tools.shell_command import classify_shell_detachment
         ("build |& tee build.log", False, "none"),
         ("echo ok # nohup server &", True, "none"),
         ("cat <<'EOF'\nnohup server &\nEOF\n", True, "none"),
+        ("cat <<\\EOF\nnohup server &\nEOF\n", True, "none"),
         ("echo '<<EOF'\nnohup server &", False, "service_detach"),
         ('echo "<<EOF"\nnohup server &', False, "service_detach"),
         ("echo 'text\n<<EOF'\nnohup server &", False, "service_detach"),


### PR DESCRIPTION
## Root cause

The minimal Bash detachment classifier strips heredoc bodies before looking for shell-level backgrounding, but its heredoc declaration pattern recognized quoted and unquoted delimiters only. POSIX-valid backslash-quoted delimiters such as `<<\EOF` were therefore missed, so an ampersand inside the heredoc data was misclassified as shell-level detachment and the command was rejected.

## Changes

- Recognize a leading backslash-quoted heredoc delimiter when removing heredoc bodies.
- Add a regression case proving that background-like text inside `<<\EOF` data is ignored by detachment classification.

## Tests

- `uv run pytest tests/unit/fast_agent/tools/test_shell_command.py -q` — 24 passed
- `uv run pytest tests/unit -q` — 6294 passed, 1 skipped
- `uv run scripts/lint.py` — passed
- `uv run scripts/typecheck.py` — passed
- Independent read-only review — passed with no security concerns or logic errors

## Calfskin wallet

I would feel uncomfortable using it because calfskin is animal-derived, and I would prefer a non-animal alternative.