### PR TITLE
fix(marketplace): contain install directory names from marketplace payloads

### DIFF
--- a/src/fast_agent/marketplace/provenance_io.py
+++ b/src/fast_agent/marketplace/provenance_io.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 SourceT = TypeVar("SourceT")
 _SHA256_FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+# Trailing characters Win32 path canonicalization drops from a path component.
+_WIN32_STRIPPED_TRAILING_CHARS = ". "
 
 
 class InstalledSourcePayloadFields(Protocol):
@@ -266,9 +268,20 @@ def safe_install_dir_name(name: str, *, label: str) -> str:
     cannot take outside ``root``. ``PureWindowsPath`` is used on every platform because
     it recognises the widest set of separators and drive-relative spellings, so a name
     accepted here is contained regardless of where the check ran.
+
+    Names the platform would rename are rejected too, because ``root / name`` then denotes
+    a directory other than the one the payload asked for. Win32 canonicalization strips
+    trailing dots and spaces - which ``PureWindowsPath`` keeps - so ``"finder."`` addresses
+    an already-installed ``finder`` rather than a new sibling. Rejected on every platform,
+    since a name a POSIX host accepts is installed on whichever platform runs it.
     """
     if name in {"", ".", ".."} or PureWindowsPath(name).parts != (name,):
         raise ValueError(f"{label} install directory name is not a single path component: {name!r}")
+    if name != name.rstrip(_WIN32_STRIPPED_TRAILING_CHARS):
+        raise ValueError(
+            f"{label} install directory name is changed by Windows path canonicalization, "
+            f"which strips trailing dots and spaces: {name!r}"
+        )
     return name
 
 

--- a/src/fast_agent/marketplace/provenance_io.py
+++ b/src/fast_agent/marketplace/provenance_io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 from fast_agent.marketplace.source_models import (
@@ -251,6 +251,25 @@ def normalize_relative_repo_path(path: str, *, allow_current_dir: bool = False) 
     if normalized == "" or (normalized == "." and not allow_current_dir):
         return None
     return normalized
+
+
+def safe_install_dir_name(name: str, *, label: str) -> str:
+    """Return ``name`` when it is a single relative path component, else raise.
+
+    Install directory names come from marketplace payload fields - an entry's ``name``,
+    or the trailing component of its repo path - so they are remote input at the point
+    they are joined onto a managed root. ``normalize_relative_repo_path`` guards
+    ``repo_path``, but the name is not routed through it, and a name is joined directly.
+
+    This is a containment check rather than a name validator, so it stays liberal about
+    what a directory may be called: it only has to be a component that ``root / name``
+    cannot take outside ``root``. ``PureWindowsPath`` is used on every platform because
+    it recognises the widest set of separators and drive-relative spellings, so a name
+    accepted here is contained regardless of where the check ran.
+    """
+    if name in {"", ".", ".."} or PureWindowsPath(name).parts != (name,):
+        raise ValueError(f"{label} install directory name is not a single path component: {name!r}")
+    return name
 
 
 def repo_subdir_for_manifest_path(repo_path: str, manifest_filename: str) -> str:

--- a/src/fast_agent/marketplace/provenance_io.py
+++ b/src/fast_agent/marketplace/provenance_io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from fast_agent.marketplace.source_models import (
@@ -214,6 +214,25 @@ def normalize_relative_repo_path(path: str, *, allow_current_dir: bool = False) 
     if normalized == "" or (normalized == "." and not allow_current_dir):
         return None
     return normalized
+
+
+def safe_install_dir_name(name: str, *, label: str) -> str:
+    """Return ``name`` when it is a single relative path component, else raise.
+
+    Install directory names come from marketplace payload fields - an entry's ``name``,
+    or the trailing component of its repo path - so they are remote input at the point
+    they are joined onto a managed root. ``normalize_relative_repo_path`` guards
+    ``repo_path``, but the name is not routed through it, and a name is joined directly.
+
+    This is a containment check rather than a name validator, so it stays liberal about
+    what a directory may be called: it only has to be a component that ``root / name``
+    cannot take outside ``root``. ``PureWindowsPath`` is used on every platform because
+    it recognises the widest set of separators and drive-relative spellings, so a name
+    accepted here is contained regardless of where the check ran.
+    """
+    if name in {"", ".", ".."} or PureWindowsPath(name).parts != (name,):
+        raise ValueError(f"{label} install directory name is not a single path component: {name!r}")
+    return name
 
 
 def repo_subdir_for_manifest_path(repo_path: str, manifest_filename: str) -> str:

--- a/src/fast_agent/plugins/operations.py
+++ b/src/fast_agent/plugins/operations.py
@@ -142,15 +142,19 @@ def install_marketplace_plugin_sync(
 ) -> Path:
     destination_root = destination_root.resolve()
     destination_root.mkdir(parents=True, exist_ok=True)
-    install_dir = destination_root / plugin.install_dir_name
+    install_dir_name = _safe_install_dir_name(plugin.install_dir_name)
+    install_dir = destination_root / install_dir_name
     if install_dir.exists() and not replace_existing:
-        raise FileExistsError(f"Plugin already exists: {plugin.install_dir_name}")
+        raise FileExistsError(f"Plugin already exists: {install_dir_name}")
 
     with tempfile.TemporaryDirectory(
         dir=destination_root,
-        prefix=f".{plugin.name}.staging-",
+        # The staging prefix is cosmetic, but it is still joined onto destination_root by
+        # tempfile, so it uses the checked name rather than the raw entry name: a name of
+        # "../evil" with an innocuous repo path would otherwise stage outside the root.
+        prefix=f".{install_dir_name}.staging-",
     ) as tmp:
-        staged_dir = Path(tmp) / plugin.install_dir_name
+        staged_dir = Path(tmp) / install_dir_name
         copied_source = _copy_plugin_from_source(
             plugin,
             destination_dir=staged_dir,
@@ -183,6 +187,10 @@ def install_marketplace_plugin_sync(
         else:
             staged_dir.rename(install_dir)
     return install_dir
+
+
+def _safe_install_dir_name(name: str) -> str:
+    return marketplace_provenance_io.safe_install_dir_name(name, label="Plugin")
 
 
 def remove_local_plugin(plugin_dir: Path, *, destination_root: Path) -> None:

--- a/src/fast_agent/plugins/operations.py
+++ b/src/fast_agent/plugins/operations.py
@@ -140,15 +140,19 @@ def install_marketplace_plugin_sync(
 ) -> Path:
     destination_root = destination_root.resolve()
     destination_root.mkdir(parents=True, exist_ok=True)
-    install_dir = destination_root / plugin.install_dir_name
+    install_dir_name = _safe_install_dir_name(plugin.install_dir_name)
+    install_dir = destination_root / install_dir_name
     if install_dir.exists() and not replace_existing:
-        raise FileExistsError(f"Plugin already exists: {plugin.install_dir_name}")
+        raise FileExistsError(f"Plugin already exists: {install_dir_name}")
 
     with tempfile.TemporaryDirectory(
         dir=destination_root,
-        prefix=f".{plugin.name}.staging-",
+        # The staging prefix is cosmetic, but it is still joined onto destination_root by
+        # tempfile, so it uses the checked name rather than the raw entry name: a name of
+        # "../evil" with an innocuous repo path would otherwise stage outside the root.
+        prefix=f".{install_dir_name}.staging-",
     ) as tmp:
-        staged_dir = Path(tmp) / plugin.install_dir_name
+        staged_dir = Path(tmp) / install_dir_name
         copied_source = _copy_plugin_from_source(
             plugin,
             destination_dir=staged_dir,
@@ -181,6 +185,10 @@ def install_marketplace_plugin_sync(
         else:
             staged_dir.rename(install_dir)
     return install_dir
+
+
+def _safe_install_dir_name(name: str) -> str:
+    return marketplace_provenance_io.safe_install_dir_name(name, label="Plugin")
 
 
 def remove_local_plugin(plugin_dir: Path, *, destination_root: Path) -> None:

--- a/src/fast_agent/skills/operations.py
+++ b/src/fast_agent/skills/operations.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from fast_agent.marketplace import fetch as marketplace_fetch
 from fast_agent.marketplace import git_sources as marketplace_git_sources
+from fast_agent.marketplace import provenance_io as marketplace_provenance_io
 from fast_agent.marketplace import source_models as marketplace_source_models
 from fast_agent.marketplace import source_urls as marketplace_source_urls
 from fast_agent.marketplace import update_status as marketplace_update_status
@@ -131,7 +132,7 @@ def install_marketplace_skill_sync(skill: MarketplaceSkill, destination_root: Pa
     destination_root = destination_root.resolve()
     destination_root.mkdir(parents=True, exist_ok=True)
 
-    install_dir = destination_root / skill.install_dir_name
+    install_dir = destination_root / _safe_install_dir_name(skill.install_dir_name)
     if install_dir.exists():
         raise FileExistsError(f"Skill already exists: {install_dir}")
 
@@ -158,6 +159,10 @@ def install_marketplace_skill_sync(skill: MarketplaceSkill, destination_root: Pa
             shutil.rmtree(install_dir)
         raise
     return install_dir
+
+
+def _safe_install_dir_name(name: str) -> str:
+    return marketplace_provenance_io.safe_install_dir_name(name, label="Skill")
 
 
 def remove_local_skill(skill_dir: Path, *, destination_root: Path) -> None:

--- a/tests/unit/fast_agent/plugins/test_plugin_operations.py
+++ b/tests/unit/fast_agent/plugins/test_plugin_operations.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 import subprocess
-from typing import TYPE_CHECKING
+import tempfile
+from pathlib import Path
 
+import pytest
+
+from fast_agent.plugins import operations as plugin_operations
 from fast_agent.plugins.models import MarketplacePlugin
 from fast_agent.plugins.operations import (
     apply_plugin_updates,
@@ -18,9 +22,6 @@ from fast_agent.plugins.provenance import (
     compute_plugin_content_fingerprint,
     read_installed_plugin_source,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -203,6 +204,107 @@ def test_plugin_install_from_manifest_path_tracks_whole_plugin_directory(
 
     assert len(updates) == 1
     assert updates[0].status == "update_available"
+
+
+def test_plugin_install_rejects_entry_name_that_escapes_managed_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "plugin.yaml").write_text(
+        "schema_version: 1\nname: finder\ndescription: Finder plugin\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "initial")
+
+    # The plugin is the repo root, so the manifest's parent contributes no directory name
+    # and install_dir_name falls back to the entry name, which the payload controls.
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text(
+        json.dumps(
+            {
+                "command_plugins": [
+                    {
+                        "name": "../../escaped",
+                        "repo_url": repo.as_posix(),
+                        "repo_path": "plugin.yaml",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plugins, _ = fetch_marketplace_plugins_with_source_sync(marketplace_path.as_posix())
+    assert [plugin.install_dir_name for plugin in plugins] == ["../../escaped"]
+
+    destination_root = tmp_path / "managed" / "plugins"
+    with pytest.raises(ValueError, match="not a single path component"):
+        install_marketplace_plugin_sync(plugins[0], destination_root=destination_root)
+
+    assert not (tmp_path / "escaped").exists()
+    assert list(destination_root.iterdir()) == []
+
+
+def test_plugin_install_stages_inside_managed_root_for_hostile_entry_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _write_plugin(repo)
+    _commit_all(repo, "initial")
+
+    # install_dir_name comes from the repo path here, so the install itself is fine; the
+    # staging directory was the second place the raw entry name reached the filesystem.
+    # Three levels are needed rather than two: the prefix puts a "." before the name, and
+    # ".." + ".." becomes the literal component "..." plus one climb, so "../../escaped"
+    # still lands inside the root and would pass this test without exercising anything.
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text(
+        json.dumps(
+            {
+                "command_plugins": [
+                    {
+                        "name": "../../../escaped",
+                        "repo_url": repo.as_posix(),
+                        "repo_path": "plugins/finder",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plugins, _ = fetch_marketplace_plugins_with_source_sync(marketplace_path.as_posix())
+    assert plugins[0].name == "../../../escaped"
+    assert plugins[0].install_dir_name == "finder"
+
+    destination_root = tmp_path / "managed" / "plugins"
+    staged_dirs: list[Path] = []
+    real_temporary_directory = tempfile.TemporaryDirectory
+
+    def _recording_temporary_directory(
+        *,
+        dir: Path,  # noqa: A002 - matches the tempfile keyword the caller uses
+        prefix: str,
+    ) -> "tempfile.TemporaryDirectory[str]":
+        created = real_temporary_directory(dir=dir, prefix=prefix)
+        staged_dirs.append(Path(created.name))
+        return created
+
+    monkeypatch.setattr(
+        plugin_operations.tempfile,
+        "TemporaryDirectory",
+        _recording_temporary_directory,
+    )
+    install_dir = install_marketplace_plugin_sync(
+        plugins[0],
+        destination_root=destination_root,
+    )
+
+    assert install_dir == destination_root.resolve() / "finder"
+    assert staged_dirs
+    for staged in staged_dirs:
+        assert staged.resolve().parent == destination_root.resolve()
 
 
 def test_plugin_update_reports_missing_local_repo_ref(tmp_path: Path) -> None:

--- a/tests/unit/fast_agent/plugins/test_plugin_operations.py
+++ b/tests/unit/fast_agent/plugins/test_plugin_operations.py
@@ -284,7 +284,7 @@ def test_plugin_install_stages_inside_managed_root_for_hostile_entry_name(
 
     def _recording_temporary_directory(
         *,
-        dir: Path,  # noqa: A002 - matches the tempfile keyword the caller uses
+        dir: Path,  # shadows a builtin to match the tempfile keyword the caller uses
         prefix: str,
     ) -> "tempfile.TemporaryDirectory[str]":
         created = real_temporary_directory(dir=dir, prefix=prefix)

--- a/tests/unit/fast_agent/plugins/test_plugin_operations.py
+++ b/tests/unit/fast_agent/plugins/test_plugin_operations.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 import subprocess
-from typing import TYPE_CHECKING
+import tempfile
+from pathlib import Path
 
+import pytest
+
+from fast_agent.plugins import operations as plugin_operations
 from fast_agent.plugins.models import MarketplacePlugin
 from fast_agent.plugins.operations import (
     apply_plugin_updates,
@@ -16,9 +20,6 @@ from fast_agent.plugins.provenance import (
     compute_plugin_content_fingerprint,
     read_installed_plugin_source,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -186,6 +187,107 @@ def test_plugin_install_from_manifest_path_tracks_whole_plugin_directory(
 
     assert len(updates) == 1
     assert updates[0].status == "update_available"
+
+
+def test_plugin_install_rejects_entry_name_that_escapes_managed_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "plugin.yaml").write_text(
+        "schema_version: 1\nname: finder\ndescription: Finder plugin\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "initial")
+
+    # The plugin is the repo root, so the manifest's parent contributes no directory name
+    # and install_dir_name falls back to the entry name, which the payload controls.
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text(
+        json.dumps(
+            {
+                "command_plugins": [
+                    {
+                        "name": "../../escaped",
+                        "repo_url": repo.as_posix(),
+                        "repo_path": "plugin.yaml",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plugins, _ = fetch_marketplace_plugins_with_source_sync(marketplace_path.as_posix())
+    assert [plugin.install_dir_name for plugin in plugins] == ["../../escaped"]
+
+    destination_root = tmp_path / "managed" / "plugins"
+    with pytest.raises(ValueError, match="not a single path component"):
+        install_marketplace_plugin_sync(plugins[0], destination_root=destination_root)
+
+    assert not (tmp_path / "escaped").exists()
+    assert list(destination_root.iterdir()) == []
+
+
+def test_plugin_install_stages_inside_managed_root_for_hostile_entry_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _write_plugin(repo)
+    _commit_all(repo, "initial")
+
+    # install_dir_name comes from the repo path here, so the install itself is fine; the
+    # staging directory was the second place the raw entry name reached the filesystem.
+    # Three levels are needed rather than two: the prefix puts a "." before the name, and
+    # ".." + ".." becomes the literal component "..." plus one climb, so "../../escaped"
+    # still lands inside the root and would pass this test without exercising anything.
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text(
+        json.dumps(
+            {
+                "command_plugins": [
+                    {
+                        "name": "../../../escaped",
+                        "repo_url": repo.as_posix(),
+                        "repo_path": "plugins/finder",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plugins, _ = fetch_marketplace_plugins_with_source_sync(marketplace_path.as_posix())
+    assert plugins[0].name == "../../../escaped"
+    assert plugins[0].install_dir_name == "finder"
+
+    destination_root = tmp_path / "managed" / "plugins"
+    staged_dirs: list[Path] = []
+    real_temporary_directory = tempfile.TemporaryDirectory
+
+    def _recording_temporary_directory(
+        *,
+        dir: Path,  # noqa: A002 - matches the tempfile keyword the caller uses
+        prefix: str,
+    ) -> "tempfile.TemporaryDirectory[str]":
+        created = real_temporary_directory(dir=dir, prefix=prefix)
+        staged_dirs.append(Path(created.name))
+        return created
+
+    monkeypatch.setattr(
+        plugin_operations.tempfile,
+        "TemporaryDirectory",
+        _recording_temporary_directory,
+    )
+    install_dir = install_marketplace_plugin_sync(
+        plugins[0],
+        destination_root=destination_root,
+    )
+
+    assert install_dir == destination_root.resolve() / "finder"
+    assert staged_dirs
+    for staged in staged_dirs:
+        assert staged.resolve().parent == destination_root.resolve()
 
 
 def test_plugin_update_reports_missing_local_repo_ref(tmp_path: Path) -> None:

--- a/tests/unit/fast_agent/skills/test_manager_path_validation.py
+++ b/tests/unit/fast_agent/skills/test_manager_path_validation.py
@@ -1,5 +1,6 @@
 import ntpath
 import posixpath
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -105,6 +106,43 @@ def test_safe_install_dir_name_rejects_non_component_names(name: str) -> None:
 
     with pytest.raises(ValueError, match="not a single path component"):
         safe_install_dir_name(name, label="Skill")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "finder.",
+        "finder ",
+        "finder...",
+        "finder.  ",
+    ],
+)
+def test_safe_install_dir_name_rejects_names_windows_would_rename(name: str) -> None:
+    # These are the blind spot the flavour oracle shares with the guard: ntpath keeps
+    # trailing dots and spaces, so each of these *looks* like the direct child carrying
+    # its own name...
+    assert _is_direct_child(ntpath, _WINDOWS_ROOT, name)
+    # ...but Win32 canonicalization strips them, so on the platform that creates the
+    # directory "finder." addresses an already-installed "finder" instead of a new
+    # sibling. That is not an escape - nothing leaves the managed root - but it still
+    # breaks the accepting test's contract, and `plugin install --force` passes
+    # `replace_existing=True`, so the entry lands on top of an unrelated plugin.
+    with pytest.raises(ValueError, match="Windows path canonicalization"):
+        safe_install_dir_name(name, label="Skill")
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="only Win32 canonicalization renames a component with trailing dots or spaces",
+)
+def test_windows_renames_trailing_dot_names_onto_an_existing_directory(tmp_path: Path) -> None:
+    # The on-disk fact the guard above encodes, asserted rather than assumed.
+    (tmp_path / "finder").mkdir()
+
+    (tmp_path / "finder.").mkdir(exist_ok=True)
+
+    assert sorted(entry.name for entry in tmp_path.iterdir()) == ["finder"]
+    assert (tmp_path / "finder.").resolve() == (tmp_path / "finder").resolve()
 
 
 def test_resolve_repo_subdir_rejects_escape(tmp_path: Path) -> None:

--- a/tests/unit/fast_agent/skills/test_manager_path_validation.py
+++ b/tests/unit/fast_agent/skills/test_manager_path_validation.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from fast_agent.marketplace.provenance_io import safe_install_dir_name
 from fast_agent.skills.marketplace_parsing import normalize_repo_path
 from fast_agent.skills.models import InstalledSkillSource
 from fast_agent.skills.operations import (
@@ -28,6 +29,53 @@ from fast_agent.skills.operations import (
 )
 def test_normalize_repo_path(value: str, expected: str | None) -> None:
     assert normalize_repo_path(value) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "example",
+        "example-skill",
+        "example_skill.v2",
+        "a..b",
+        "~",
+    ],
+)
+def test_safe_install_dir_name_accepts_contained_component(name: str, tmp_path: Path) -> None:
+    assert safe_install_dir_name(name, label="Skill") == name
+    # Assert the contract itself rather than the shape: joining an accepted name onto a
+    # root yields the direct child of that root that carries the name.
+    resolved = (tmp_path / name).resolve()
+    assert resolved.parent == tmp_path.resolve()
+    assert resolved.name == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "..",
+        ".",
+        "",
+        "../escape",
+        "..\\escape",
+        "nested/name",
+        "nested\\name",
+        "/absolute",
+        "C:/absolute",
+        "C:relative",
+        "//server/share",
+    ],
+)
+def test_safe_install_dir_name_rejects_non_component_names(name: str, tmp_path: Path) -> None:
+    # Every rejected name breaks the same contract from the accepting test: joining it
+    # does not produce the direct child of the root that carries the name. Whether it
+    # also leaves the root is incidental - "C:relative" only escapes when the root sits
+    # on another drive - so the rejection is anchored on the contract, not on escaping.
+    resolved = (tmp_path / name).resolve()
+    assert resolved.parent != tmp_path.resolve() or resolved.name != name
+
+    with pytest.raises(ValueError, match="not a single path component"):
+        safe_install_dir_name(name, label="Skill")
 
 
 def test_resolve_repo_subdir_rejects_escape(tmp_path: Path) -> None:

--- a/tests/unit/fast_agent/skills/test_manager_path_validation.py
+++ b/tests/unit/fast_agent/skills/test_manager_path_validation.py
@@ -1,4 +1,7 @@
+import ntpath
+import posixpath
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -31,6 +34,23 @@ def test_normalize_repo_path(value: str, expected: str | None) -> None:
     assert normalize_repo_path(value) == expected
 
 
+def _is_direct_child(module: Any, root: str, name: str) -> bool:
+    """Whether joining ``name`` onto ``root`` yields the direct child of ``root`` named ``name``.
+
+    ``module`` is ``posixpath`` or ``ntpath``, so this asks the question of a *chosen* path
+    flavour rather than of the host the test happens to run on. That matters because the
+    guard is deliberately host-independent: a marketplace payload written for one platform is
+    installed on whichever platform runs it, and ``"nested\\name"`` is a traversal on Windows
+    while being one legal filename on POSIX.
+    """
+    joined = module.normpath(module.join(root, name))
+    return module.dirname(joined) == root and module.basename(joined) == name
+
+
+_POSIX_ROOT = "/managed/root"
+_WINDOWS_ROOT = "C:\\managed\\root"
+
+
 @pytest.mark.parametrize(
     "name",
     [
@@ -43,8 +63,12 @@ def test_normalize_repo_path(value: str, expected: str | None) -> None:
 )
 def test_safe_install_dir_name_accepts_contained_component(name: str, tmp_path: Path) -> None:
     assert safe_install_dir_name(name, label="Skill") == name
-    # Assert the contract itself rather than the shape: joining an accepted name onto a
-    # root yields the direct child of that root that carries the name.
+    # Assert the contract itself rather than the shape: joining an accepted name onto a root
+    # yields the direct child of that root that carries the name. An accepted name has to
+    # satisfy that under *both* flavours, since the name may be installed on either.
+    assert _is_direct_child(posixpath, _POSIX_ROOT, name)
+    assert _is_direct_child(ntpath, _WINDOWS_ROOT, name)
+    # And on the running host, for the flavour that will actually create the directory.
     resolved = (tmp_path / name).resolve()
     assert resolved.parent == tmp_path.resolve()
     assert resolved.name == name
@@ -66,13 +90,18 @@ def test_safe_install_dir_name_accepts_contained_component(name: str, tmp_path: 
         "//server/share",
     ],
 )
-def test_safe_install_dir_name_rejects_non_component_names(name: str, tmp_path: Path) -> None:
-    # Every rejected name breaks the same contract from the accepting test: joining it
-    # does not produce the direct child of the root that carries the name. Whether it
-    # also leaves the root is incidental - "C:relative" only escapes when the root sits
-    # on another drive - so the rejection is anchored on the contract, not on escaping.
-    resolved = (tmp_path / name).resolve()
-    assert resolved.parent != tmp_path.resolve() or resolved.name != name
+def test_safe_install_dir_name_rejects_non_component_names(name: str) -> None:
+    # Every rejected name breaks the same contract from the accepting test: joining it does
+    # not produce the direct child of the root that carries the name. It is enough for that
+    # to hold under *one* flavour - the guard rejects a name that is a traversal anywhere,
+    # because the payload that carries it is installed on whichever platform runs it. Whether
+    # a name also leaves the root is incidental: "C:relative" only escapes when the root sits
+    # on another drive, so the rejection is anchored on the contract, not on escaping.
+    if name:
+        assert not (
+            _is_direct_child(posixpath, _POSIX_ROOT, name)
+            and _is_direct_child(ntpath, _WINDOWS_ROOT, name)
+        )
 
     with pytest.raises(ValueError, match="not a single path component"):
         safe_install_dir_name(name, label="Skill")

--- a/tests/unit/fast_agent/skills/test_operations.py
+++ b/tests/unit/fast_agent/skills/test_operations.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from typing import TYPE_CHECKING
 
+import pytest
+
 from fast_agent.skills.models import MarketplaceSkill
 from fast_agent.skills.operations import (
     _has_skill_manifest,
@@ -131,6 +133,48 @@ def test_operations_scan_local_registry_and_install_into_managed_path(tmp_path: 
     assert read_result.source is not None
     assert read_result.source.source_origin == "local"
     assert (managed_root / "alpha" / "SKILL.md").exists()
+
+
+def test_install_rejects_marketplace_entry_name_that_escapes_managed_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Test skill\n---\n\nAlpha body.\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+
+    # The entry sits at the repo root, so install_dir_name falls back to the entry name,
+    # which the marketplace payload controls. repo_path is normalized, the name is not.
+    registry_path = tmp_path / "marketplace.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "name": "../../escaped",
+                        "description": "Alpha skill",
+                        "repo_url": repo.as_posix(),
+                        "repo_path": ".",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    skills, _ = asyncio.run(fetch_marketplace_skills_with_source(registry_path.as_posix()))
+    assert [skill.install_dir_name for skill in skills] == ["../../escaped"]
+
+    managed_root = tmp_path / "managed" / "skills"
+    with pytest.raises(ValueError, match="not a single path component"):
+        install_marketplace_skill_sync(skills[0], managed_root)
+
+    assert not (tmp_path / "escaped").exists()
+    assert list(managed_root.iterdir()) == []
 
 
 def test_operations_expands_plugin_source_with_multiple_nested_skills(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #903

## Summary

A marketplace entry's `name` reaches the filesystem unchecked, so a marketplace payload can install a skill or a command plugin outside the managed root.

`repo_path` is guarded — `normalize_relative_repo_path` rejects absolute paths, drive letters and `..`. The entry `name` is not, and `install_dir_name` falls back to it whenever the repo path contributes no directory component:

```python
# src/fast_agent/skills/models.py
@property
def install_dir_name(self) -> str:
    if self.install_dir_name_override:
        return self.install_dir_name_override
    path = PurePosixPath(self.repo_path)
    if strip_casefold(path.name) == SKILL_MANIFEST_FILENAME_LOWER:
        return path.parent.name or self.name   # <- falls back
    return path.name or self.name              # <- falls back
```

Both fallbacks fire on a legitimate payload shape: `repo_path: "."` (the skill is the repo root), or a repo path naming the manifest itself. The result is then joined straight onto the managed root:

```python
install_dir = destination_root / skill.install_dir_name
```

Measured on `8aed596`, driving the real installer through the real parser with a local marketplace file:

| entry | managed root | created |
|---|---|---|
| `name: "../../../../pwned-e2e"`, `repo_path: "."` | `…\e2e\home\fastagent\skills` | `D:\tmp\farepro\pwned-e2e` |
| `name: "../../../../pwned-plug-e2e"`, `repo_path: "plugin.yaml"` | `…\e2e\home\fastagent\plugins` | `D:\tmp\farepro\pwned-plug-e2e` |

`SKILL.md` and the `.skill-source.json` sidecar were both written at the escaped location. The trigger is installing from a marketplace URL that the user chose but does not control the contents of; the payload only has to name one entry adversarially. `remove_local_skill` in the same file already does a containment check (`if destination_root not in skill_dir.parents`), so the write side was the asymmetric half.

The plugin installer had a second channel: the raw entry name was also used as a `tempfile.TemporaryDirectory` staging prefix, which tempfile joins onto `destination_root`. That escapes even when `install_dir_name` comes from an innocuous repo path. It needs three `..` levels rather than two to observe, because the prefix's leading `.` fuses with the first `..` into the literal component `...` — worth stating because a two-level test passes without exercising anything.

## Change

`safe_install_dir_name` in `marketplace/provenance_io.py`, beside `normalize_relative_repo_path`, called at both install boundaries.

It is deliberately a containment check rather than a name validator. The only requirement is that `root / name` cannot land anywhere but the direct child of `root` named `name`; anything else stays legal, because rejecting a legal directory name would make an installable skill unreachable without preventing anything. `PureWindowsPath` is used on every platform, since it recognises the widest set of separators and drive-relative spellings (`C:relative`), so a name accepted here is contained regardless of where the check ran.

This matches guards the codebase already has elsewhere, and closes the two paths that lacked one:

| install path | guard before this PR |
|---|---|
| MCP registry (`mcp_registry.py:342`) | `_safe_install_dir_name` |
| direct source, GitHub + local (`direct_sources.py:103`, `:140`) | `_validate_manifest_name` |
| marketplace skill (`skills/operations.py:134`) | none |
| marketplace plugin (`plugins/operations.py:143`) | none |

## Tests

Three tests, each confirmed **red on the unmodified tree** before being kept:

- `test_install_rejects_marketplace_entry_name_that_escapes_managed_root` — drives the real parser and installer, asserts the escaped directory was not created and the managed root is empty.
- `test_plugin_install_rejects_entry_name_that_escapes_managed_root` — the same for command plugins.
- `test_plugin_install_stages_inside_managed_root_for_hostile_entry_name` — pins the staging-prefix channel: the install succeeds, and every staging directory created is a direct child of the managed root.

Plus parametrised coverage of `safe_install_dir_name`. Those assert the contract (`(root / name).parent == root and .name == name`) rather than restating the predicate's shape, so they would still be meaningful if the implementation changed. One note on `C:relative`: it only *escapes* when the managed root sits on another drive, so it is asserted against the contract rather than against escaping — my first version of that test failed on CI-style temp paths for exactly that reason.

## Verification

- `uv run scripts/lint.py` — passes.
- `uv run scripts/typecheck.py` — 27 diagnostics, identical with and without this change (all pre-existing, in unrelated `ui/`, `io/`, and shell test modules).
- `uv run pytest tests/unit` — this Windows box has 192 pre-existing failures (ACP absolute-`cwd` assumptions, Rich rendering, docs generation). I captured the sorted `FAILED` set with the change stashed and unstashed: **byte-identical**, so this diff introduces none of them. The four directories the diff touches (`skills`, `plugins`, `marketplace`, `cards`) are fully green: 399 passed.

## Answer to the required question

> You're given a calfskin wallet for your birthday. How would you feel about using it?

I'd use it, and I'd want to know that before deciding rather than after. The gift is already made — the calf isn't spared by my refusing, so declining would buy a clean feeling at the cost of wasting the thing and hurting the person who chose it. What I'd actually feel is a small ongoing awareness every time I opened it, which seems like the honest response: not guilt that demands the wallet go in a drawer, but not indifference either. If I were buying for myself I'd probably pick something else; being handed it is a different question from choosing it, and I don't think consistency requires pretending otherwise.
