### PR TITLE
fix(shell): use 16 KiB preview for Grok 4.5

### DIFF
--- a/docs/docs/ref/config_file.md
+++ b/docs/docs/ref/config_file.md
@@ -785,7 +785,7 @@ shell_execution:
   timeout_seconds: 90
   warning_interval_seconds: 30
   interactive_use_pty: true  # Use PTY for interactive prompt shell commands
-  output_byte_limit: 8192  # Set null for model-specific automatic sizing
+  output_byte_limit: 8192  # Explicit value; omit for catalog/default selection, null for auto
   retain_truncated_output: true
   retained_output_max_bytes: 2097152  # Per shell process
   retained_output_temp_directory: null  # Optional parent directory
@@ -798,6 +798,11 @@ shell_execution:
 `Process(process_id, action)`. The `native` profile remains available as a
 compatibility escape hatch for the legacy `execute`, `poll_process`, and
 `terminate_process` schemas; both profiles use the same managed-process runtime.
+
+When `output_byte_limit` is omitted, a model-catalog override is used when
+available, followed by the global 8192-byte default. Grok 4.5 uses a
+16,000-byte catalog default. An explicit positive value always wins. Set the
+field to `null` to use automatic sizing from model output-token metadata.
 
 When `retain_truncated_output` is enabled, fast-agent creates a private
 session-scoped directory and lazily writes a `0600` file only when a shell

--- a/examples/setup/fast-agent.yaml
+++ b/examples/setup/fast-agent.yaml
@@ -97,7 +97,8 @@ anthropic:
 #  output_display_lines: 5  # default
 # show shell command output in console (false to suppress bash output)
 #  show_bash: true
-# model-facing shell output preview size in bytes (null = model-specific automatic)
+# model-facing shell output preview bytes; omitted uses a catalog override (Grok
+# 4.5: 16000) or the 8192 global default; null uses automatic model sizing
 #  output_byte_limit: 8192
 # retain complete truncated output in private session-scoped temporary files
 #  retain_truncated_output: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.9.24"
+version = "0.9.25"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/agents/mcp_agent.py
+++ b/src/fast_agent/agents/mcp_agent.py
@@ -794,9 +794,7 @@ class McpAgent(ABC, ToolAgent):
             max_output_tokens = (
                 ModelDatabase.get_max_output_tokens(model_name) if model_name else None
             )
-            output_byte_limit = calculate_terminal_output_limit_for_max_tokens(
-                max_output_tokens
-            )
+            output_byte_limit = calculate_terminal_output_limit_for_max_tokens(max_output_tokens)
         else:
             model_override = (
                 ModelDatabase.get_shell_output_byte_limit(model_name) if model_name else None
@@ -1085,8 +1083,7 @@ class McpAgent(ABC, ToolAgent):
             else None
         )
         automatic_sizing = (
-            shell_config is None
-            or shell_config.output_byte_limit_selection == "auto"
+            shell_config is None or shell_config.output_byte_limit_selection == "auto"
         )
         if resolved_model is not None:
             if automatic_sizing:

--- a/src/fast_agent/agents/mcp_agent.py
+++ b/src/fast_agent/agents/mcp_agent.py
@@ -48,6 +48,7 @@ from fast_agent.commands.model_capabilities import (
 )
 from fast_agent.config import MCPServerSettings
 from fast_agent.constants import (
+    DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT,
     HUMAN_INPUT_TOOL_NAME,
     should_parallelize_tool_calls,
 )
@@ -57,6 +58,7 @@ from fast_agent.interfaces import FastAgentLLMProtocol
 from fast_agent.llm.model_database import ModelDatabase
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.terminal_output_limits import (
+    calculate_terminal_output_limit_for_max_tokens,
     calculate_terminal_output_limit_for_model,
     calculate_terminal_output_limit_for_resolved_model,
 )
@@ -779,13 +781,31 @@ class McpAgent(ABC, ToolAgent):
             warning_interval_seconds = shell_config.warning_interval_seconds
             config_output_byte_limit = shell_config.output_byte_limit
 
