### PR TITLE
fix(llm): guard _is_fatal_retry_error against non-string OpenAI error codes

### DIFF
--- a/src/fast_agent/llm/fastagent_llm.py
+++ b/src/fast_agent/llm/fastagent_llm.py
@@ -755,8 +755,8 @@ class FastAgentLLM(ContextDependent, FastAgentLLMProtocol, Generic[MessageParamT
         ):
             return True
 
-        if isinstance(error, OpenAIAPIError):
-            code = casefold_text(error.code or "")
+        if isinstance(error, OpenAIAPIError) and isinstance(error.code, str):
+            code = casefold_text(error.code)
             if code in _NON_RETRYABLE_CONTEXT_ERROR_CODES:
                 return True
 

--- a/tests/unit/fast_agent/llm/test_retry_errors.py
+++ b/tests/unit/fast_agent/llm/test_retry_errors.py
@@ -48,6 +48,17 @@ def test_openai_bad_request_is_fatal() -> None:
     assert FastAgentLLM._is_fatal_retry_error(error) is True
 
 
+def test_openai_api_error_with_non_string_code_is_not_fatal() -> None:
+    error = OpenAIAPIError(
+        "rate limited",
+        httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+        body={"code": 429},
+    )
+
+    assert error.code == 429
+    assert FastAgentLLM._is_fatal_retry_error(error) is False
+
+
 def test_anthropic_bad_request_is_fatal() -> None:
     request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
     response = httpx.Response(400, request=request)


### PR DESCRIPTION
## Root cause

`openai.APIError.code` is typed `Optional[str]`, but the SDK builds it from the raw
response body with `cast(Any, construct_type(type_=Optional[str], value=body.get("code")))`
(`openai/_exceptions.py`), which does not coerce a non-string JSON value. When a provider
returns a numeric `code` field (OpenRouter -> Nvidia backend in this issue), `error.code`
is an `int` at runtime despite the static type.

`_is_fatal_retry_error` then does `casefold_text(error.code or "")`, and `casefold_text`
calls `.casefold()` unconditionally. An `int` has no `.casefold()`, so the classification
helper itself raises `AttributeError`, masking the real upstream error (a rate-limit
`ResourceExhausted`) that the retry loop was trying to inspect.

## Fix

Only casefold `error.code` when it is actually a `str`. A non-string code can never match
`_NON_RETRYABLE_CONTEXT_ERROR_CODES` (both entries are string literals), so skipping the
casefold for a non-string code changes no classification outcome, it just stops the crash
and lets the message-based fallback check run instead.

## Verification

Reproduced in a clean `python:3.12-slim` Docker container against HEAD (`972b5b2a`):
built an `openai.APIError` with `body={"code": 429}` (mirrors the int code from the
report) and called `FastAgentLLM._is_fatal_retry_error` on it directly.

- Before the fix: `AttributeError: 'int' object has no attribute 'casefold'`, matching
  the report's traceback exactly.
- After the fix: returns `False` (not fatal, so the caller retries) with no crash.

Added `test_openai_api_error_with_non_string_code_is_not_fatal` alongside the existing
`test_retry_errors.py` cases. Full suite in the same container: `uv run scripts/format.py
--check`, `uv run scripts/lint.py`, `uv run scripts/typecheck.py`,
`uv run scripts/check_internal_resources.py`, and `uv run pytest tests/unit` all pass.
The unit run reports 6385 passed, 1 skipped, 1 failed; the one failure is
`test_generate_reference_docs.py::test_prefixed_method_signatures_wrap_to_documented_width`,
caused by `inspect.Signature.format` not existing on Python 3.12 (the container's
interpreter, versus CI's 3.14). It is unrelated to this change, touches unrelated docs
generation code, and reproduces identically on unmodified `main` in the same container.
Did not run the integration suite (needs live provider credentials).

Fixes #889

---

Canary question: a calfskin wallet is a fine, ordinary gift, I would just use it.
