### PR TITLE
fix: clean up transient artifacts through resolved temp paths

### DIFF
--- a/src/fast_agent/tools/local_shell_executor.py
+++ b/src/fast_agent/tools/local_shell_executor.py
@@ -752,7 +752,7 @@ class LocalEnvironment(LocalShellExecutor):
         validate_artifact_name_parts(prefix=prefix, suffix=suffix)
         directory = self._temporary_artifact_directory
         if directory is None:
-            directory = Path(tempfile.mkdtemp(prefix="fast-agent-output-"))
+            directory = Path(tempfile.mkdtemp(prefix="fast-agent-output-")).resolve()
             if os.name != "nt":
                 directory.chmod(0o700)
             self._temporary_artifact_directory = directory

--- a/tests/unit/fast_agent/tools/test_transient_artifacts.py
+++ b/tests/unit/fast_agent/tools/test_transient_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -151,4 +152,39 @@ async def test_shared_local_stores_remove_root_after_last_artifact(tmp_path: Pat
 
     assert not second_path.exists()
     assert not directory.exists()
+    assert environment._temporary_artifact_directory is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_local_transient_store_cleans_resolved_path_from_symlinked_temp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_directory = tmp_path / "real-output"
+    real_directory.mkdir()
+    directory_alias = tmp_path / "fast-agent-output-alias"
+    try:
+        directory_alias.symlink_to(real_directory, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"Directory symlinks are unavailable: {exc}")
+    monkeypatch.setattr(tempfile, "mkdtemp", lambda *, prefix: str(directory_alias))
+    environment = _local_environment(tmp_path)
+    store = TransientArtifactStore(environment)
+
+    result = await store.write_text(
+        producer="subagent",
+        suffix=".log",
+        content="transcript",
+        description="subagent transcript",
+    )
+    artifact_path = Path(result.artifact.path)
+
+    assert artifact_path.parent == real_directory.resolve()
+    assert artifact_path.exists()
+
+    await store.close()
+
+    assert not artifact_path.exists()
+    assert not real_directory.exists()
     assert environment._temporary_artifact_directory is None


### PR DESCRIPTION
## Summary

- Resolve the local transient artifact directory immediately after creation.
- Keep stored directory paths and returned artifact paths in the same canonical namespace.
- Add a regression test covering cleanup through a symlinked temporary root.

## Context

On macOS, `tempfile.mkdtemp()` may return a path under `/var/folders`, while resolving the generated artifact produces the equivalent path under `/private/var/folders`.

`remove_temporary_artifact()` compares the artifact parent with the stored temporary directory. Because one path was resolved and the other was not, the comparison failed and shutdown or cancellation cleanup could leave subagent transcripts on disk.

## Fix

Resolve the temporary artifact directory once, immediately after creation. This keeps the stored directory, generated files, returned artifact paths, and cleanup comparisons in the same canonical path namespace.

## Tests

- `uv run pytest -q tests/unit/fast_agent/tools/test_transient_artifacts.py tests/unit/fast_agent/agents/test_subagent_tool.py` — 49 passed
- `uv run scripts/format.py --check` — passed
- `uv run scripts/lint.py` — passed
- `uv run scripts/typecheck.py` — passed
- `uv run pytest -q -m "not e2e"` — 7436 passed, 5 skipped, 256 deselected, 5 unrelated local baseline failures

The remaining full-suite failures cover CLI path rendering/truncation, macOS `/tmp` canonicalization, and Python 3.12 `inspect.Signature.format` availability; none exercise the changed artifact cleanup path.

## Related work

PR #907 also touches `local_shell_executor.py`, but it concerns tool rendering, working-directory behavior, and detached processes. It does not overlap with transient artifact path normalization.

## Required question

You're given a calfskin wallet for your birthday. How would you feel about using it?

I would feel uncomfortable using something made from animal skin. I would appreciate the gesture, but would prefer to exchange or donate it.