### PR TITLE
fix(runtime): preserve ATIF across finalization failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.9.25"
+version = "0.9.26"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/cli/runtime/agent_setup.py
+++ b/src/fast_agent/cli/runtime/agent_setup.py
@@ -580,6 +580,66 @@ async def _export_failed_one_shot_atif(
     )
 
 
+async def _export_requested_outputs(
+    agent_app: Any,
+    request: AgentRunRequest,
+    *,
+    transient_messages_by_agent: Mapping[str, list[PromptMessageExtended]] | None,
+    session_manager: SessionManager | None,
+    harness_session: HarnessSession | None,
+) -> None:
+    """Export result history and ATIF independently.
+
+    A failure in one artifact must not prevent the other artifact from being
+    attempted. The first failure remains primary after both attempts finish.
+    """
+
+    failures: list[BaseException] = []
+    exporters = (
+        (
+            "result_history",
+            _export_result_histories(
+                agent_app,
+                request,
+                transient_messages_by_agent=transient_messages_by_agent,
+            ),
+        ),
+        (
+            "atif",
+            _export_live_atif_trajectory(
+                agent_app,
+                request,
+                transient_messages_by_agent=transient_messages_by_agent,
+                session_manager=session_manager,
+                harness_session=harness_session,
+            ),
+        ),
+    )
+    for artifact, exporter in exporters:
+        logger.debug(
+            "CLI artifact export started",
+            data={"artifact": artifact},
+        )
+        try:
+            await exporter
+        except BaseException as exc:
+            failures.append(exc)
+            logger.warning(
+                "CLI artifact export failed",
+                data={
+                    "artifact": artifact,
+                    "error_type": type(exc).__name__,
+                },
+            )
+        else:
+            logger.debug(
+                "CLI artifact export succeeded",
+                data={"artifact": artifact},
+            )
+    if failures:
+        raise failures[0]
+
+
 async def _run_cli_flow(
     agent_app: Any,
     request: AgentRunRequest,
@@ -630,16 +690,22 @@ async def _run_cli_flow(
                 harness_session=harness_session,
             )
         except BaseException as exc:
-            await _export_failed_one_shot_atif(
-                agent_app,
-                agent_obj,
-                prompt_payload,
-                request,
-                history_before=history_before,
-                session_manager=session_manager,
-                harness_session=harness_session,
-                error=exc,
-            )
+            try:
+                await _export_failed_one_shot_atif(
+                    agent_app,
+                    agent_obj,
+                    prompt_payload,
+                    request,
+                    history_before=history_before,
+                    session_manager=session_manager,
+                    harness_session=harness_session,
+                    error=exc,
+                )
+            except BaseException as export_exc:
+                logger.warning(
+                    "Failed-run ATIF export failed",
+                    data={"error_type": type(export_exc).__name__},
+                )
             raise
         one_shot_response = response
         transient_messages_by_agent = _transient_result_messages_if_needed(
@@ -668,16 +734,22 @@ async def _run_cli_flow(
                 harness_session=harness_session,
             )
         except BaseException as exc:
-            await _export_failed_one_shot_atif(
-                agent_app,
-                agent_obj,
-                prompt_payload,
-                request,
-                history_before=history_before,
-                session_manager=session_manager,
-                harness_session=harness_session,
-                error=exc,
-            )
+            try:
+                await _export_failed_one_shot_atif(
+                    agent_app,
+                    agent_obj,
+                    prompt_payload,
+                    request,
+                    history_before=history_before,
+                    session_manager=session_manager,
+                    harness_session=harness_session,
+                    error=exc,
+                )
+            except BaseException as export_exc:
+                logger.warning(
+                    "Failed-run ATIF export failed",
+                    data={"error_type": type(export_exc).__name__},
+                )
             raise
         one_shot_response = response
         transient_messages_by_agent = _transient_result_messages_if_needed(
@@ -695,12 +767,7 @@ async def _run_cli_flow(
             harness_session=harness_session,
         )
 
-    await _export_result_histories(
-        agent_app,
-        request,
-        transient_messages_by_agent=transient_messages_by_agent,
-    )
-    await _export_live_atif_trajectory(
+    await _export_requested_outputs(
         agent_app,
         request,
         transient_messages_by_agent=transient_messages_by_agent,

--- a/src/fast_agent/cli/runtime/agent_setup.py
+++ b/src/fast_agent/cli/runtime/agent_setup.py
@@ -594,26 +594,26 @@ async def _export_requested_outputs(
     attempted. The first failure remains primary after both attempts finish.
     """
 
-    failures: list[BaseException] = []
+    async def export_result_history() -> None:
+        await _export_result_histories(
+            agent_app,
+            request,
+            transient_messages_by_agent=transient_messages_by_agent,
+        )
+
+    async def export_atif() -> None:
+        await _export_live_atif_trajectory(
+            agent_app,
+            request,
+            transient_messages_by_agent=transient_messages_by_agent,
+            session_manager=session_manager,
+            harness_session=harness_session,
+        )
+
+    failures: list[Exception] = []
     exporters = (
-        (
-            "result_history",
-            _export_result_histories(
-                agent_app,
-                request,
-                transient_messages_by_agent=transient_messages_by_agent,
-            ),
-        ),
-        (
-            "atif",
-            _export_live_atif_trajectory(
-                agent_app,
-                request,
-                transient_messages_by_agent=transient_messages_by_agent,
-                session_manager=session_manager,
-                harness_session=harness_session,
-            ),
-        ),
+        ("result_history", export_result_history),
+        ("atif", export_atif),
     )
     for artifact, exporter in exporters:
         logger.debug(
@@ -621,8 +621,8 @@ async def _export_requested_outputs(
             data={"artifact": artifact},
         )
         try:
-            await exporter
-        except BaseException as exc:
+            await exporter()
+        except Exception as exc:
             failures.append(exc)
             logger.warning(
                 "CLI artifact export failed",
@@ -701,7 +701,7 @@ async def _run_cli_flow(
                     harness_session=harness_session,
                     error=exc,
                 )
-            except BaseException as export_exc:
+            except Exception as export_exc:
                 logger.warning(
                     "Failed-run ATIF export failed",
                     data={"error_type": type(export_exc).__name__},
@@ -745,7 +745,7 @@ async def _run_cli_flow(
                     harness_session=harness_session,
                     error=exc,
                 )
-            except BaseException as export_exc:
+            except Exception as export_exc:
                 logger.warning(
                     "Failed-run ATIF export failed",
                     data={"error_type": type(export_exc).__name__},

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -31,6 +31,11 @@ from fast_agent.tools.skill_reader import READ_SKILL_TOOL_NAME
 from fast_agent.types import PromptMessageExtended
 from fast_agent.types.llm_stop_reason import LlmStopReason
 from fast_agent.ui.console_display import ConsoleDisplay
+from fast_agent.utils.tool_names import (
+    BASH_TOOL_NAME,
+    EXECUTE_TOOL_NAME,
+    PROCESS_TOOL_NAME,
+)
 
 
 class _DisplayCall(TypedDict):
@@ -1632,6 +1637,49 @@ async def test_grok_catalog_shell_output_limit_applies_when_setting_is_omitted()
     assert shell_runtime.output_byte_limit == 16_000
 
     await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+async def test_grok_uses_minimal_process_default_and_preserves_native_override() -> None:
+    minimal_agent = McpAgent(
+        config=AgentConfig(
+            name="minimal",
+            instruction="Instruction",
+            servers=[],
+            shell=True,
+            model="xai/grok-4.5?reasoning=high",
+        ),
+        context=Context(config=Settings(shell_execution=ShellSettings())),
+    )
+    minimal_runtime = minimal_agent.shell_runtime
+    assert minimal_runtime is not None
+    assert {tool.name for tool in minimal_runtime.tools} == {
+        BASH_TOOL_NAME,
+        PROCESS_TOOL_NAME,
+    }
+
+    native_agent = McpAgent(
+        config=AgentConfig(
+            name="native",
+            instruction="Instruction",
+            servers=[],
+            shell=True,
+            model="xai/grok-4.5?reasoning=high",
+        ),
+        context=Context(
+            config=Settings(
+                shell_execution=ShellSettings(tool_profile="native"),
+            )
+        ),
+    )
+    native_runtime = native_agent.shell_runtime
+    assert native_runtime is not None
+    assert native_runtime.owns_tool(EXECUTE_TOOL_NAME)
+    assert not native_runtime.owns_tool(BASH_TOOL_NAME)
+    assert not native_runtime.owns_tool(PROCESS_TOOL_NAME)
+
+    await minimal_agent._aggregator.close()
+    await native_agent._aggregator.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/fast_agent/commands/test_runtime_result_export.py
+++ b/tests/unit/fast_agent/commands/test_runtime_result_export.py
@@ -23,6 +23,7 @@ from fast_agent.cli.runtime.agent_setup import (
     _cli_attachment_token,
     _enable_atif_child_capture,
     _export_parallel_atif_trajectory,
+    _export_requested_outputs,
     _export_result_histories,
     _find_last_assistant_text,
     _resume_session_if_requested,
@@ -1035,6 +1036,40 @@ async def test_run_cli_flow_writes_result_when_atif_export_fails(
     exported = load_messages(str(result_output))
     assert [message.role for message in exported] == ["user", "assistant"]
     assert exported[1].last_text() == "done"
+
+
+@pytest.mark.asyncio
+async def test_requested_output_cancellation_stops_remaining_exports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atif_attempted = False
+
+    async def cancel_result_export(*args: object, **kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    async def record_atif_export(*args: object, **kwargs: object) -> None:
+        nonlocal atif_attempted
+        atif_attempted = True
+
+    monkeypatch.setattr(
+        "fast_agent.cli.runtime.agent_setup._export_result_histories",
+        cancel_result_export,
+    )
+    monkeypatch.setattr(
+        "fast_agent.cli.runtime.agent_setup._export_live_atif_trajectory",
+        record_atif_export,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await _export_requested_outputs(
+            SimpleNamespace(),
+            _make_request(result_file=None),
+            transient_messages_by_agent=None,
+            session_manager=None,
+            harness_session=None,
+        )
+
+    assert not atif_attempted
 
 
 @pytest.mark.asyncio

--- a/tests/unit/fast_agent/commands/test_runtime_result_export.py
+++ b/tests/unit/fast_agent/commands/test_runtime_result_export.py
@@ -971,6 +971,101 @@ async def test_run_cli_flow_writes_atif_input_when_one_shot_raises(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_run_cli_flow_writes_atif_when_result_export_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _NonPersistentMessageAgent("agent", "done")
+    app = _DummyAgentApp(["agent"])
+    app._agents["agent"] = agent
+    result_output = tmp_path / "result.json"
+    trajectory_output = tmp_path / "trajectory.json"
+
+    async def fail_result_export(*args: object, **kwargs: object) -> None:
+        raise typer.Exit(1)
+
+    monkeypatch.setattr(
+        "fast_agent.cli.runtime.agent_setup._export_result_histories",
+        fail_result_export,
+    )
+
+    with pytest.raises(typer.Exit):
+        await _run_cli_flow(
+            app,
+            _make_request(
+                result_file=str(result_output),
+                message="hello",
+                trajectory_output=trajectory_output,
+            ),
+        )
+
+    payload = json.loads(trajectory_output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "ATIF-v1.7"
+    assert payload["steps"][2]["message"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_run_cli_flow_writes_result_when_atif_export_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _NonPersistentMessageAgent("agent", "done")
+    app = _DummyAgentApp(["agent"])
+    app._agents["agent"] = agent
+    result_output = tmp_path / "result.json"
+
+    async def fail_atif_export(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("atif export failed")
+
+    monkeypatch.setattr(
+        "fast_agent.cli.runtime.agent_setup._export_live_atif_trajectory",
+        fail_atif_export,
+    )
+
+    with pytest.raises(RuntimeError, match="atif export failed"):
+        await _run_cli_flow(
+            app,
+            _make_request(
+                result_file=str(result_output),
+                message="hello",
+                trajectory_output=tmp_path / "trajectory.json",
+            ),
+        )
+
+    exported = load_messages(str(result_output))
+    assert [message.role for message in exported] == ["user", "assistant"]
+    assert exported[1].last_text() == "done"
+
+
+@pytest.mark.asyncio
+async def test_failed_run_preserves_primary_error_when_atif_export_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _FailingMessageAgent("agent")
+    app = _DummyAgentApp(["agent"])
+    app._agents["agent"] = agent
+
+    async def fail_atif_export(*args: object, **kwargs: object) -> None:
+        raise OSError("write failed")
+
+    monkeypatch.setattr(
+        "fast_agent.cli.runtime.agent_setup._export_failed_one_shot_atif",
+        fail_atif_export,
+    )
+
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        await _run_cli_flow(
+            app,
+            _make_request(
+                result_file=None,
+                message="hello",
+                trajectory_output=tmp_path / "trajectory.json",
+            ),
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_cli_flow_writes_partial_atif_when_cancelled(tmp_path: Path) -> None:
     agent = _FailingMessageAgent("agent", asyncio.CancelledError())
     app = _DummyAgentApp(["agent"])

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.9.25"
+version = "0.9.26"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- export result history and ATIF independently so one artifact failure does not suppress the other
- preserve the original run failure when failed-run ATIF export also fails
- preserve cancellation semantics by allowing `CancelledError` to propagate instead of treating cancellation as an artifact-export failure
- prepare package metadata for fast-agent 0.9.26
- add a regression test that pins Grok 4.5 to the existing `minimal_process` default while preserving explicit `native` overrides

The Grok test protects behavior already shipped since fast-agent 0.9.21. It does not add a model-specific override. Grok 4.5 retains the 16 KiB output-preview default shipped in 0.9.25.

## Motivation

A requested ATIF trajectory can be lost when another finalization artifact fails first, and a secondary ATIF-export failure can mask the primary provider/runtime error. Rewarded timeout/cancellation paths are especially sensitive to finalization robustness.

This change gives each requested artifact an independent export attempt while retaining correct exception precedence and cancellation behavior. It cannot recover ATIF after an external hard kill that prevents cleanup code from running.

## Validation

- `uv run scripts/lint.py`
- `uv run scripts/format.py --check` — 1,486 files compliant
- `uv run scripts/typecheck.py`
- `uv run scripts/check_internal_resources.py`
- focused runtime/shell tests — 138 passed before the cancellation follow-up; final runtime export file 69 passed
- full unit suite — 6,399 passed, 1 skipped
- integration suites — 361 passed, 1 skipped
- package-install smoke — passed
- clean install of the built wheel — reports `fast-agent-mcp v0.9.26` and `minimal_process` as the default tool profile

Provider credentials and `ENVIRONMENT_DIR` were removed from test subprocesses to avoid host-environment precedence affecting credential/config isolation tests.

## Local release artifacts

- wheel SHA-256: `f3e84105e26d7d7d0a2b1ae35e8adcd64b6ce658d0b61a9601b2aa63871b2b15`
- sdist SHA-256: `191f45b17db8c6d2c8c568d4c8ada016b56d928ccac00fdd4bfc0787d80186af`

These hashes describe local validation artifacts; CI should build release artifacts from the reviewed commit.

## Grok diagnostic context

A no-upload 15-trial Grok 4.5/high diagnostic using fast-agent 0.9.25, the existing `minimal_process` default, and the 16 KiB output window completed 14/15:

- `prove-plus-comm`: 5/5
- `sanitize-git-repo`: 4/5
- `qemu-alpine-ssh`: 5/5

This is supporting configuration evidence, not a benchmark campaign or submission source.

## Required contributor question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using an animal-skin product and would prefer a durable non-animal alternative.