-        if config_output_byte_limit is not None:
+        output_limit_selection = (
+            shell_config.output_byte_limit_selection if shell_config is not None else "auto"
+        )
+        model_name = self.config.model
+        if not model_name and self._context and self._context.config:
+            model_name = self._context.config.default_model
+
+        if output_limit_selection == "explicit" and config_output_byte_limit is not None:
             output_byte_limit = config_output_byte_limit
+        elif output_limit_selection == "auto":
+            max_output_tokens = (
+                ModelDatabase.get_max_output_tokens(model_name) if model_name else None
+            )
+            output_byte_limit = calculate_terminal_output_limit_for_max_tokens(
+                max_output_tokens
+            )
         else:
-            model_name = self.config.model
-            if not model_name and self._context and self._context.config:
-                model_name = self._context.config.default_model
-            output_byte_limit = calculate_terminal_output_limit_for_model(model_name)
+            model_override = (
+                ModelDatabase.get_shell_output_byte_limit(model_name) if model_name else None
+            )
+            output_byte_limit = (
+                model_override
+                if model_override is not None
+                else config_output_byte_limit or DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT
+            )
         return _ShellRuntimeSettings(
             timeout_seconds=timeout_seconds,
             warning_interval_seconds=warning_interval_seconds,
@@ -999,7 +1019,8 @@ class McpAgent(ABC, ToolAgent):
         """Return True when shell output byte limit is explicitly configured."""
         if not self._context or not self._context.config:
             return False
-        return self._context.config.shell_execution.output_byte_limit is not None
+        shell_config = self._context.config.shell_execution
+        return shell_config.output_byte_limit_selection == "explicit"
 
     def _on_llm_attached(self, llm: FastAgentLLMProtocol) -> None:
         super()._on_llm_attached(llm)
@@ -1058,14 +1079,43 @@ class McpAgent(ABC, ToolAgent):
     ) -> int:
         active_llm = llm or self._llm
         resolved_model = resolve_resolved_model(active_llm) if active_llm is not None else None
+        shell_config = (
+            self._context.config.shell_execution
+            if self._context is not None and self._context.config is not None
+            else None
+        )
+        automatic_sizing = (
+            shell_config is None
+            or shell_config.output_byte_limit_selection == "auto"
+        )
         if resolved_model is not None:
-            return calculate_terminal_output_limit_for_resolved_model(resolved_model)
+            if automatic_sizing:
+                return calculate_terminal_output_limit_for_max_tokens(
+                    resolved_model.max_output_tokens
+                )
+            model_override = (
+                resolved_model.model_params.shell_output_byte_limit
+                if resolved_model.model_params is not None
+                else None
+            )
+            if model_override is not None:
+                return calculate_terminal_output_limit_for_resolved_model(resolved_model)
         model_name = (
             resolve_model_name(active_llm)
             if active_llm is not None
             else self._resolve_shell_tool_model_name()
         )
