### PR TITLE
docs: add Grok 4.5 Terminal-Bench result

### DIFF
--- a/docs/docs/javascripts/homepage-benchmark-data.js
+++ b/docs/docs/javascripts/homepage-benchmark-data.js
@@ -95,6 +95,23 @@ window.fastAgentBenchmark = {
           url: "https://hub.harborframework.com/datasets/terminal-bench/terminal-bench-2-1/6/leaderboards/main/rows/6d091468-3fda-4cbf-ba1c-645b0f522e97",
         },
         {
+          fastAgent: true,
+          harness: "fast-agent",
+          label: "fast-agent / Grok 4.5",
+          model: "Grok 4.5 · high",
+          score: 80.45,
+          cost: 0.359173,
+          tokensIn: "192.30M",
+          tokensOut: "5.88M",
+          date: "2026-07-27",
+          attempts: "445 trials · PR #180",
+          note:
+            "fast-agent 0.9.25. Accuracy, cost, and tokens aggregated from the seven linked Harbor source jobs.",
+          disclaimer: "Provisional result pending Terminal-Bench leaderboard review.",
+          disclaimerLabel: "Provisional",
+          url: "https://github.com/harbor-framework/terminal-bench-2-1/pull/180",
+        },
+        {
           harness: "Claude Code",
           model: "Opus 4.8 · high",
           score: 78.88,


### PR DESCRIPTION
## Summary

- add the fast-agent + Grok 4.5 high run to the homepage Terminal-Bench 2.1 comparison
- report the 358/445 aggregate score (80.45%) and $0.359173 cost per task
- include aggregate token usage and link Terminal-Bench submission PR #180
- mark the result provisional pending leaderboard review

## Source

The seven non-overlapping Harbor source jobs linked from https://github.com/harbor-framework/terminal-bench-2-1/pull/180 total 445 trials, $159.832056, 192.30M input tokens, and 5.88M output tokens.

## Validation

- `node --check docs/docs/javascripts/homepage-benchmark-data.js`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- Playwright homepage smoke check, including selection of the Grok result

## Contributor question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it because it is made from calfskin. I would appreciate the giver's thoughtfulness, but would prefer to exchange it for a durable non-animal alternative.
