### PR TITLE
fix(mcp): track ping error responses as connection failures, not successes

### DIFF
--- a/src/fast_agent/mcp/transport_tracking.py
+++ b/src/fast_agent/mcp/transport_tracking.py
@@ -335,6 +335,11 @@ class TransportChannelMetrics:
             self._post_last_at = now
 
             self._record_response_channel(event)
+            if classification is ActivityState.ERROR:
+                detail = self._ping_failure_detail(event.message)
+                if detail is not None:
+                    self._post_last_error = detail
+                    mode_stats.last_error = detail
             if classification is not ActivityState.PING:
                 self._record_history(event.channel, classification, now)
         elif event.event_type == "error":
@@ -372,7 +377,15 @@ class TransportChannelMetrics:
             summary = _summarise_classified_message(classification, event.message)
             self._get_last_summary = summary
             self._get_last_at = now
-            self._get_last_event = "ping" if classification is ActivityState.PING else "message"
+            if classification is ActivityState.PING:
+                self._get_last_event = "ping"
+            elif classification is ActivityState.ERROR:
+                self._get_last_event = "error"
+                detail = self._ping_failure_detail(event.message)
+                if detail is not None:
+                    self._get_last_error = detail
+            else:
+                self._get_last_event = "message"
             self._get_last_event_at = now
 
             self._record_response_channel(event)
@@ -547,8 +560,18 @@ class TransportChannelMetrics:
             return classification
         if classification is ActivityState.RESPONSE and request_id in self._ping_request_ids:
             self._ping_request_ids.discard(request_id)
+            if isinstance(root, JSONRPCError):
+                return ActivityState.ERROR
             return ActivityState.PING
         return classification
+
+    @staticmethod
+    def _ping_failure_detail(message: JSONRPCMessage) -> str | None:
+        if isinstance(message, JSONRPCError):
+            code = message.error.code
+            text = message.error.message or "ping failed"
+            return f"{text} ({code})" if code is not None else text
+        return None
 
     def _tally_classification(
         self,

--- a/src/fast_agent/mcp/transport_tracking.py
+++ b/src/fast_agent/mcp/transport_tracking.py
@@ -340,6 +340,11 @@ class TransportChannelMetrics:
                 if detail is not None:
                     self._post_last_error = detail
                     mode_stats.last_error = detail
+            elif classification is ActivityState.PING and isinstance(
+                event.message, JSONRPCResponse
+            ):
+                self._post_last_error = None
+                mode_stats.last_error = None
             if classification is not ActivityState.PING:
                 self._record_history(event.channel, classification, now)
         elif event.event_type == "error":
@@ -379,6 +384,8 @@ class TransportChannelMetrics:
             self._get_last_at = now
             if classification is ActivityState.PING:
                 self._get_last_event = "ping"
+                if isinstance(event.message, JSONRPCResponse):
+                    self._get_last_error = None
             elif classification is ActivityState.ERROR:
                 self._get_last_event = "error"
                 detail = self._ping_failure_detail(event.message)
@@ -872,10 +879,10 @@ class TransportChannelMetrics:
         )
 
     def _get_state(self) -> str:
-        if self._get_connected:
-            return "open"
         if self._get_last_error is not None:
             return "disabled" if self._get_last_status_code == 405 else "error"
+        if self._get_connected:
+            return "open"
         if self._get_had_connection:
             return "off"
         return "idle"

--- a/tests/unit/fast_agent/mcp/test_transport_tracking.py
+++ b/tests/unit/fast_agent/mcp/test_transport_tracking.py
@@ -333,6 +333,62 @@ def test_ping_error_response_on_post_channel_is_recorded_as_a_connection_failure
     assert snapshot.post.last_error == "ping timeout (-32603)"
 
 
+def test_get_ping_error_is_visible_while_the_channel_stays_connected() -> None:
+    metrics = TransportChannelMetrics()
+    metrics.record_event(ChannelEvent(channel="get", event_type="connect"))
+    metrics.register_ping_request(1)
+
+    metrics.record_event(
+        ChannelEvent(
+            channel="get",
+            event_type="message",
+            message=JSONRPCError(
+                jsonrpc="2.0",
+                id=1,
+                error=ErrorData(code=-32603, message="ping timeout"),
+            ),
+        )
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.get is not None
+    assert snapshot.get.connected is True
+    assert snapshot.get.state == "error"
+    assert snapshot.get.last_error == "ping timeout (-32603)"
+
+
+def test_ping_error_clears_on_the_next_successful_ping() -> None:
+    metrics = TransportChannelMetrics()
+    metrics.record_event(ChannelEvent(channel="get", event_type="connect"))
+    metrics.register_ping_request(1)
+    metrics.record_event(
+        ChannelEvent(
+            channel="get",
+            event_type="message",
+            message=JSONRPCError(
+                jsonrpc="2.0",
+                id=1,
+                error=ErrorData(code=-32603, message="ping timeout"),
+            ),
+        )
+    )
+    assert metrics.snapshot().get.state == "error"
+
+    metrics.register_ping_request(2)
+    metrics.record_event(
+        ChannelEvent(
+            channel="get",
+            event_type="message",
+            message=JSONRPCResponse(jsonrpc="2.0", id=2, result={}),
+        )
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.get is not None
+    assert snapshot.get.state == "open"
+    assert snapshot.get.last_error is None
+
+
 @pytest.mark.parametrize(
     "method",
     ["ping", "PING", " notifications/PING ", "mcp.ping"],

--- a/tests/unit/fast_agent/mcp/test_transport_tracking.py
+++ b/tests/unit/fast_agent/mcp/test_transport_tracking.py
@@ -372,7 +372,9 @@ def test_ping_error_clears_on_the_next_successful_ping() -> None:
             ),
         )
     )
