### PR TITLE
fix(llm): preserve Responses error event details

### DIFF
--- a/src/fast_agent/llm/provider/openai/responses_streaming.py
+++ b/src/fast_agent/llm/provider/openai/responses_streaming.py
@@ -682,7 +682,7 @@ class ResponsesStreamingMixin(OpenAIToolNotificationMixin):
                 continue
             if is_responses_failure_event(event_type):
                 response = getattr(event, "response", None)
-                error = getattr(response, "error", None)
+                error = getattr(response, "error", None) if response is not None else event
                 message = getattr(error, "message", None)
                 code = getattr(error, "code", None)
                 if not isinstance(message, str) or not message:

--- a/tests/unit/fast_agent/llm/providers/test_responses_stream_replay.py
+++ b/tests/unit/fast_agent/llm/providers/test_responses_stream_replay.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 from openai import APIError
+from openai.types.responses import ResponseErrorEvent
 
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.llm.provider.openai.openresponses_streaming import OpenResponsesStreamingMixin
@@ -797,5 +798,36 @@ async def test_failed_responses_raise_provider_error_details() -> None:
         "error": {
             "message": "DeepSeek generation failed",
             "code": "server_error",
+        }
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_error_event_raises_provider_error_details() -> None:
+    harness = _ResponsesHarness()
+    error_event = ResponseErrorEvent(
+        code="rate_limit_exceeded",
+        message="Too many requests",
+        param=None,
+        sequence_number=1,
+        type="error",
+    )
+    stream = _FakeResponsesStream(
+        events=[error_event],
+        final_response=SimpleNamespace(output=[], usage=None),
+    )
+
+    with pytest.raises(APIError, match="Too many requests") as exc_info:
+        await harness._process_stream(
+            stream,
+            model="deepseek-v4-flash",
+            capture_filename=None,
+        )
+
+    assert exc_info.value.body == {
+        "error": {
+            "message": "Too many requests",
+            "code": "rate_limit_exceeded",
         }
     }


### PR DESCRIPTION
## Root cause

Responses streams have two failure shapes: `response.failed` stores its error under `event.response.error`, while the SDK's top-level `error` event stores `message` and `code` directly on the event. The shared failure handler always read the nested shape, so top-level errors were replaced with the generic `Responses stream failed.` message and lost their provider error code.

## Changes

- use the top-level event as the error payload when no response object is present
- add a regression test built from the SDK's concrete `ResponseErrorEvent`
- retain the existing nested `response.failed` behavior

## Tests

- RED: `uv run pytest tests/unit/fast_agent/llm/providers/test_responses_stream_replay.py::test_error_event_raises_provider_error_details -v` (failed with the generic fallback message)
- GREEN: the same focused test passed
- `uv run pytest tests/unit/fast_agent/llm/providers/test_responses_stream_replay.py -q` — 21 passed
- `env -u ENVIRONMENT_DIR uv run pytest tests/unit -q` — 6502 passed, 1 skipped
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `git diff --cached --check`

## Related issue

No existing issue was found for this failure shape.

## Required question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it because it is made from animal skin, and I would prefer a durable non-animal alternative.