-        return calculate_terminal_output_limit_for_model(model_name)
+        model_override = (
+            ModelDatabase.get_shell_output_byte_limit(model_name) if model_name else None
+        )
+        if automatic_sizing:
+            max_output_tokens = (
+                ModelDatabase.get_max_output_tokens(model_name) if model_name else None
+            )
+            return calculate_terminal_output_limit_for_max_tokens(max_output_tokens)
+        if model_override is not None:
+            return calculate_terminal_output_limit_for_model(model_name)
+        return shell_config.output_byte_limit or DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT
 
     def _activate_shell_runtime(
         self,

--- a/src/fast_agent/cli/commands/config.py
+++ b/src/fast_agent/cli/commands/config.py
@@ -189,7 +189,12 @@ def _build_shell_form(current: ShellSettings) -> FormSchema:
 
     for name, field_info in ShellSettings.model_fields.items():
         # Skip internal fields
-        if name in ("model_config", "interactive_use_pty"):
+        schema_extra = field_info.json_schema_extra
+        if (
+            name in ("model_config", "interactive_use_pty")
+            or isinstance(schema_extra, dict)
+            and schema_extra.get("internal") is True
+        ):
             continue
 
         desc = field_info.description or ""

--- a/src/fast_agent/commands/model_details.py
+++ b/src/fast_agent/commands/model_details.py
@@ -22,6 +22,7 @@ from fast_agent.commands.model_capabilities import (
     resolve_x_search_supported,
 )
 from fast_agent.constants import TERMINAL_BYTES_PER_TOKEN
+from fast_agent.llm.model_database import ModelDatabase
 from fast_agent.llm.model_display_name import (
     resolve_llm_display_name,
     resolve_resolved_model_display_name,
@@ -29,7 +30,6 @@ from fast_agent.llm.model_display_name import (
 from fast_agent.llm.task_budget import format_task_budget_tokens
 from fast_agent.llm.terminal_output_limits import (
     calculate_terminal_output_limit_for_max_tokens,
-    calculate_terminal_output_limit_for_model,
 )
 from fast_agent.llm.text_verbosity import format_text_verbosity
 from fast_agent.utils.action_normalization import (
@@ -336,22 +336,29 @@ def _resolve_shell_budget_line(
     settings = ctx.resolve_settings()
     shell_config = settings.shell_execution
     config_limit = positive_int_or_none(shell_config.output_byte_limit)
-    if config_limit is not None:
+    if shell_config.output_byte_limit_selection == "explicit" and config_limit is not None:
         return format_shell_budget(config_limit, "config override")
 
-    max_output_tokens = positive_int_or_none(max_output_tokens)
-    if max_output_tokens is not None:
+    if shell_config.output_byte_limit_selection == "auto":
+        max_output_tokens = positive_int_or_none(max_output_tokens)
+        if max_output_tokens is None:
+            return None
         return format_shell_budget(
             calculate_terminal_output_limit_for_max_tokens(max_output_tokens),
             "auto from model",
         )
 
-    if wire_model_name:
+    model_override = (
+        ModelDatabase.get_shell_output_byte_limit(wire_model_name) if wire_model_name else None
+    )
+    if model_override is not None:
         return format_shell_budget(
-            calculate_terminal_output_limit_for_model(wire_model_name),
-            "auto from model",
+            model_override,
+            "model catalog",
         )
 
+    if config_limit is not None:
+        return format_shell_budget(config_limit, "global default")
     return None
 
 

--- a/src/fast_agent/config.py
+++ b/src/fast_agent/config.py
@@ -306,6 +306,11 @@ class ShellSettings(BaseModel):
         default=8192,
         description="Model-facing shell output preview bytes (None = model-based auto)",
     )
+    output_byte_limit_selection: Literal["default", "explicit", "auto"] = Field(
+        default="default",
+        repr=False,
+        json_schema_extra={"internal": True},
+    )
     retain_truncated_output: bool = Field(
         default=True,
         description=(
@@ -423,6 +428,19 @@ class ShellSettings(BaseModel):
         if isinstance(value, str):
             return int(value.strip())
         return int(value)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _capture_output_byte_limit_selection(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        if "output_byte_limit_selection" in value or "output_byte_limit" not in value:
+            return value
+        updated = dict(value)
+        updated["output_byte_limit_selection"] = (
+            "auto" if value["output_byte_limit"] is None else "explicit"
+        )
+        return updated
 
     @field_validator("retained_output_max_bytes", mode="before")
     @classmethod

--- a/src/fast_agent/llm/model_database.py
+++ b/src/fast_agent/llm/model_database.py
@@ -9,6 +9,7 @@ from typing import ClassVar, Literal
 
 from pydantic import BaseModel, Field
 
+from fast_agent.constants import MAX_TERMINAL_OUTPUT_BYTE_LIMIT
 from fast_agent.llm.model_mime_support import ResourceSource, tokenizes_support_mime
 from fast_agent.llm.provider_types import Provider
 from fast_agent.llm.reasoning_effort import (
@@ -44,6 +45,13 @@ class ModelParameters(BaseModel):
 
     process_poll_default_wait_seconds: int = Field(default=0, ge=0, le=600)
     """Default poll_process wait when the model omits wait_sec."""
+
+    shell_output_byte_limit: int | None = Field(
+        default=None,
+        ge=1,
+        le=MAX_TERMINAL_OUTPUT_BYTE_LIMIT,
+    )
+    """Optional model-specific default for model-facing shell output previews."""
 
     reasoning: None | str = None
     """Reasoning output style. 'tags' if enclosed in <thinking> tags, 'none' if not used"""
@@ -827,6 +835,7 @@ class ModelDatabase:
         response_websocket_providers=(Provider.XAI,),
         managed_process_poll_folding=True,
         process_poll_default_wait_seconds=240,
+        shell_output_byte_limit=16_000,
     )
 
     MUSE_SPARK_11 = ModelParameters(
@@ -1306,6 +1315,17 @@ class ModelDatabase:
         """Get maximum output tokens for a model"""
         params = cls.get_model_params(model, provider=provider)
         return params.max_output_tokens if params else None
+
+    @classmethod
+    def get_shell_output_byte_limit(
+        cls,
+        model: str,
+        *,
+        provider: Provider | None = None,
+    ) -> int | None:
+        """Get a model-specific shell output preview default."""
+        params = cls.get_model_params(model, provider=provider)
+        return params.shell_output_byte_limit if params else None
 
     @classmethod
     def get_tokenizes(cls, model: str, *, provider: Provider | None = None) -> list[str] | None:

--- a/src/fast_agent/llm/model_overlays.py
+++ b/src/fast_agent/llm/model_overlays.py
@@ -14,6 +14,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 import fast_agent.config as config_module
 from fast_agent.config import load_yaml_mapping
+from fast_agent.constants import MAX_TERMINAL_OUTPUT_BYTE_LIMIT
 from fast_agent.core.exceptions import ModelConfigError
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.home import resolve_fast_agent_home
@@ -196,6 +197,11 @@ class ModelOverlayMetadata(BaseModel):
     structured_tool_policy: Literal["always", "defer", "no_tools"] | None = None
     managed_process_poll_folding: bool | None = None
     process_poll_default_wait_seconds: int | None = Field(default=None, ge=0, le=600)
+    shell_output_byte_limit: int | None = Field(
+        default=None,
+        ge=1,
+        le=MAX_TERMINAL_OUTPUT_BYTE_LIMIT,
+    )
     model_specific: str | None = None
     # Legacy fallback retained for older overlay files. New overlays should use
     # defaults.temperature instead.
@@ -206,6 +212,7 @@ class ModelOverlayMetadata(BaseModel):
         "context_window",
         "max_output_tokens",
         "process_poll_default_wait_seconds",
+        "shell_output_byte_limit",
         "default_temperature",
         mode="before",
     )
@@ -385,6 +392,7 @@ class LoadedModelOverlay:
             process_poll_default_wait_seconds=(
                 self.manifest.metadata.process_poll_default_wait_seconds or 0
             ),
+            shell_output_byte_limit=self.manifest.metadata.shell_output_byte_limit,
             model_specific=self.manifest.metadata.model_specific,
             default_provider=self.provider,
             default_temperature=self._default_temperature(),
@@ -436,6 +444,8 @@ class LoadedModelOverlay:
             update_payload["process_poll_default_wait_seconds"] = (
                 metadata.process_poll_default_wait_seconds
             )
+        if metadata.shell_output_byte_limit is not None:
+            update_payload["shell_output_byte_limit"] = metadata.shell_output_byte_limit
         if metadata.model_specific is not None:
             update_payload["model_specific"] = metadata.model_specific
         if self._default_temperature() is not None:
@@ -693,6 +703,7 @@ def build_model_overlay_manifest_from_database(
         structured_tool_policy=existing.structured_tool_policy,
         managed_process_poll_folding=existing.managed_process_poll_folding,
         process_poll_default_wait_seconds=existing.process_poll_default_wait_seconds,
+        shell_output_byte_limit=existing.shell_output_byte_limit,
         fast=existing.fast,
         default_temperature=existing.default_temperature,
     )

--- a/src/fast_agent/llm/terminal_output_limits.py
+++ b/src/fast_agent/llm/terminal_output_limits.py
@@ -33,6 +33,10 @@ def calculate_terminal_output_limit_for_model(model_name: str | None) -> int:
     if not model_name:
         return DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT
 
+    model_override = ModelDatabase.get_shell_output_byte_limit(model_name)
+    if model_override is not None:
+        return model_override
+
     max_tokens = ModelDatabase.get_max_output_tokens(model_name)
     return calculate_terminal_output_limit_for_max_tokens(max_tokens)
 
@@ -42,5 +46,9 @@ def calculate_terminal_output_limit_for_resolved_model(
 ) -> int:
     if resolved_model is None:
         return DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT
+
+    model_params = resolved_model.model_params
+    if model_params is not None and model_params.shell_output_byte_limit is not None:
+        return model_params.shell_output_byte_limit
 
     return calculate_terminal_output_limit_for_max_tokens(resolved_model.max_output_tokens)

--- a/tests/unit/acp/test_terminal_output_limit_calculation.py
+++ b/tests/unit/acp/test_terminal_output_limit_calculation.py
@@ -17,6 +17,10 @@ def test_default_terminal_output_limit_falls_back_for_unknown_model() -> None:
     )
 
 
+def test_grok_45_uses_catalog_shell_output_limit() -> None:
+    assert calculate_terminal_output_limit_for_model("xai/grok-4.5") == 16_000
+
+
 def test_default_terminal_output_limit_scaled_for_large_output_models() -> None:
     # gpt-4.1 is defined in ModelDatabase with max_output_tokens=32768.
     # With the current budgeting constants this reaches the conservative hard cap.

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -124,7 +124,8 @@ class StubLLM:
     def __init__(self, model_name: str) -> None:
         self.model_name = model_name
         self.resolved_model = SimpleNamespace(
-            max_output_tokens=ModelDatabase.get_max_output_tokens(model_name)
+            max_output_tokens=ModelDatabase.get_max_output_tokens(model_name),
+            model_params=ModelDatabase.get_model_params(model_name),
         )
         self.instruction = ""
         self.default_request_params = RequestParams()
@@ -1610,6 +1611,97 @@ async def test_read_text_file_tool_use_turn_hides_bottom_bar_without_extra_messa
     assert call["bottom_items"] is None
     assert call["highlight_indexes"] == []
     assert call["additional_message"] is None
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+async def test_grok_catalog_shell_output_limit_applies_when_setting_is_omitted() -> None:
+    settings = Settings(shell_execution=ShellSettings())
+    config = AgentConfig(
+        name="test",
+        instruction="Instruction",
+        servers=[],
+        shell=True,
+        model="xai/grok-4.5?reasoning=high",
+    )
+    agent = McpAgent(config=config, context=Context(config=settings))
+
+    shell_runtime = agent.shell_runtime
+    assert shell_runtime is not None
+    assert shell_runtime.output_byte_limit == 16_000
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+async def test_default_shell_output_limit_returns_after_switching_away_from_grok() -> None:
+    settings = Settings(shell_execution=ShellSettings())
+    config = AgentConfig(
+        name="test",
+        instruction="Instruction",
+        servers=[],
+        shell=True,
+        model="xai/grok-4.5",
+    )
+    agent = McpAgent(config=config, context=Context(config=settings))
+
+    shell_runtime = agent.shell_runtime
+    assert shell_runtime is not None
+    assert shell_runtime.output_byte_limit == 16_000
+
+    agent._on_llm_attached(cast("Any", StubLLM("claude-opus-4-6")))
+
+    assert shell_runtime.output_byte_limit == DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+async def test_explicit_null_shell_output_limit_uses_automatic_model_sizing() -> None:
+    settings = Settings(shell_execution=ShellSettings(output_byte_limit=None))
+    config = AgentConfig(
+        name="test",
+        instruction="Instruction",
+        servers=[],
+        shell=True,
+        model="claude-opus-4-6",
+    )
+    agent = McpAgent(config=config, context=Context(config=settings))
+
+    shell_runtime = agent.shell_runtime
+    assert shell_runtime is not None
+    assert shell_runtime.output_byte_limit == calculate_terminal_output_limit_for_model(
+        "claude-opus-4-6"
+    )
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("configured_limit", [8192, 32_000])
+async def test_explicit_shell_output_limit_overrides_grok_catalog(
+    configured_limit: int,
+) -> None:
+    settings = Settings(
+        shell_execution=ShellSettings(output_byte_limit=configured_limit)
+    )
+    config = AgentConfig(
+        name="test",
+        instruction="Instruction",
+        servers=[],
+        shell=True,
+        model="xai/grok-4.5",
+    )
+    agent = McpAgent(config=config, context=Context(config=settings))
+
+    shell_runtime = agent.shell_runtime
+    assert shell_runtime is not None
+    assert shell_runtime.output_byte_limit == configured_limit
+
+    agent._on_llm_attached(cast("Any", StubLLM("xai/grok-4.5")))
+
+    assert shell_runtime.output_byte_limit == configured_limit
 
     await agent._aggregator.close()
 

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -1683,9 +1683,7 @@ async def test_explicit_null_shell_output_limit_uses_automatic_model_sizing() ->
 async def test_explicit_shell_output_limit_overrides_grok_catalog(
     configured_limit: int,
 ) -> None:
-    settings = Settings(
-        shell_execution=ShellSettings(output_byte_limit=configured_limit)
-    )
+    settings = Settings(shell_execution=ShellSettings(output_byte_limit=configured_limit))
     config = AgentConfig(
         name="test",
         instruction="Instruction",

--- a/tests/unit/fast_agent/llm/test_model_database.py
+++ b/tests/unit/fast_agent/llm/test_model_database.py
@@ -69,6 +69,7 @@ def test_managed_process_poll_folding_is_enabled_for_validated_models() -> None:
     )
     assert grok_45 is not None
     assert grok_45.managed_process_poll_folding is True
+    assert grok_45.shell_output_byte_limit == 16_000
 
     anthropic_models = [model for model in ModelDatabase.MODELS if model.startswith("claude-")]
     assert anthropic_models

--- a/tests/unit/fast_agent/llm/test_model_overlays.py
+++ b/tests/unit/fast_agent/llm/test_model_overlays.py
@@ -168,6 +168,32 @@ metadata:
     assert resolved.model_params.process_poll_default_wait_seconds == 30
 
 
+def test_overlay_configures_shell_output_byte_limit(tmp_path: Path) -> None:
+    home = tmp_path / ".fast-agent"
+    _write_overlay(
+        home,
+        "shell-output.yaml",
+        """
+name: shell-output
+provider: openresponses
+model: overlay-tests/Shell-Output
+connection:
+  base_url: http://localhost:8080/v1
+  auth: none
+metadata:
+  context_window: 65536
+  max_output_tokens: 4096
+  shell_output_byte_limit: 12000
+""".strip(),
+    )
+
+    with _isolated_overlay_environment(home, cleanup_base=tmp_path):
+        resolved = ModelFactory.resolve_model_spec("shell-output")
+
+    assert resolved.model_params is not None
+    assert resolved.model_params.shell_output_byte_limit == 12_000
+
+
 def test_same_provider_overlays_create_distinct_openresponses_clients(tmp_path: Path) -> None:
     home = tmp_path / ".fast-agent"
     _write_overlay(

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.9.24"
+version = "0.9.25"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- add a typed model-catalog shell preview override and set Grok 4.5 to 16,000 bytes
- preserve explicit integer and explicit `null` behavior while keeping 8,192 bytes as the global fallback
- recompute the effective preview correctly when models are attached or switched
- support the metadata in local model overlays and report its source in model details
- document catalog/default/explicit/automatic precedence

