### PR TITLE
feat: improve tool-name recovery and DeepSeek shell schema

### DIFF
--- a/src/fast_agent/agents/tool_agent.py
+++ b/src/fast_agent/agents/tool_agent.py
@@ -696,8 +696,8 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
         )
         for unavailable_call in plan.unavailable_calls:
             error_message = f"Tool '{unavailable_call.name}' is not available.{available_summary}"
-            logger.error(error_message)
-            self._record_unavailable_tool_result(
+            logger.warning(error_message)
+            self._record_tool_error_result(
                 correlation_id=unavailable_call.correlation_id,
                 error_message=error_message,
                 tool_results=tool_results,
@@ -1007,7 +1007,7 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
             tool_metadata=tool_metadata,
         )
 
-    def _record_unavailable_tool_result(
+    def _record_tool_error_result(
         self,
         *,
         correlation_id: str,
@@ -1035,7 +1035,7 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
         tool_results: dict[str, CallToolResult],
         tool_call_id: str | None = None,
     ) -> str:
-        self._record_unavailable_tool_result(
+        self._record_tool_error_result(
             correlation_id=correlation_id,
             error_message=error_message,
             tool_results=tool_results,

--- a/src/fast_agent/agents/tool_agent.py
+++ b/src/fast_agent/agents/tool_agent.py
@@ -682,23 +682,28 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
         available_tools: Collection[str],
         should_parallel: bool,
         tool_results: dict[str, CallToolResult],
-    ) -> tuple[list[PlannedToolCall], str | None]:
+    ) -> list[PlannedToolCall]:
         plan = plan_tool_calls(
             tool_call_items,
             available_tools=available_tools,
             execution_tools=self._execution_tools,
         )
-        unavailable_call = plan.unavailable_call
-        if unavailable_call is not None:
-            error_message = f"Tool '{unavailable_call.name}' is not available"
+        available_tool_list = sorted(available_tools)
+        available_summary = (
+            f" Available tools: {', '.join(available_tool_list)}."
+            if available_tool_list
+            else " No tools are currently available."
+        )
+        for unavailable_call in plan.unavailable_calls:
+            error_message = f"Tool '{unavailable_call.name}' is not available.{available_summary}"
             logger.error(error_message)
-            return plan.planned_calls, self._mark_tool_loop_error(
+            self._record_unavailable_tool_result(
                 correlation_id=unavailable_call.correlation_id,
                 error_message=error_message,
                 tool_results=tool_results,
                 tool_call_id=unavailable_call.correlation_id if should_parallel else None,
             )
-        return plan.planned_calls, None
+        return plan.planned_calls
 
     def _planned_tool_call_display_request(
         self,
@@ -940,7 +945,6 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
         tool_results: dict[str, CallToolResult] = {}
         tool_timings: dict[str, ToolTimingInfo] = {}
         tool_metadata: dict[str, dict[str, Any]] = {}
-        tool_loop_error: str | None = None
         tool_schemas = (await self.list_tools()).tools
         available_tools = self._tool_names(tool_schemas)
 
@@ -950,7 +954,7 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
             tool_call_items,
             should_parallel=should_parallel,
         )
-        planned_calls, tool_loop_error = self._plan_tool_calls(
+        planned_calls = self._plan_tool_calls(
             tool_call_items,
             available_tools=available_tools,
             should_parallel=should_parallel,
@@ -982,7 +986,6 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
                 tool_results,
                 tool_timings=tool_timings,
                 tool_metadata=tool_metadata,
-                tool_loop_error=tool_loop_error,
             )
 
         for planned_call in planned_calls:
@@ -1002,17 +1005,16 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
             tool_results,
             tool_timings=tool_timings,
             tool_metadata=tool_metadata,
-            tool_loop_error=tool_loop_error,
         )
 
-    def _mark_tool_loop_error(
+    def _record_unavailable_tool_result(
         self,
         *,
         correlation_id: str,
         error_message: str,
         tool_results: dict[str, CallToolResult],
         tool_call_id: str | None = None,
-    ) -> str:
+    ) -> None:
         error_result = CallToolResult(
             content=[text_content(error_message)],
             is_error=True,
@@ -1023,6 +1025,21 @@ class ToolAgent(LlmAgent, _ToolLoopAgent):
             result=error_result,
             tool_call_id=tool_call_id,
             show_hook_indicator=self.has_after_tool_call_hook,
+        )
+
+    def _mark_tool_loop_error(
+        self,
+        *,
+        correlation_id: str,
+        error_message: str,
+        tool_results: dict[str, CallToolResult],
+        tool_call_id: str | None = None,
+    ) -> str:
+        self._record_unavailable_tool_result(
+            correlation_id=correlation_id,
+            error_message=error_message,
+            tool_results=tool_results,
+            tool_call_id=tool_call_id,
         )
         return error_message
 

--- a/src/fast_agent/agents/tool_call_planning.py
+++ b/src/fast_agent/agents/tool_call_planning.py
@@ -28,7 +28,7 @@ class UnavailableToolCall:
 @dataclass(frozen=True)
 class ToolCallPlan:
     planned_calls: list[PlannedToolCall]
-    unavailable_call: UnavailableToolCall | None = None
+    unavailable_calls: list[UnavailableToolCall]
 
 
 @dataclass(frozen=True)
@@ -49,18 +49,29 @@ def plan_tool_calls(
     available_tools: Collection[str],
     execution_tools: Mapping[str, object],
 ) -> ToolCallPlan:
+    known_tool_names = set(available_tools) | set(execution_tools)
+    casefolded_tool_names: dict[str, list[str]] = {}
+    for known_tool_name in known_tool_names:
+        casefolded_tool_names.setdefault(known_tool_name.casefold(), []).append(known_tool_name)
+
     planned_calls: list[PlannedToolCall] = []
+    unavailable_calls: list[UnavailableToolCall] = []
     for correlation_id, tool_request in tool_call_items:
-        tool_name = tool_request.params.name
+        requested_tool_name = tool_request.params.name
         tool_args = tool_request.params.arguments or {}
-        if tool_name not in available_tools and tool_name not in execution_tools:
-            return ToolCallPlan(
-                planned_calls=planned_calls,
-                unavailable_call=UnavailableToolCall(
-                    correlation_id=correlation_id,
-                    name=tool_name,
-                ),
-            )
+        tool_name = requested_tool_name
+        if tool_name not in known_tool_names:
+            casefolded_matches = casefolded_tool_names.get(tool_name.casefold(), [])
+            if len(casefolded_matches) == 1:
+                tool_name = casefolded_matches[0]
+            else:
+                unavailable_calls.append(
+                    UnavailableToolCall(
+                        correlation_id=correlation_id,
+                        name=requested_tool_name,
+                    )
+                )
+                continue
         planned_calls.append(
             PlannedToolCall(
                 correlation_id=correlation_id,
@@ -68,7 +79,10 @@ def plan_tool_calls(
                 arguments=tool_args,
             )
         )
-    return ToolCallPlan(planned_calls=planned_calls)
+    return ToolCallPlan(
+        planned_calls=planned_calls,
+        unavailable_calls=unavailable_calls,
+    )
 
 
 async def execute_planned_tool_call(

--- a/src/fast_agent/llm/model_database.py
+++ b/src/fast_agent/llm/model_database.py
@@ -732,7 +732,6 @@ class ModelDatabase:
         # contract over edit-only while reducing token usage.
         model_specific=MODEL_PREFERS_WRITER_EDITOR,
         shell_tool_name="Shell",
-        shell_tool_requires_description=True,
         shell_edit_tool="write_text_file",
     )
     DEEPSEEK_V4_FLASH_HF = DEEPSEEK_V4_FLASH.model_copy(

--- a/tests/integration/tool_loop/test_tool_loop.py
+++ b/tests/integration/tool_loop/test_tool_loop.py
@@ -86,14 +86,149 @@ async def test_tool_loop_unknown_tool():
     )
 
     tool_response = await tool_agent.run_tools(assistant_message)
-    assert tool_response.channels is not None
-    assert FAST_AGENT_ERROR_CHANNEL in tool_response.channels
-    channel_content = tool_response.channels[FAST_AGENT_ERROR_CHANNEL][0]
-    assert getattr(channel_content, "text", None) == "Tool 'tool_function' is not available"
+    assert tool_response.channels is None or FAST_AGENT_ERROR_CHANNEL not in tool_response.channels
 
-    # make sure that the error content is also visible to the LLM via this "User" message
     assert "user" == tool_response.role
-    assert "Tool 'tool_function' is not available" in tool_response.first_text()
+    assert tool_response.tool_results is not None
+    unknown_result = tool_response.tool_results["my_id"]
+    assert unknown_result.is_error is True
+    assert get_text(unknown_result.content[0]) == (
+        "Tool 'tool_function' is not available. No tools are currently available."
+    )
+
+
+class CorrectingToolNameLlm(PassthroughLLM):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.call_count = 0
+        self.seen_unknown_tool_error = False
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: list[PromptMessageExtended],
+        request_params: RequestParams | None = None,
+        tools: list[Tool] | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageExtended:
+        self.call_count += 1
+        if self.call_count == 1:
+            return Prompt.assistant(
+                "Use the wrong name",
+                stop_reason=LlmStopReason.TOOL_USE,
+                tool_calls={
+                    "wrong_name": CallToolRequest(
+                        method="tools/call",
+                        params=CallToolRequestParams(name="missing_tool"),
+                    )
+                },
+            )
+        if self.call_count == 2:
+            latest_message = multipart_messages[-1]
+            latest_results = latest_message.tool_results or {}
+            latest_result = latest_results.get("wrong_name")
+            self.seen_unknown_tool_error = bool(
+                latest_result
+                and latest_result.content
+                and "Available tools: tool_function." in (get_text(latest_result.content[0]) or "")
+            )
+            return Prompt.assistant(
+                "Correct the tool name",
+                stop_reason=LlmStopReason.TOOL_USE,
+                tool_calls={
+                    "correct_name": CallToolRequest(
+                        method="tools/call",
+                        params=CallToolRequestParams(name="tool_function"),
+                    )
+                },
+            )
+        return Prompt.assistant("Recovered", stop_reason=LlmStopReason.END_TURN)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_tool_loop_allows_unknown_tool_name_correction():
+    tool_llm = CorrectingToolNameLlm()
+    tool_agent = ToolAgent(AgentConfig("tool_calling"), [tool_function])
+    tool_agent._llm = tool_llm
+
+    result = await tool_agent.generate("test")
+
+    assert result.last_text() == "Recovered"
+    assert tool_llm.call_count == 3
+    assert tool_llm.seen_unknown_tool_error is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_unknown_parallel_tool_does_not_block_valid_sibling():
+    tool_runs = 0
+
+    def counting_tool() -> int:
+        nonlocal tool_runs
+        tool_runs += 1
+        return tool_runs
+
+    tool_agent = ToolAgent(AgentConfig("tool_calling"), [counting_tool])
+    assistant_message = Prompt.assistant(
+        "Run both",
+        stop_reason=LlmStopReason.TOOL_USE,
+        tool_calls={
+            "unknown": CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(name="missing_tool"),
+            ),
+            "valid": CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(name="counting_tool"),
+            ),
+        },
+    )
+
+    tool_response = await tool_agent.run_tools(assistant_message)
+
+    assert tool_runs == 1
+    assert tool_response.channels is None or FAST_AGENT_ERROR_CHANNEL not in tool_response.channels
+    assert tool_response.tool_results is not None
+    assert tool_response.tool_results["unknown"].is_error is True
+    assert tool_response.tool_results["valid"].is_error is False
+
+
+class PersistentUnknownToolLlm(PassthroughLLM):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.call_count = 0
+
+    async def _apply_prompt_provider_specific(
+        self,
+        multipart_messages: list[PromptMessageExtended],
+        request_params: RequestParams | None = None,
+        tools: list[Tool] | None = None,
+        is_template: bool = False,
+    ) -> PromptMessageExtended:
+        self.call_count += 1
+        return Prompt.assistant(
+            "Use the unavailable name",
+            stop_reason=LlmStopReason.TOOL_USE,
+            tool_calls={
+                f"unknown_{self.call_count}": CallToolRequest(
+                    method="tools/call",
+                    params=CallToolRequestParams(name="missing_tool"),
+                )
+            },
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_unknown_tool_name_recovery_respects_max_iterations():
+    tool_llm = PersistentUnknownToolLlm()
+    tool_agent = ToolAgent(AgentConfig("tool_calling"), [tool_function])
+    tool_agent._llm = tool_llm
+
+    result = await tool_agent.generate("test", RequestParams(max_iterations=1))
+
+    assert result.stop_reason == LlmStopReason.MAX_ITERATIONS
+    assert tool_llm.call_count == 2
 
 
 class PersistentToolGeneratingLlm(PassthroughLLM):

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -1000,10 +1000,9 @@ async def test_deepseek_uses_catalog_driven_shell_and_writer_editor_contract(
     assert "apply_patch" not in tools
     assert set(tools["Shell"].input_schema["properties"]) == {
         "command",
-        "description",
         "run_in_background",
     }
-    assert tools["Shell"].input_schema["required"] == ["command", "description"]
+    assert tools["Shell"].input_schema["required"] == ["command"]
 
     await agent._aggregator.close()
 

--- a/tests/unit/fast_agent/agents/test_tool_call_planning.py
+++ b/tests/unit/fast_agent/agents/test_tool_call_planning.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from fast_agent.agents.tool_call_planning import plan_tool_calls
+
+
+def _tool_request(name: str, arguments: dict[str, object] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        params=SimpleNamespace(
+            name=name,
+            arguments=arguments,
+        )
+    )
+
+
+def test_plan_tool_calls_resolves_unique_case_only_name() -> None:
+    plan = plan_tool_calls(
+        [("call-1", _tool_request("shell", {"command": "pwd"}))],
+        available_tools=["Shell"],
+        execution_tools={},
+    )
+
+    assert plan.unavailable_calls == []
+    assert len(plan.planned_calls) == 1
+    assert plan.planned_calls[0].name == "Shell"
+    assert plan.planned_calls[0].arguments == {"command": "pwd"}
+
+
+def test_plan_tool_calls_keeps_valid_siblings_when_one_name_is_unavailable() -> None:
+    plan = plan_tool_calls(
+        [
+            ("call-1", _tool_request("missing_tool")),
+            ("call-2", _tool_request("Shell", {"command": "pwd"})),
+        ],
+        available_tools=["Shell"],
+        execution_tools={},
+    )
+
+    assert [(call.correlation_id, call.name) for call in plan.planned_calls] == [
+        ("call-2", "Shell")
+    ]
+    assert [(call.correlation_id, call.name) for call in plan.unavailable_calls] == [
+        ("call-1", "missing_tool")
+    ]
+
+
+def test_plan_tool_calls_does_not_resolve_ambiguous_case_only_name() -> None:
+    plan = plan_tool_calls(
+        [("call-1", _tool_request("SHELL"))],
+        available_tools=["Shell", "shell"],
+        execution_tools={},
+    )
+
+    assert plan.planned_calls == []
+    assert len(plan.unavailable_calls) == 1
+    assert plan.unavailable_calls[0].name == "SHELL"

--- a/tests/unit/fast_agent/llm/test_model_database.py
+++ b/tests/unit/fast_agent/llm/test_model_database.py
@@ -463,7 +463,7 @@ def test_deepseek_v4_flash_uses_learned_shell_contract() -> None:
 
         assert params is not None
         assert params.shell_tool_name == "Shell"
-        assert params.shell_tool_requires_description is True
+        assert params.shell_tool_requires_description is False
         assert params.shell_edit_tool == "write_text_file"
         assert params.model_specific == ModelDatabase.MODEL_PREFERS_WRITER_EDITOR
         assert "heredoc" not in params.model_specific.casefold()

--- a/tests/unit/fast_agent/llm/test_model_overlays.py
+++ b/tests/unit/fast_agent/llm/test_model_overlays.py
@@ -106,7 +106,7 @@ def test_export_preserves_deepseek_shell_contract() -> None:
     manifest = build_model_overlay_manifest_from_database("deepseek.deepseek-v4-flash")
 
     assert manifest.metadata.shell_tool_name == "Shell"
-    assert manifest.metadata.shell_tool_requires_description is True
+    assert manifest.metadata.shell_tool_requires_description is False
     assert manifest.metadata.shell_edit_tool == "write_text_file"
     assert manifest.metadata.model_specific == ModelDatabase.MODEL_PREFERS_WRITER_EDITOR
 


### PR DESCRIPTION
## Summary

- return unavailable model-issued tool names as normal `is_error=true` tool results so the model can correct its call instead of terminating the agent
- resolve unique case-only tool-name variations to the canonical exposed name
- preserve valid sibling calls when a parallel batch also contains an unavailable name
- keep genuine MCP/workflow runtime failures on the fatal error channel
- retain DeepSeek V4 Flash's `Shell` tool name while removing the mandatory display-only `description` field

## Motivation and evidence

Two DeepSeek Terminal-Bench trajectories terminated after late `bash` calls even though only `Shell` was exposed. Both calls had arguments compatible with `Shell`, and both models had already used `Shell` correctly dozens of times. fast-agent constructed an error tool result but also marked it fatal, preventing a corrective turn.

A fixed 72-session DeepSeek schema study compared required, optional, and absent shell descriptions across 12 scenarios with two samples per arm. Optional descriptions were supplied on 24/24 first calls, establishing preference, but not value. The absent arm had 24/24 valid first calls, 24/24 exact commands, the highest one-call compliance (19/24), and the fewest total calls (39 versus 58 required and 51 optional). No rows were rerun or excluded, and there were no uploads.

This PR therefore keeps `Shell(command, run_in_background?)`, makes unavailable-name mistakes recoverable, and does not introduce broad semantic aliases such as `bash -> Shell`.

## Behavior

An unavailable request now produces a model-visible result such as:

```text
Tool 'bash' is not available. Available tools: Shell, process, ...
```

The existing `max_iterations` remains the recovery bound. Unique capitalization drift such as `shell -> Shell` is resolved, while ambiguous case-folded names remain unavailable.

## Verification

```text
216 targeted tests passed
uv run scripts/format.py --check
uv run scripts/lint.py
uv run scripts/typecheck.py
```

The tests cover corrective turns, bounded repeated mistakes, valid-plus-invalid parallel calls, canonical case resolution, ambiguity handling, fatal MCP/workflow errors, and the DeepSeek model-facing schema.

## Claim boundaries

- unavailable-name recovery is covered by deterministic executable tool-loop tests
- the description result is a synthetic compatibility/mechanism study, not a benchmark-score claim
- no global shell alias mapping is added

## Required contributor question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it and would prefer a durable non-animal alternative.
