### PR TITLE
Release 0.9.29 with clearer shell lifecycle guidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.9.28"
+version = "0.9.29"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/agents/mcp_agent.py
+++ b/src/fast_agent/agents/mcp_agent.py
@@ -897,6 +897,14 @@ class McpAgent(ABC, ToolAgent):
         return int(minor) >= 2
 
     @staticmethod
+    def _prefers_extended_shell_guidance(model_name: str | None) -> bool:
+        """Return True for GPT-5.6-class models."""
+        if not model_name:
+            return False
+        normalized = ModelDatabase.normalize_model_name(model_name)
+        return re.match(r"^gpt-5\.6(?:$|[-.])", normalized) is not None
+
+    @staticmethod
     def _prefers_anthropic_edit_file_model(model_name: str | None) -> bool:
         """Return True for Anthropic-series models."""
         if not model_name:
@@ -1063,6 +1071,10 @@ class McpAgent(ABC, ToolAgent):
 
         if self._shell_runtime is None:
             return
+        self._shell_runtime.set_extended_guidance(
+            self._prefers_extended_shell_guidance(resolve_model_name(llm))
+        )
+        self._bash_tool = self._shell_runtime.tool
         self._shell_runtime.set_process_poll_default_wait_seconds(
             self._model_process_poll_default_wait_seconds(llm)
         )
@@ -1141,6 +1153,9 @@ class McpAgent(ABC, ToolAgent):
             config=self._context.config if self._context else None,
             agent_name=self._name,
             shell_environment=self._shell_environment,
+            extended_guidance=self._prefers_extended_shell_guidance(
+                self._resolve_shell_tool_model_name()
+            ),
         )
         self._shell_runtime_enabled = self._shell_runtime.enabled
         self._bash_tool = self._shell_runtime.tool

--- a/src/fast_agent/history/process_poll_folding.py
+++ b/src/fast_agent/history/process_poll_folding.py
@@ -26,6 +26,7 @@ from fast_agent.utils.tool_names import (
     EXECUTE_TOOL_NAME,
     POLL_PROCESS_TOOL_NAME,
     PROCESS_TOOL_NAME,
+    matches_tool_name,
 )
 
 if TYPE_CHECKING:
@@ -69,10 +70,10 @@ def _single_poll_call(
         return None
     call_id, request = next(iter(calls.items()))
     arguments = request.params.arguments or {}
-    if request.params.name == POLL_PROCESS_TOOL_NAME:
+    if matches_tool_name(request.params.name, POLL_PROCESS_TOOL_NAME):
         wait_sec = arguments.get("wait_sec")
         wake_on_output = arguments.get("wake_on_output", False)
-    elif request.params.name == PROCESS_TOOL_NAME:
+    elif matches_tool_name(request.params.name, PROCESS_TOOL_NAME):
         action = arguments.get("action", "status")
         if action not in {"status", "wait"}:
             return None
@@ -109,7 +110,10 @@ def _managed_process_start_id(
     calls = request.tool_calls or {}
     results = result.tool_results or {}
     for call_id, call in calls.items():
-        if call.params.name not in {EXECUTE_TOOL_NAME, BASH_TOOL_NAME}:
+        if not (
+            matches_tool_name(call.params.name, EXECUTE_TOOL_NAME)
+            or matches_tool_name(call.params.name, BASH_TOOL_NAME)
+        ):
             continue
         tool_result = results.get(call_id)
         if tool_result is None:

--- a/src/fast_agent/tools/shell_output.py
+++ b/src/fast_agent/tools/shell_output.py
@@ -143,8 +143,9 @@ class ShellOutputBuffer:
         return (
             f"{completeness} is available during this session at "
             f"{self.retained_output_path}. Use read_text_file for selected line ranges "
-            "or run a targeted search against that file; avoid reading the entire file "
-            "unless necessary."
+            "or run a targeted search against that file; before drawing conclusions "
+            "from truncated output, inspect the relevant retained content. Avoid "
+            "reading the entire file unless necessary."
         )
 
     def _start_retained(self, triggering_blob: bytes) -> None:

--- a/src/fast_agent/tools/shell_output.py
+++ b/src/fast_agent/tools/shell_output.py
@@ -35,6 +35,7 @@ class ShellOutputBuffer:
     retained_output_max_bytes: int = 0
     retained_output_bytes: int = 0
     retained_output_complete: bool = True
+    extended_guidance: bool = False
 
     def append(self, text: str) -> None:
         output_blob = text.encode("utf-8", errors="replace")
@@ -140,12 +141,16 @@ class ShellOutputBuffer:
                 "temporary-file quota was reached"
             )
         )
+        guidance = (
+            "before drawing conclusions from truncated output, inspect the relevant "
+            "retained content. Avoid reading the entire file unless necessary."
+            if self.extended_guidance
+            else "avoid reading the entire file unless necessary."
+        )
         return (
             f"{completeness} is available during this session at "
             f"{self.retained_output_path}. Use read_text_file for selected line ranges "
-            "or run a targeted search against that file; before drawing conclusions "
-            "from truncated output, inspect the relevant retained content. Avoid "
-            "reading the entire file unless necessary."
+            f"or run a targeted search against that file; {guidance}"
         )
 
     def _start_retained(self, triggering_blob: bytes) -> None:

--- a/src/fast_agent/tools/shell_process.py
+++ b/src/fast_agent/tools/shell_process.py
@@ -288,9 +288,7 @@ def build_managed_process_result(
                 "because it reached the foreground yield threshold."
             )
         else:
-            status_message = (
-                "Command is still running; no completion result is available yet."
-            )
+            status_message = "Command is still running; no completion result is available yet."
         if minimal_process_profile and persistent_background:
             next_action = (
                 "This command was intentionally started with "

--- a/src/fast_agent/tools/shell_process.py
+++ b/src/fast_agent/tools/shell_process.py
@@ -203,6 +203,7 @@ class ManagedShellProcess:
     task: asyncio.Task[ShellExecution]
     request: ShellExecutionRequest
     lifecycle: Literal["session", "persistent"]
+    intentional_persistent_background: bool
     callbacks: ShellRuntimeCallbacks
     output_state: ShellOutputBuffer
     display_state: ShellDisplayState
@@ -273,34 +274,47 @@ def build_managed_process_result(
     if output_spool_path is not None:
         sections.append(f"output_spool_path: {output_spool_path}")
     if not process.task.done():
-        if yielded_reason == "background":
-            reason = "started in the background"
+        persistent_background = process.intentional_persistent_background
+        if persistent_background:
+            status_message = "Managed background process is still running."
         elif yielded_reason == "idle":
-            reason = "reached the no-output yield threshold"
+            status_message = (
+                "Command is still running; no completion result is available yet "
+                "because it reached the no-output yield threshold."
+            )
         elif yielded_reason == "foreground":
-            reason = "reached the foreground yield threshold"
+            status_message = (
+                "Command is still running; no completion result is available yet "
+                "because it reached the foreground yield threshold."
+            )
         else:
-            reason = "is still running"
-        status_message = (
-            "Process is still running."
-            if yielded_reason is None
-            else f"Process is still running because it {reason}."
-        )
+            status_message = (
+                "Command is still running; no completion result is available yet."
+            )
+        if minimal_process_profile and persistent_background:
+            next_action = (
+                "This command was intentionally started with "
+                "run_in_background=true. Do not wait for it to exit; use `process` "
+                "with action='status' to inspect it or action='stop' to terminate it, "
+                "and run readiness checks in a separate `bash` call."
+            )
+        elif minimal_process_profile:
+            next_action = (
+                "Next: call `process` with action='wait' or 'status'. Do not rely "
+                "on partial output or end the task until the command completes."
+            )
+        else:
+            next_action = (
+                f"Use {POLL_PROCESS_TOOL_NAME} to monitor it or "
+                f"{TERMINATE_PROCESS_TOOL_NAME} to stop it."
+            )
         sections.extend(
             [
                 status_message,
                 f"process_id: {process.process_id}",
                 f"elapsed_seconds: {elapsed:.1f}",
                 f"total_output_bytes: {process.output_state.lifetime_output_bytes}",
-                (
-                    "Use Process with action='status' or 'wait' to monitor it, "
-                    "or action='stop' to stop it."
-                    if minimal_process_profile
-                    else (
-                        f"Use {POLL_PROCESS_TOOL_NAME} to monitor it or "
-                        f"{TERMINATE_PROCESS_TOOL_NAME} to stop it."
-                    )
-                ),
+                next_action,
             ]
         )
         if (

--- a/src/fast_agent/tools/shell_runtime.py
+++ b/src/fast_agent/tools/shell_runtime.py
@@ -177,6 +177,7 @@ class ShellRuntime:
         shell_environment: ShellEnvironment | None = None,
         idle_yield_seconds: float = _DEFAULT_IDLE_YIELD_SECONDS,
         foreground_yield_seconds: float = _DEFAULT_FOREGROUND_YIELD_SECONDS,
+        extended_guidance: bool = False,
     ) -> None:
         self._working_directory = str(working_directory) if working_directory is not None else None
         self._environment = shell_environment or LocalShellExecutor(
@@ -200,6 +201,7 @@ class ShellRuntime:
         self._agent_name = agent_name
         self._idle_yield_seconds = idle_yield_seconds
         self._foreground_yield_seconds = foreground_yield_seconds
+        self._extended_guidance = extended_guidance
         self._managed_processes: dict[str, ManagedShellProcess] = {}
         self._next_process_id = 1
         self._processes_lock = asyncio.Lock()
@@ -240,13 +242,17 @@ class ShellRuntime:
             shell_name = self.runtime_info().name
             if self._minimal_process_profile:
                 self._tool = set_tool_source(
-                    build_minimal_bash_tool(shell_name=shell_name),
+                    build_minimal_bash_tool(
+                        shell_name=shell_name,
+                        extended_guidance=self._extended_guidance,
+                    ),
                     SHELL_TOOL_SOURCE,
                 )
                 self._poll_process_tool = set_tool_source(
                     build_minimal_process_tool(
                         default_wait_seconds=self._minimal_process_wait_seconds(),
                         max_wait_seconds=self._max_process_poll_seconds,
+                        extended_guidance=self._extended_guidance,
                     ),
                     SHELL_TOOL_SOURCE,
                 )
@@ -292,6 +298,30 @@ class ShellRuntime:
     def active_process_count(self) -> int:
         """Return the number of managed processes that are currently alive."""
         return sum(not process.task.done() for process in self._managed_processes.values())
+
+    def set_extended_guidance(self, enabled: bool) -> None:
+        """Refresh model-facing minimal tools when model guidance policy changes."""
+        if self._extended_guidance == enabled:
+            return
+        self._extended_guidance = enabled
+        if not self.enabled or not self._minimal_process_profile:
+            return
+        shell_name = self.runtime_info().name
+        self._tool = set_tool_source(
+            build_minimal_bash_tool(
+                shell_name=shell_name,
+                extended_guidance=enabled,
+            ),
+            SHELL_TOOL_SOURCE,
+        )
+        self._poll_process_tool = set_tool_source(
+            build_minimal_process_tool(
+                default_wait_seconds=self._minimal_process_wait_seconds(),
+                max_wait_seconds=self._max_process_poll_seconds,
+                extended_guidance=enabled,
+            ),
+            SHELL_TOOL_SOURCE,
+        )
 
     async def process_snapshots(self) -> tuple[ManagedProcessSnapshot, ...]:
         """Return retained process state for interactive status displays."""
@@ -824,6 +854,7 @@ class ShellRuntime:
             output_byte_limit_requested=output_byte_limit is not None,
             retained_output_path=self._next_retained_output_path(),
             retained_output_max_bytes=self._retained_output_max_bytes,
+            extended_guidance=self._extended_guidance,
         )
         display_state = self._build_display_state(
             defer_display_to_tool_result=defer_display_to_tool_result,
@@ -864,6 +895,7 @@ class ShellRuntime:
             output_byte_limit_requested=parsed.output_byte_limit is not None,
             retained_output_path=self._next_retained_output_path(),
             retained_output_max_bytes=self._retained_output_max_bytes,
+            extended_guidance=self._extended_guidance,
         )
         display_state = self._build_display_state(
             defer_display_to_tool_result=defer_display_to_tool_result,

--- a/src/fast_agent/tools/shell_runtime.py
+++ b/src/fast_agent/tools/shell_runtime.py
@@ -504,7 +504,7 @@ class ShellRuntime:
         tool_name: str,
         arguments: dict[str, Any],
     ) -> _ManagedProcessOperation:
-        if tool_name == PROCESS_TOOL_NAME and self._minimal_process_profile:
+        if tool_name.casefold() == PROCESS_TOOL_NAME and self._minimal_process_profile:
             try:
                 parsed = parse_minimal_process_arguments(
                     arguments,
@@ -1360,7 +1360,7 @@ class ShellRuntime:
         defer_display_to_tool_result: bool = False,
     ) -> CallToolResult:
         """Dispatch one model-facing shell lifecycle tool."""
-        if name == BASH_TOOL_NAME and self._minimal_process_profile:
+        if name.casefold() == BASH_TOOL_NAME and self._minimal_process_profile:
             try:
                 parsed = parse_minimal_bash_arguments(arguments)
             except ValueError as exc:
@@ -1371,7 +1371,7 @@ class ShellRuntime:
                 show_tool_call_id=show_tool_call_id,
                 defer_display_to_tool_result=defer_display_to_tool_result,
             )
-        if name == PROCESS_TOOL_NAME and self._minimal_process_profile:
+        if name.casefold() == PROCESS_TOOL_NAME and self._minimal_process_profile:
             try:
                 parsed_process = parse_minimal_process_arguments(
                     arguments,

--- a/src/fast_agent/tools/shell_runtime.py
+++ b/src/fast_agent/tools/shell_runtime.py
@@ -914,6 +914,9 @@ class ShellRuntime:
                 task=task,
                 request=request,
                 lifecycle=parsed.lifecycle,
+                intentional_persistent_background=(
+                    parsed.background and parsed.lifecycle == "persistent"
+                ),
                 callbacks=callbacks,
                 output_state=output_state,
                 display_state=display_state,

--- a/src/fast_agent/tools/shell_tool_definitions.py
+++ b/src/fast_agent/tools/shell_tool_definitions.py
@@ -240,7 +240,7 @@ def build_minimal_bash_tool(*, shell_name: str) -> Tool:
             "running for the verifier. Do not use shell `&`, `nohup`, or `disown` "
             "to detach services. Foreground commands that take time may yield a "
             "managed process ID. Do not assume a yielded process completed: use "
-            "Process with `wait` or `status` before relying on its output or ending "
+            "process with `wait` or `status` before relying on its output or ending "
             "the task, unless it is an intentionally persistent service. If output "
             "is truncated and a retained-output path is reported, inspect the "
             "relevant ranges with read_text_file or a targeted search before drawing "
@@ -275,14 +275,14 @@ def build_minimal_process_tool(
     return Tool(
         name=PROCESS_TOOL_NAME,
         description=(
-            "List, inspect, wait for, or stop managed processes returned by Bash. "
+            "List, inspect, wait for, or stop managed processes returned by bash. "
             "`list` returns all retained processes in creation order and takes no "
             "process ID. "
             "`status` returns immediately. `wait` accepts an optional `wait_sec`; "
             "when omitted it uses the configured model-specific polling interval "
             "(with a nonzero fallback when the model has none). "
             f"Use {default_wait_seconds} seconds unless more frequent monitoring "
-            "is needed. When Bash yields a foreground process ID, use `wait` or "
+            "is needed. When bash yields a foreground process ID, use `wait` or "
             "`status` until completion before relying on its result or ending the "
             "task. `stop` terminates the process group."
         ),
@@ -292,7 +292,7 @@ def build_minimal_process_tool(
                 "process_id": {
                     "type": "string",
                     "description": (
-                        "Managed process ID returned by Bash. Required for status, "
+                        "Managed process ID returned by bash. Required for status, "
                         "wait, and stop; omit for list."
                     ),
                 },
@@ -444,7 +444,7 @@ def parse_minimal_bash_arguments(
     _reject_unknown_arguments(
         payload,
         _MINIMAL_BASH_ARGUMENTS,
-        tool_name="Bash",
+        tool_name="bash",
     )
     run_in_background = payload.get("run_in_background", False)
     if type(run_in_background) is not bool:
@@ -464,8 +464,8 @@ def parse_minimal_bash_arguments(
         raise ValueError(
             "Shell-level backgrounding was not executed.\n"
             "Submit only the long-running service command with "
-            "run_in_background=true. Use Process to inspect or stop it, "
-            "and run readiness checks in a separate Bash call."
+            "run_in_background=true. Use process to inspect or stop it, "
+            "and run readiness checks in a separate bash call."
         )
     return ShellExecuteArguments(
         command=command,
@@ -487,7 +487,7 @@ def parse_minimal_process_arguments(
     _reject_unknown_arguments(
         payload,
         _MINIMAL_PROCESS_ARGUMENTS,
-        tool_name="Process",
+        tool_name="process",
     )
     action = payload.get("action", "status")
     if action not in {"list", "status", "wait", "stop"}:

--- a/src/fast_agent/tools/shell_tool_definitions.py
+++ b/src/fast_agent/tools/shell_tool_definitions.py
@@ -239,7 +239,13 @@ def build_minimal_bash_tool(*, shell_name: str) -> Tool:
             "long-running command; it returns a managed process ID and remains "
             "running for the verifier. Do not use shell `&`, `nohup`, or `disown` "
             "to detach services. Foreground commands that take time may yield a "
-            "managed process ID; use Process to inspect, wait for, or stop it."
+            "managed process ID. Do not assume a yielded process completed: use "
+            "Process with `wait` or `status` before relying on its output or ending "
+            "the task, unless it is an intentionally persistent service. If output "
+            "is truncated and a retained-output path is reported, inspect the "
+            "relevant ranges with read_text_file or a targeted search before drawing "
+            "conclusions. Before ending, run a task-relevant verification and inspect "
+            "its result."
         ),
         inputSchema={
             "type": "object",
@@ -276,7 +282,9 @@ def build_minimal_process_tool(
             "when omitted it uses the configured model-specific polling interval "
             "(with a nonzero fallback when the model has none). "
             f"Use {default_wait_seconds} seconds unless more frequent monitoring "
-            "is needed. `stop` terminates the process group."
+            "is needed. When Bash yields a foreground process ID, use `wait` or "
+            "`status` until completion before relying on its result or ending the "
+            "task. `stop` terminates the process group."
         ),
         inputSchema={
             "type": "object",

--- a/src/fast_agent/tools/shell_tool_definitions.py
+++ b/src/fast_agent/tools/shell_tool_definitions.py
@@ -230,7 +230,21 @@ def build_terminate_process_tool() -> Tool:
     )
 
 
-def build_minimal_bash_tool(*, shell_name: str) -> Tool:
+def build_minimal_bash_tool(*, shell_name: str, extended_guidance: bool = False) -> Tool:
+    process_guidance = (
+        "Foreground commands that take time may yield a managed process ID. "
+        "Do not assume a yielded process completed: use process with `wait` or "
+        "`status` before relying on its output or ending the task, unless it is "
+        "an intentionally persistent service. If output is truncated and a "
+        "retained-output path is reported, inspect the relevant ranges with "
+        "read_text_file or a targeted search before drawing conclusions. Before "
+        "ending, run a task-relevant verification and inspect its result."
+        if extended_guidance
+        else (
+            "Foreground commands that take time may yield a managed process ID; "
+            "use process to inspect, wait for, or stop it."
+        )
+    )
     return Tool(
         name=BASH_TOOL_NAME,
         description=(
@@ -238,14 +252,7 @@ def build_minimal_bash_tool(*, shell_name: str) -> Tool:
             "`run_in_background=true` for a server, service, or other "
             "long-running command; it returns a managed process ID and remains "
             "running for the verifier. Do not use shell `&`, `nohup`, or `disown` "
-            "to detach services. Foreground commands that take time may yield a "
-            "managed process ID. Do not assume a yielded process completed: use "
-            "process with `wait` or `status` before relying on its output or ending "
-            "the task, unless it is an intentionally persistent service. If output "
-            "is truncated and a retained-output path is reported, inspect the "
-            "relevant ranges with read_text_file or a targeted search before drawing "
-            "conclusions. Before ending, run a task-relevant verification and inspect "
-            "its result."
+            f"to detach services. {process_guidance}"
         ),
         inputSchema={
             "type": "object",
@@ -271,7 +278,14 @@ def build_minimal_process_tool(
     *,
     default_wait_seconds: int,
     max_wait_seconds: int,
+    extended_guidance: bool = False,
 ) -> Tool:
+    completion_guidance = (
+        " When bash yields a foreground process ID, use `wait` or `status` until "
+        "completion before relying on its result or ending the task."
+        if extended_guidance
+        else ""
+    )
     return Tool(
         name=PROCESS_TOOL_NAME,
         description=(
@@ -282,9 +296,7 @@ def build_minimal_process_tool(
             "when omitted it uses the configured model-specific polling interval "
             "(with a nonzero fallback when the model has none). "
             f"Use {default_wait_seconds} seconds unless more frequent monitoring "
-            "is needed. When bash yields a foreground process ID, use `wait` or "
-            "`status` until completion before relying on its result or ending the "
-            "task. `stop` terminates the process group."
+            f"is needed.{completion_guidance} `stop` terminates the process group."
         ),
         inputSchema={
             "type": "object",

--- a/src/fast_agent/ui/tool_display.py
+++ b/src/fast_agent/ui/tool_display.py
@@ -657,7 +657,13 @@ class ToolDisplay:
             (
                 index
                 for index, line in enumerate(lines)
-                if line.startswith("Process is still running")
+                if line.startswith(
+                    (
+                        "Process is still running",
+                        "Command is still running",
+                        "Managed background process is still running",
+                    )
+                )
             ),
             None,
         )
@@ -719,7 +725,13 @@ class ToolDisplay:
         ):
             return False
         lines = content[0].text.splitlines()
-        return bool(lines) and lines[0].startswith("Process is still running")
+        return bool(lines) and lines[0].startswith(
+            (
+                "Process is still running",
+                "Command is still running",
+                "Managed background process is still running",
+            )
+        )
 
     @staticmethod
     def _structured_tool_result_display_content(

--- a/src/fast_agent/utils/tool_names.py
+++ b/src/fast_agent/utils/tool_names.py
@@ -8,8 +8,8 @@ from fast_agent.utils.action_normalization import normalize_action_token
 EXECUTE_TOOL_NAME = "execute"
 POLL_PROCESS_TOOL_NAME = "poll_process"
 TERMINATE_PROCESS_TOOL_NAME = "terminate_process"
-BASH_TOOL_NAME = "Bash"
-PROCESS_TOOL_NAME = "Process"
+BASH_TOOL_NAME = "bash"
+PROCESS_TOOL_NAME = "process"
 SHELL_EXECUTION_TOOL_NAMES = frozenset(
     {
         EXECUTE_TOOL_NAME,

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -334,7 +334,7 @@ async def test_shell_and_card_tools_are_both_highlighted() -> None:
         content=[TextContent(type="text", text="response")],
         tool_calls={
             "shell": CallToolRequest(
-                    params=CallToolRequestParams(name="bash", arguments={"command": "pwd"})
+                params=CallToolRequestParams(name="bash", arguments={"command": "pwd"})
             ),
             "lsp": CallToolRequest(
                 params=CallToolRequestParams(
@@ -956,6 +956,41 @@ async def test_default_shell_profile_exposes_facades_with_file_tools() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "expects_extended_guidance"),
+    [
+        ("gpt-5.6-luna", True),
+        ("openai/gpt-5.6-sol", True),
+        ("deepseek.deepseek-v4-flash", False),
+        ("sonnet", False),
+    ],
+)
+async def test_minimal_shell_extended_guidance_is_gpt56_specific(
+    model: str,
+    expects_extended_guidance: bool,
+) -> None:
+    config = AgentConfig(
+        name="test",
+        instruction="Instruction",
+        servers=[],
+        shell=True,
+        model=model,
+    )
+    agent = McpAgent(config=config, context=Context(config=Settings()))
+
+    tools = {tool.name: tool for tool in (await agent.list_tools()).tools}
+    bash_description = tools["bash"].description or ""
+    process_description = tools["process"].description or ""
+
+    assert ("task-relevant verification" in bash_description) is expects_extended_guidance
+    assert (
+        "before relying on its result or ending the task" in process_description
+    ) is expects_extended_guidance
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
 async def test_minimal_process_planned_metadata_matches_runtime_dispatch() -> None:
     settings = Settings()
     config = AgentConfig(
@@ -1562,7 +1597,7 @@ async def test_shell_tool_use_turn_hides_bottom_bar_and_mentions_shell_access() 
     tool_calls = {
         "1": CallToolRequest(
             params=CallToolRequestParams(
-                        name="bash",
+                name="bash",
                 arguments={"command": "pwd"},
             )
         )
@@ -1795,7 +1830,7 @@ async def test_local_shell_result_is_not_retruncated_by_mcp_result_policy() -> N
         tool_calls={
             "call-1": CallToolRequest(
                 params=CallToolRequestParams(
-                        name="bash",
+                    name="bash",
                     arguments={"command": "emit output"},
                 )
             )

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -334,7 +334,7 @@ async def test_shell_and_card_tools_are_both_highlighted() -> None:
         content=[TextContent(type="text", text="response")],
         tool_calls={
             "shell": CallToolRequest(
-                params=CallToolRequestParams(name="Bash", arguments={"command": "pwd"})
+                    params=CallToolRequestParams(name="bash", arguments={"command": "pwd"})
             ),
             "lsp": CallToolRequest(
                 params=CallToolRequestParams(
@@ -468,8 +468,8 @@ async def test_shell_can_include_local_read_text_file_when_enabled(tmp_path: Pat
     agent = McpAgent(config=config, context=Context(config=settings))
 
     tool_names = {tool.name for tool in (await agent.list_tools()).tools}
-    assert "Bash" in tool_names
-    assert "Process" in tool_names
+    assert "bash" in tool_names
+    assert "process" in tool_names
     assert "read_text_file" in tool_names
     assert "write_text_file" in tool_names
     assert "edit_file" in tool_names
@@ -742,8 +742,8 @@ async def test_local_read_text_file_option_is_enabled_by_default() -> None:
     agent = McpAgent(config=config, context=Context())
 
     tool_names = {tool.name for tool in (await agent.list_tools()).tools}
-    assert "Bash" in tool_names
-    assert "Process" in tool_names
+    assert "bash" in tool_names
+    assert "process" in tool_names
     assert "read_text_file" in tool_names
     assert "write_text_file" in tool_names
     assert "edit_file" in tool_names
@@ -944,8 +944,8 @@ async def test_default_shell_profile_exposes_facades_with_file_tools() -> None:
     agent = McpAgent(config=config, context=Context(config=settings))
 
     tool_names = {tool.name for tool in (await agent.list_tools()).tools}
-    assert "Bash" in tool_names
-    assert "Process" in tool_names
+    assert "bash" in tool_names
+    assert "process" in tool_names
     assert "execute" not in tool_names
     assert "poll_process" not in tool_names
     assert "terminate_process" not in tool_names
@@ -967,7 +967,7 @@ async def test_minimal_process_planned_metadata_matches_runtime_dispatch() -> No
     agent = McpAgent(config=config, context=Context(config=settings))
 
     bash_metadata = agent._metadata_for_planned_tool(
-        tool_name="Bash",
+        tool_name="bash",
         tool_args={"command": "service", "run_in_background": True},
         local_tool=None,
         is_external_runtime_tool=False,
@@ -979,7 +979,7 @@ async def test_minimal_process_planned_metadata_matches_runtime_dispatch() -> No
     assert bash_metadata["lifecycle"] == "persistent"
 
     status_metadata = agent._metadata_for_planned_tool(
-        tool_name="Process",
+        tool_name="process",
         tool_args={"process_id": "process-1", "action": "status"},
         local_tool=None,
         is_external_runtime_tool=False,
@@ -991,7 +991,7 @@ async def test_minimal_process_planned_metadata_matches_runtime_dispatch() -> No
     assert status_metadata["wait_sec"] == 0
 
     stop_metadata = agent._metadata_for_planned_tool(
-        tool_name="Process",
+        tool_name="process",
         tool_args={"process_id": "process-1", "action": "stop"},
         local_tool=None,
         is_external_runtime_tool=False,
@@ -1562,7 +1562,7 @@ async def test_shell_tool_use_turn_hides_bottom_bar_and_mentions_shell_access() 
     tool_calls = {
         "1": CallToolRequest(
             params=CallToolRequestParams(
-                name="Bash",
+                        name="bash",
                 arguments={"command": "pwd"},
             )
         )
@@ -1795,7 +1795,7 @@ async def test_local_shell_result_is_not_retruncated_by_mcp_result_policy() -> N
         tool_calls={
             "call-1": CallToolRequest(
                 params=CallToolRequestParams(
-                    name="Bash",
+                        name="bash",
                     arguments={"command": "emit output"},
                 )
             )

--- a/tests/unit/fast_agent/tools/test_environment_filesystem_runtime.py
+++ b/tests/unit/fast_agent/tools/test_environment_filesystem_runtime.py
@@ -477,13 +477,13 @@ async def test_mcp_agent_routes_file_tools_to_injected_execution_environment() -
     agent = McpAgent(config=config, context=Context(), shell_environment=env)
 
     tool_names = {tool.name for tool in (await agent.list_tools()).tools}
-    assert "Bash" in tool_names
-    assert "Process" in tool_names
+    assert "bash" in tool_names
+    assert "process" in tool_names
     assert "read_text_file" in tool_names
     assert "apply_patch" in tool_names
 
     read = await agent.call_tool("read_text_file", {"path": "remote.txt"})
-    shell = await agent.call_tool("Bash", {"command": "pwd"})
+    shell = await agent.call_tool("bash", {"command": "pwd"})
 
     assert read.isError is False
     assert _text(read) == "remote file\n"
@@ -507,8 +507,8 @@ async def test_mcp_agent_does_not_expose_host_file_tools_for_shell_only_environm
 
     tool_names = {tool.name for tool in (await agent.list_tools()).tools}
 
-    assert "Bash" in tool_names
-    assert "Process" in tool_names
+    assert "bash" in tool_names
+    assert "process" in tool_names
     assert "read_text_file" not in tool_names
     assert "write_text_file" not in tool_names
     assert "apply_patch" not in tool_names

--- a/tests/unit/fast_agent/tools/test_shell_runtime.py
+++ b/tests/unit/fast_agent/tools/test_shell_runtime.py
@@ -1422,7 +1422,10 @@ async def test_silent_command_yields_alive_then_poll_reports_completion() -> Non
     assert result.isError is False
     assert result.content is not None
     assert isinstance(result.content[0], TextContent)
-    assert "Process is still running" in result.content[0].text
+    assert "Command is still running; no completion result is available yet" in (
+        result.content[0].text
+    )
+    assert "Do not rely on partial output or end the task" in result.content[0].text
     assert "process_id: process-1" in result.content[0].text
     assert environment.requests[0].terminate_after_idle is False
     assert environment.requests[0].retain_output is False
@@ -1430,7 +1433,12 @@ async def test_silent_command_yields_alive_then_poll_reports_completion() -> Non
     running_poll = await runtime.poll_process({"process_id": "process-1"})
     assert running_poll.content is not None
     assert isinstance(running_poll.content[0], TextContent)
-    assert "Process is still running." in running_poll.content[0].text
+    assert "Command is still running; no completion result is available yet." in (
+        running_poll.content[0].text
+    )
+    assert "Next: call `process` with action='wait' or 'status'." in (
+        running_poll.content[0].text
+    )
     assert "because it is still running" not in running_poll.content[0].text
     assert "output_activity: 0 lines / 0 bytes since last poll" in (running_poll.content[0].text)
     assert "no output observed for" in running_poll.content[0].text
@@ -1753,7 +1761,9 @@ async def test_poll_can_buffer_output_until_deadline() -> None:
     assert result.content is not None
     assert isinstance(result.content[0], TextContent)
     assert "still working" in result.content[0].text
-    assert "Process is still running." in result.content[0].text
+    assert "Managed background process is still running." in result.content[0].text
+    assert "Do not wait for it to exit" in result.content[0].text
+    assert "run readiness checks in a separate `bash` call" in result.content[0].text
     process_metadata = (result.meta or {})[FAST_AGENT_SHELL_PROCESS_METADATA]
     assert process_metadata["poll_elapsed_seconds"] >= 0.9
     assert process_metadata["poll_deadline_overshoot_seconds"] >= 0

--- a/tests/unit/fast_agent/tools/test_shell_runtime.py
+++ b/tests/unit/fast_agent/tools/test_shell_runtime.py
@@ -1436,9 +1436,7 @@ async def test_silent_command_yields_alive_then_poll_reports_completion() -> Non
     assert "Command is still running; no completion result is available yet." in (
         running_poll.content[0].text
     )
-    assert "Next: call `process` with action='wait' or 'status'." in (
-        running_poll.content[0].text
-    )
+    assert "Next: call `process` with action='wait' or 'status'." in (running_poll.content[0].text)
     assert "because it is still running" not in running_poll.content[0].text
     assert "output_activity: 0 lines / 0 bytes since last poll" in (running_poll.content[0].text)
     assert "no output observed for" in running_poll.content[0].text

--- a/tests/unit/fast_agent/tools/test_shell_runtime.py
+++ b/tests/unit/fast_agent/tools/test_shell_runtime.py
@@ -586,7 +586,7 @@ def test_minimal_process_profile_exposes_only_bash_and_process() -> None:
         config=Settings(shell_execution=ShellSettings(tool_profile="minimal_process")),
     )
 
-    assert [tool.name for tool in runtime.tools] == ["Bash", "Process"]
+    assert [tool.name for tool in runtime.tools] == ["bash", "process"]
     assert runtime.tool is not None
     assert set(runtime.tool.inputSchema["properties"]) == {
         "command",

--- a/tests/unit/fast_agent/tools/test_tb21_shell_behavior_guidance.py
+++ b/tests/unit/fast_agent/tools/test_tb21_shell_behavior_guidance.py
@@ -9,11 +9,12 @@ from fast_agent.tools.shell_tool_definitions import (
 
 def test_minimal_bash_guidance_requires_managed_process_and_output_followup() -> None:
     tool = build_minimal_bash_tool(shell_name="bash")
+    assert tool.name == "bash"
     assert tool.description is not None
     description = tool.description
 
     assert "Do not assume a yielded process completed" in description
-    assert "Process with `wait` or `status`" in description
+    assert "process with `wait` or `status`" in description
     assert "retained-output path" in description
     assert "read_text_file" in description
     assert "task-relevant verification" in description
@@ -25,6 +26,7 @@ def test_minimal_process_guidance_requires_completion_check() -> None:
         default_wait_seconds=240,
         max_wait_seconds=250,
     )
+    assert tool.name == "process"
     assert tool.description is not None
     description = tool.description
 

--- a/tests/unit/fast_agent/tools/test_tb21_shell_behavior_guidance.py
+++ b/tests/unit/fast_agent/tools/test_tb21_shell_behavior_guidance.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from fast_agent.tools.shell_output import ShellOutputBuffer
+from fast_agent.tools.shell_tool_definitions import (
+    build_minimal_bash_tool,
+    build_minimal_process_tool,
+)
+
+
+def test_minimal_bash_guidance_requires_managed_process_and_output_followup() -> None:
+    tool = build_minimal_bash_tool(shell_name="bash")
+    assert tool.description is not None
+    description = tool.description
+
+    assert "Do not assume a yielded process completed" in description
+    assert "Process with `wait` or `status`" in description
+    assert "retained-output path" in description
+    assert "read_text_file" in description
+    assert "task-relevant verification" in description
+    assert "Do not use shell `&`, `nohup`, or `disown`" in description
+
+
+def test_minimal_process_guidance_requires_completion_check() -> None:
+    tool = build_minimal_process_tool(
+        default_wait_seconds=240,
+        max_wait_seconds=250,
+    )
+    assert tool.description is not None
+    description = tool.description
+
+    assert "use `wait` or `status` until completion" in description
+    assert "before relying on its result or ending the task" in description
+
+
+def test_truncation_guidance_requires_targeted_retained_output_inspection(
+    tmp_path: Path,
+) -> None:
+    retained = tmp_path / "output.log"
+    buffer = ShellOutputBuffer(
+        output_byte_limit=16,
+        retained_output_path=retained,
+        retained_output_max_bytes=1024,
+    )
+    buffer.append("output larger than the preview limit")
+
+    text = buffer.combined()
+
+    assert "before drawing conclusions from truncated output" in text
+    assert "read_text_file" in text
+    assert str(retained) in text

--- a/tests/unit/fast_agent/tools/test_tb21_shell_behavior_guidance.py
+++ b/tests/unit/fast_agent/tools/test_tb21_shell_behavior_guidance.py
@@ -8,7 +8,7 @@ from fast_agent.tools.shell_tool_definitions import (
 
 
 def test_minimal_bash_guidance_requires_managed_process_and_output_followup() -> None:
-    tool = build_minimal_bash_tool(shell_name="bash")
+    tool = build_minimal_bash_tool(shell_name="bash", extended_guidance=True)
     assert tool.name == "bash"
     assert tool.description is not None
     description = tool.description
@@ -25,6 +25,7 @@ def test_minimal_process_guidance_requires_completion_check() -> None:
     tool = build_minimal_process_tool(
         default_wait_seconds=240,
         max_wait_seconds=250,
+        extended_guidance=True,
     )
     assert tool.name == "process"
     assert tool.description is not None
@@ -42,6 +43,7 @@ def test_truncation_guidance_requires_targeted_retained_output_inspection(
         output_byte_limit=16,
         retained_output_path=retained,
         retained_output_max_bytes=1024,
+        extended_guidance=True,
     )
     buffer.append("output larger than the preview limit")
 
@@ -50,3 +52,30 @@ def test_truncation_guidance_requires_targeted_retained_output_inspection(
     assert "before drawing conclusions from truncated output" in text
     assert "read_text_file" in text
     assert str(retained) in text
+
+
+def test_concise_minimal_tools_omit_extended_guidance() -> None:
+    bash = build_minimal_bash_tool(shell_name="bash")
+    process = build_minimal_process_tool(
+        default_wait_seconds=240,
+        max_wait_seconds=250,
+    )
+
+    assert "use process to inspect, wait for, or stop it" in (bash.description or "")
+    assert "task-relevant verification" not in (bash.description or "")
+    assert "before relying on its result or ending the task" not in (process.description or "")
+
+
+def test_concise_truncation_notice_omits_extended_guidance(tmp_path: Path) -> None:
+    retained = tmp_path / "output.log"
+    buffer = ShellOutputBuffer(
+        output_byte_limit=16,
+        retained_output_path=retained,
+        retained_output_max_bytes=1024,
+    )
+    buffer.append("output larger than the preview limit")
+
+    text = buffer.combined()
+
+    assert "avoid reading the entire file unless necessary" in text
+    assert "before drawing conclusions from truncated output" not in text

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.9.28"
+version = "0.9.29"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- bump `fast-agent-mcp` package metadata from 0.9.28 to 0.9.29
- expose the minimal shell tools as lowercase `bash` and `process` for all models
- give GPT-5.6-class models stronger static guidance for yielded commands, retained output, and final verification
- clarify model-facing results for unfinished foreground commands and intentional persistent background processes for all models
- preserve case-insensitive handling for historical uppercase process-poll trajectories

## Model policy

GPT-5.6-class models receive the extended static `bash`/`process` descriptions and the stronger retained-output truncation reminder.

Other models, including DeepSeek V4 Flash, retain concise static tool descriptions and concise retained-output guidance. They still receive lowercase tool names and the clearer event-specific managed-process results.

## Dynamic process results

Automatically yielded foreground commands explicitly say that no completion result is available, direct the model to lowercase `process` with `wait` or `status`, and warn against relying on partial output or ending the task early.

Intentional persistent background commands instead say not to wait for exit, and direct the model to use `process status`/`stop` plus a separate lowercase `bash` readiness check.

## Compatibility

- model-facing minimal tool identifiers change from `Bash`/`Process` to `bash`/`process`
- shell runtime dispatch remains case-tolerant
- process-poll folding continues to recognize historical uppercase trajectories
- native `execute`/`poll_process`/`terminate_process` behavior is retained

## Validation

- 515 focused shell, agent, history, and display tests passed
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `git diff --check`
- tests cover GPT-5.6 Luna/Sol extended guidance and concise DeepSeek/Anthropic behavior