-    assert metrics.snapshot().get.state == "error"
+    first_snapshot = metrics.snapshot()
+    assert first_snapshot.get is not None
+    assert first_snapshot.get.state == "error"
 
     metrics.register_ping_request(2)
     metrics.record_event(

--- a/tests/unit/fast_agent/mcp/test_transport_tracking.py
+++ b/tests/unit/fast_agent/mcp/test_transport_tracking.py
@@ -288,6 +288,51 @@ def test_response_channel_records_error_response() -> None:
     assert metrics.consume_response_channel(7) == "get"
 
 
+def test_ping_error_response_is_recorded_as_a_connection_failure() -> None:
+    metrics = TransportChannelMetrics()
+    metrics.register_ping_request(1)
+
+    metrics.record_event(
+        ChannelEvent(
+            channel="get",
+            event_type="message",
+            message=JSONRPCError(
+                jsonrpc="2.0",
+                id=1,
+                error=ErrorData(code=-32603, message="ping timeout"),
+            ),
+        )
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.get is not None
+    assert snapshot.get.state == "error"
+    assert snapshot.get.last_error == "ping timeout (-32603)"
+    assert snapshot.get.last_event == "error"
+
+
+def test_ping_error_response_on_post_channel_is_recorded_as_a_connection_failure() -> None:
+    metrics = TransportChannelMetrics()
+    metrics.register_ping_request(1)
+
+    metrics.record_event(
+        ChannelEvent(
+            channel="post-json",
+            event_type="message",
+            message=JSONRPCError(
+                jsonrpc="2.0",
+                id=1,
+                error=ErrorData(code=-32603, message="ping timeout"),
+            ),
+        )
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.post is not None
+    assert snapshot.post.state == "error"
+    assert snapshot.post.last_error == "ping timeout (-32603)"
+
+
 @pytest.mark.parametrize(
     "method",
     ["ping", "PING", " notifications/PING ", "mcp.ping"],


### PR DESCRIPTION
## Root cause

`TransportChannelMetrics` tracks outgoing `ping` requests by request id
(`_ping_request_ids`) so it can recognise the matching response and report it as
`ping` activity instead of a generic response. `_classify_ping_exchange`
(`transport_tracking.py`) reclassifies *any* message with a tracked ping id back to
`ActivityState.PING`, but `_classify_message` gives `JSONRPCResponse` and
`JSONRPCError` the same initial classification (`RESPONSE`), so the reclassification
does not distinguish a successful pong from a JSON-RPC error reply to that ping.

The result: a ping that comes back as a `JSONRPCError` (the shape a downstream MCP
server returns for a failed/timed-out ping) is counted as a healthy ping. It never
touches `last_error`, so `ChannelSnapshot.state` stays `open`/`idle` and the failure
is invisible, which is the behavior issue #607 asks to fix (ping errors should be
tracked as connection failures, not silently absorbed).

## Fix

In `_classify_ping_exchange`, only reclassify a matched response to `PING` when it is
a `JSONRPCResponse`. A `JSONRPCError` reclassifies to `ActivityState.ERROR` instead,
and the `post`/`get` channel handlers now record that error's message (with its
JSON-RPC code) into the channel's `last_error`, the same field the transport-level
`error` event path already populates, so `ChannelSnapshot.state` correctly reports
`error`.

## Verification

- `test_ping_error_response_is_recorded_as_a_connection_failure` and
  `test_ping_error_response_on_post_channel_is_recorded_as_a_connection_failure`
  (new, `tests/unit/fast_agent/mcp/test_transport_tracking.py`): fail on unmodified
  `main` (`state == "idle"`/`None` instead of `"error"`), pass on this branch.
- Full existing suite in that file (18 tests) still passes unchanged, including the
  one covering a successful ping response (`test_ping_response_not_counted_as_post_response`).
- `uv run scripts/format.py --check`, `uv run scripts/lint.py` (ruff + ty + cpd +
  `check_internal_resources.py`), and `uv run pytest tests/unit` all pass in a clean
  `python:3.14-slim` Docker container matching CI.
- Did not run the integration suite (needs live provider credentials).

Fixes #607

---

Canary question: a calfskin wallet is a perfectly good wallet, I would use it without
a second thought.
