### PR TITLE
feat: expand skills and harness workflows

### DIFF
--- a/docs/docs/guides/core-concepts.md
+++ b/docs/docs/guides/core-concepts.md
@@ -434,18 +434,19 @@ Hugging Face and Anthropic skills, and teams can add their own.
 Common workflow:
 
 ```text
-/skills            # list available skills
-/skills add        # browse and install from the active registry
+/skills            # list locally installed skills
+/skills available  # browse the active registry
+/skills search web # search the active registry
+/skills add 1      # install by number or name
 /skills remove 1   # remove by number or name
 /skills registry   # view or switch registries
 ```
 
-`/skills add` presents the available skills as a numbered list, so installing
-one is usually just:
+Browse another registry for one invocation without changing the active source:
 
 ```text
-/skills add
-/skills add 1
+/skills available --registry hf
+/skills add huggingface-datasets --registry hf
 ```
 
 If an agent or sub-agent should **not** see the default skills, make that

--- a/docs/docs/guides/skills.md
+++ b/docs/docs/guides/skills.md
@@ -170,24 +170,46 @@ Available registries:
 - [1] https://github.com/huggingface/skills
 - [2] https://github.com/anthropics/skills
 
-Usage: `/skills registry [number|URL]`
+Usage: `/skills registry [number|URL|path|mcp-server]`
 ```
 
-In the TUI, switch registries by number or provide a custom URL:
+In the TUI, switch registries by number, provide a custom URL/path, or select an
+attached MCP server:
 
 === "TUI"
 
     ```text
     /skills registry 2
     /skills registry https://github.com/my-org/my-skills
+    /skills registry hf
     ```
 
-For CLI commands, pass `--registry` to browse or install from a specific registry for that invocation:
+Pass `--registry` to browse, search, or install from a specific registry for
+that invocation without changing the active registry. Slash commands also
+accept attached MCP server names:
 
 ```bash
 fast-agent skills available --registry https://github.com/my-org/my-skills
 fast-agent skills add skill-name --registry https://github.com/my-org/my-skills
 ```
+
+```text
+/skills available --registry hf
+/skills search datasets --registry hf
+/skills add huggingface-datasets --registry hf
+```
+
+Catalog listings support bounded and machine-readable output:
+
+```text
+/skills available --registry hf --compact
+/skills available --registry hf --limit 20 --page 2
+/skills available --registry hf --limit 20 --json
+```
+
+Model-facing listings default to compact output so a complete registry does not
+overflow the tool result. Interactive listings remain detailed unless you pass
+`--compact`, paging options, or `--json`.
 
 ## Configuration
 

--- a/docs/docs/guides/tui.md
+++ b/docs/docs/guides/tui.md
@@ -176,18 +176,25 @@ You can paste images directly with ++alt+v++. In terminals that reserve that cho
 
 Local image attachments, including pasted clipboard images, are displayed inline after your message when terminal image rendering is enabled. Remote image URLs remain as links.
 
-## Model Feature Toggles
+## Agent and Model Feature Toggles
 
-Use the function keys in the prompt to cycle model-specific runtime features:
+Use the function keys in the prompt to cycle agent and model runtime features:
 
-| Key    | Action                     |
-| ------ | -------------------------- |
-| ++f6++ | Cycle reasoning effort     |
-| ++f7++ | Cycle text verbosity       |
-| ++f8++ | Toggle or cycle web search |
-| ++f9++ | Toggle or cycle web fetch  |
+| Key    | Action                                               |
+| ------ | ---------------------------------------------------- |
+| ++f5++ | Cycle Standard → Delegate → Orchestrate → Harness-only |
+| ++f6++ | Cycle reasoning effort                               |
+| ++f7++ | Cycle text verbosity                                 |
+| ++f8++ | Toggle or cycle web search                           |
+| ++f9++ | Toggle or cycle web fetch                            |
 
-These toggles apply when the selected model/provider supports the feature.
+Delegate enables the built-in subagent tool. Orchestrate also enables the
+parent agent's harness tools for allow-listed commands and resources.
+Harness-only keeps those harness tools enabled without subagent delegation. The
+toolbar shows these capabilities as `↳⌘`, with active capabilities highlighted.
+Agent modes apply only to compatible agents and cannot override an explicit
+subagent disable. Model toggles apply when the selected model/provider supports
+the feature.
 
 ## Prompt Shortcuts
 

--- a/docs/docs/mcp/skills-over-mcp.md
+++ b/docs/docs/mcp/skills-over-mcp.md
@@ -68,14 +68,16 @@ This example uses the hosted Hugging Face MCP Server:
 /mcp connect --name hf https://huggingface.co/mcp
 /mcp
 /skills registry
-/skills registry hf
-/skills available
-/skills add <number|name>
+/skills available --registry hf
+/skills search datasets --registry hf
+/skills add <number|name> --registry hf
 ```
 
 `/mcp` shows when a server advertises the
-`io.modelcontextprotocol/skills` extension and points you to `/skills registry`
-to select the MCP server as the current install source.
+`io.modelcontextprotocol/skills` extension and points you to the one-shot
+`/skills available --registry <server>` browse command. Use
+`/skills registry <server>` when you want to make that server the active source
+for subsequent skills commands.
 
 Listings show `integrity: SHA-256 manifest; checked on install` when the server
 supplies a complete resource manifest. A listing has not yet checked the served

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.10.3"
+version = "0.10.4"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/acp/slash/handlers/skills.py
+++ b/src/fast_agent/acp/slash/handlers/skills.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
 
 
 async def handle_skills_available(
-    handler: "SlashCommandHandler",
+    _handler: "SlashCommandHandler",
     *,
     query: str | None = None,
     registry: str | None = None,
@@ -82,12 +82,12 @@ async def handle_skills_available(
     except Exception as exc:
         return (
             f"# {heading}\n\n"
-            f"Failed to load marketplace: {exc}\n\n"
+            f"Failed to load skills: {exc}\n\n"
             f"Repository: {markdown_code_span(display_url)}"
         )
 
     if not marketplace:
-        return f"# {heading}\n\nNo skills found in the marketplace."
+        return f"# {heading}\n\nNo skills found in the registry."
 
     selected_marketplace = list(marketplace)
     if normalized_query is not None:
@@ -156,20 +156,29 @@ async def _handle_skills_list_action(handler: "SlashCommandHandler", remainder: 
 
 
 async def _handle_skills_available_action(handler: "SlashCommandHandler", remainder: str) -> str:
-    parsed = parse_skills_slash_options(remainder)
-    if parsed.error:
-        return f"# skills available\n\n{parsed.error}"
-    return await handle_skills_available(handler, registry=parsed.registry)
+    return await _handle_skills_catalog_action(handler, action="available", argument=remainder)
 
 
 async def _handle_skills_search_action(handler: "SlashCommandHandler", remainder: str) -> str:
-    parsed = parse_skills_slash_options(remainder)
-    if parsed.error:
-        return f"# skills search\n\n{parsed.error}"
-    query = strip_to_none(parsed.argument)
-    if query is None:
-        return "# skills search\n\nUsage: /skills search <query>"
-    return await handle_skills_available(handler, query=query, registry=parsed.registry)
+    return await _handle_skills_catalog_action(handler, action="search", argument=remainder)
+
+
+async def _handle_skills_catalog_action(
+    handler: "SlashCommandHandler",
+    *,
+    action: str,
+    argument: str,
+) -> str:
+    ctx = handler._build_command_context()
+    io = cast("ACPCommandIO", ctx.io)
+    outcome = await skills_handlers.handle_skills_command(
+        ctx,
+        agent_name=handler.current_agent_name,
+        action=action,
+        argument=argument,
+        interactive=True,
+    )
+    return handler._format_outcome_as_markdown(outcome, f"skills {action}", io=io)
 
 
 async def _handle_unknown_skills_action(_handler: "SlashCommandHandler", remainder: str) -> str:
@@ -261,7 +270,16 @@ async def handle_skills_add(handler: "SlashCommandHandler", argument: str) -> st
 
     argument_value = strip_to_none(parsed.argument)
     if not argument_value:
-        return await _render_skills_add_marketplace(registry=parsed.registry)
+        browse_command = skills_handlers.skills_available_command(parsed.registry)
+        return "\n".join(
+            (
+                "# skills add",
+                "",
+                "A skill selector is required.",
+                "",
+                f"Browse with `{browse_command}` or search with `/skills search <query>`.",
+            )
+        )
 
     tool_call_id = build_tool_call_id()
     await send_skills_update(
@@ -316,31 +334,6 @@ async def handle_skills_add(handler: "SlashCommandHandler", argument: str) -> st
         )
 
     return handler._format_outcome_as_markdown(outcome, "skills add", io=io)
-
-
-async def _render_skills_add_marketplace(*, registry: str | None = None) -> str:
-    marketplace_url = registry or get_marketplace_url(get_settings())
-    display_url = format_marketplace_display_url(marketplace_url)
-    try:
-        marketplace = await fetch_marketplace_skills(marketplace_url)
-    except Exception as exc:
-        return (
-            "# skills add\n\n"
-            f"Failed to load marketplace: {exc}\n\n"
-            f"Repository: {markdown_code_span(display_url)}"
-        )
-
-    repository = display_url
-    if marketplace:
-        repo_url = marketplace[0].repo_url
-        repo_ref = marketplace[0].repo_ref
-        repository = f"{repo_url}@{repo_ref}" if repo_ref else repo_url
-
-    return render_marketplace_skills(
-        marketplace,
-        heading="skills add",
-        repository=repository,
-    )
 
 
 async def handle_skills_remove(handler: "SlashCommandHandler", argument: str) -> str:

--- a/src/fast_agent/acp/slash_commands.py
+++ b/src/fast_agent/acp/slash_commands.py
@@ -691,6 +691,9 @@ class SlashCommandHandler:
         *,
         io: ACPCommandIO | None = None,
     ) -> str:
+        has_error = any(message.channel == "error" for message in outcome.messages)
+        if outcome.direct_response is not None and not has_error:
+            return outcome.direct_response
         extra_messages = io.messages if io else None
         markdown = render_command_outcome_markdown(
             outcome,

--- a/src/fast_agent/commands/command_catalog.py
+++ b/src/fast_agent/commands/command_catalog.py
@@ -84,23 +84,65 @@ def _model_catalog_action(command: str, *, example_provider: str) -> CommandActi
 COMMAND_SPECS: Final[tuple[CommandSpec, ...]] = (
     CommandSpec(
         command="skills",
-        summary="Manage local skills",
+        summary="Manage installed skills and skill registries",
         usage="/skills [list|available|search|add|remove|update|registry|help] [args]",
         actions=(
             CommandActionSpec(action="list", help="List local skills", usage="/skills list"),
             CommandActionSpec(
                 action="available",
                 aliases=("marketplace", "browse"),
-                help="Browse marketplace skills",
-                usage="/skills available",
-                examples=("/skills available",),
+                help="Browse skills from the active or selected registry",
+                usage=(
+                    "/skills available [--registry source] [--page N] [--limit N] "
+                    "[--compact|--full|--json]"
+                ),
+                examples=(
+                    "/skills available",
+                    "/skills available --registry hf --compact",
+                ),
+                options=(
+                    CommandOptionSpec(
+                        name="--registry",
+                        aliases=("-r",),
+                        value_name="url|path|mcp-server",
+                        summary="Browse this registry without changing the active registry.",
+                    ),
+                    CommandOptionSpec(
+                        name="--page",
+                        value_name="N",
+                        summary="Show a 1-based result page.",
+                    ),
+                    CommandOptionSpec(
+                        name="--limit",
+                        value_name="N",
+                        summary="Set page size, up to 100.",
+                    ),
+                    CommandOptionSpec(
+                        name="--compact",
+                        summary="Use bounded one-line descriptions.",
+                    ),
+                    CommandOptionSpec(
+                        name="--full",
+                        summary="Use the detailed interactive listing.",
+                    ),
+                    CommandOptionSpec(
+                        name="--json",
+                        summary="Return a machine-readable catalog page.",
+                    ),
+                ),
             ),
             CommandActionSpec(
                 action="search",
                 aliases=("find",),
-                help="Search marketplace skills",
-                usage="/skills search <query>",
-                examples=("/skills search docker",),
+                help="Search skills in the active or selected registry",
+                usage=(
+                    "/skills search <query> [--registry source] [--page N] [--limit N] "
+                    "[--compact|--full|--json]"
+                ),
+                examples=(
+                    "/skills search docker",
+                    "/skills search datasets --registry hf",
+                ),
                 arguments=(
                     CommandArgumentSpec(
                         name="query",
@@ -109,12 +151,45 @@ COMMAND_SPECS: Final[tuple[CommandSpec, ...]] = (
                         required=True,
                     ),
                 ),
+                options=(
+                    CommandOptionSpec(
+                        name="--registry",
+                        aliases=("-r",),
+                        value_name="url|path|mcp-server",
+                        summary="Search this registry without changing the active registry.",
+                    ),
+                    CommandOptionSpec(
+                        name="--page",
+                        value_name="N",
+                        summary="Show a 1-based result page.",
+                    ),
+                    CommandOptionSpec(
+                        name="--limit",
+                        value_name="N",
+                        summary="Set page size, up to 100.",
+                    ),
+                    CommandOptionSpec(
+                        name="--compact",
+                        summary="Use bounded one-line descriptions.",
+                    ),
+                    CommandOptionSpec(
+                        name="--full",
+                        summary="Use the detailed interactive listing.",
+                    ),
+                    CommandOptionSpec(
+                        name="--json",
+                        summary="Return a machine-readable catalog page.",
+                    ),
+                ),
             ),
             CommandActionSpec(
                 action="add",
                 aliases=("install",),
                 help="Install a skill",
-                usage=f"/skills add [<{SKILLS_ADD_SELECTOR}>] [--registry url] [--skills-dir path]",
+                usage=(
+                    f"/skills add <{SKILLS_ADD_SELECTOR}> "
+                    "[--registry url|path|mcp-server] [--skills-dir path]"
+                ),
                 examples=(
                     f"/skills add <{SKILLS_ADD_SELECTOR}>",
                     "/skills add https://github.com/org/repo/blob/main/skills/example/SKILL.md",
@@ -125,14 +200,15 @@ COMMAND_SPECS: Final[tuple[CommandSpec, ...]] = (
                         name="selector",
                         value_name=SKILLS_ADD_SELECTOR,
                         summary="Skill name, marketplace index, GitHub SKILL.md URL, or local path.",
+                        required=True,
                     ),
                 ),
                 options=(
                     CommandOptionSpec(
                         name="--registry",
                         aliases=("-r",),
-                        value_name="url|path",
-                        summary="Override the skills registry for this invocation.",
+                        value_name="url|path|mcp-server",
+                        summary="Install from this registry without changing the active registry.",
                     ),
                     CommandOptionSpec(
                         name="--skills-dir",
@@ -200,8 +276,8 @@ COMMAND_SPECS: Final[tuple[CommandSpec, ...]] = (
                 arguments=(
                     CommandArgumentSpec(
                         name="target",
-                        value_name="number|url|path",
-                        summary="Registry selection, URL, or filesystem path.",
+                        value_name="number|url|path|mcp-server",
+                        summary="Registry selection, URL, filesystem path, or attached MCP server.",
                     ),
                 ),
             ),

--- a/src/fast_agent/commands/command_discovery.py
+++ b/src/fast_agent/commands/command_discovery.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeVar
 
 from fast_agent.commands.command_catalog import (
     COMMAND_SPECS,
+    SKILLS_ADD_SELECTOR,
     CommandActionSpec,
     get_command_action_spec,
     get_command_spec,
@@ -264,6 +265,123 @@ def _simple_command_entry(
     }
 
 
+def _mcp_action_payloads() -> list[CommandIndexAction]:
+    server_name_argument: ActionArgumentPayload = {
+        "name": "server_name",
+        "summary": "Configured or attached MCP server name.",
+        "value_name": "server-name",
+        "required": True,
+    }
+    return [
+        {
+            "name": "list",
+            "summary": MCP_TOP_LEVEL_ACTION_DESCRIPTIONS["list"],
+            "usage": "/mcp list",
+            "examples": ["/mcp list"],
+            "notes": ["Use this to discover configured server names before attaching."],
+        },
+        {
+            "name": "status",
+            "summary": MCP_TOP_LEVEL_ACTION_DESCRIPTIONS["status"],
+            "usage": "/mcp status",
+            "examples": ["/mcp status"],
+        },
+        {
+            "name": "attach",
+            "summary": MCP_TOP_LEVEL_ACTION_DESCRIPTIONS["attach"],
+            "usage": "/mcp attach <server-name>",
+            "examples": ["/mcp attach docs"],
+            "arguments": [server_name_argument],
+            "notes": ["Run /mcp list to discover configured server names."],
+        },
+        {
+            "name": "connect",
+            "summary": MCP_TOP_LEVEL_ACTION_DESCRIPTIONS["connect"],
+            "usage": (
+                "/mcp connect <target> [--name server] [--auth token] [--timeout seconds] "
+                "[--protocol auto|modern|legacy] [--oauth|--no-oauth] "
+                "[--reconnect|--no-reconnect]"
+            ),
+            "examples": [
+                "/mcp connect https://example.com/mcp",
+                "/mcp connect --name demo npx demo-server",
+            ],
+            "arguments": [
+                {
+                    "name": "target",
+                    "summary": "MCP URL, executable, npx package, or uvx package.",
+                    "value_name": "target",
+                    "required": True,
+                }
+            ],
+            "options": [
+                {
+                    "name": "--name",
+                    "summary": "Set the attached server name.",
+                    "value_name": "server",
+                    "aliases": ["-n"],
+                },
+                {
+                    "name": "--auth",
+                    "summary": "Set a bearer token for a URL server.",
+                    "value_name": "token",
+                    "aliases": [],
+                },
+                {
+                    "name": "--timeout",
+                    "summary": "Set the startup timeout.",
+                    "value_name": "seconds",
+                    "aliases": [],
+                },
+                {
+                    "name": "--protocol",
+                    "summary": "Select MCP protocol negotiation mode.",
+                    "value_name": "auto|modern|legacy",
+                    "aliases": [],
+                },
+                {
+                    "name": "--oauth",
+                    "summary": "Enable the interactive OAuth flow.",
+                    "value_name": None,
+                    "aliases": [],
+                },
+                {
+                    "name": "--no-oauth",
+                    "summary": "Disable the interactive OAuth flow.",
+                    "value_name": None,
+                    "aliases": [],
+                },
+                {
+                    "name": "--reconnect",
+                    "summary": "Force reconnect and refresh capabilities.",
+                    "value_name": None,
+                    "aliases": [],
+                },
+                {
+                    "name": "--no-reconnect",
+                    "summary": "Disable reconnect-on-disconnect.",
+                    "value_name": None,
+                    "aliases": [],
+                },
+            ],
+        },
+        {
+            "name": "disconnect",
+            "summary": MCP_TOP_LEVEL_ACTION_DESCRIPTIONS["disconnect"],
+            "usage": "/mcp disconnect <server-name>",
+            "examples": ["/mcp disconnect docs"],
+            "arguments": [server_name_argument],
+        },
+        {
+            "name": "reconnect",
+            "summary": MCP_TOP_LEVEL_ACTION_DESCRIPTIONS["reconnect"],
+            "usage": "/mcp reconnect <server-name>",
+            "examples": ["/mcp reconnect docs"],
+            "arguments": [server_name_argument],
+        },
+    ]
+
+
 def _discovery_top_level_catalog() -> tuple[CommandIndexEntry, ...]:
     families: list[CommandIndexEntry] = [
         {
@@ -360,14 +478,8 @@ def _discovery_top_level_catalog() -> tuple[CommandIndexEntry, ...]:
         {
             "name": "mcp",
             "summary": "Runtime MCP control",
-            "usage": (
-                "/mcp [list|status|attach|connect|disconnect|reconnect] [args]; "
-                "connect supports --protocol auto|modern|legacy"
-            ),
-            "actions": [
-                {"name": name, "summary": summary}
-                for name, summary in MCP_TOP_LEVEL_ACTION_DESCRIPTIONS.items()
-            ],
+            "usage": "/mcp [list|status|attach|connect|disconnect|reconnect] [args]",
+            "actions": _mcp_action_payloads(),
             "examples": [
                 "/mcp list",
                 "/mcp status",
@@ -394,6 +506,12 @@ def _discovery_top_level_catalog() -> tuple[CommandIndexEntry, ...]:
             summary="List prompt templates",
             usage="/prompts",
             examples=["/prompts"],
+        ),
+        _simple_command_entry(
+            "status",
+            summary="Show runtime status",
+            usage="/status",
+            examples=["/status"],
         ),
         {
             "name": "prompt",
@@ -460,38 +578,118 @@ def _structured_action_payloads(actions: list[CommandIndexAction]) -> list[Actio
     ]
 
 
-def _command_index_payload(entry: CommandIndexEntry) -> CommandIndexPayload:
-    return {
+def _command_index_payload(
+    entry: CommandIndexEntry,
+    *,
+    model_facing: bool = False,
+) -> CommandIndexPayload:
+    detail: CommandDetailEntry = {
         "name": entry["name"],
         "summary": entry["summary"],
         "usage": entry["usage"],
         "actions": _structured_action_payloads(entry["actions"]),
         "examples": entry["examples"],
     }
+    if model_facing:
+        detail = _model_facing_command_detail(detail)
+    return {
+        "name": detail["name"],
+        "summary": detail["summary"],
+        "usage": detail["usage"],
+        "actions": detail["actions"],
+        "examples": detail["examples"],
+    }
 
 
-def _build_command_detail(name: str) -> CommandDetailEntry | None:
+def _model_facing_command_detail(detail: CommandDetailEntry) -> CommandDetailEntry:
+    actions: list[ActionPayload] = []
+    for action in detail["actions"]:
+        transformed = action.copy()
+        if detail["name"] == "mcp" and action["name"] == "connect":
+            transformed["usage"] = (
+                "/mcp connect <target> [--name server] [--auth token] [--timeout seconds] "
+                "[--protocol auto|modern|legacy] [--no-oauth] "
+                "[--reconnect|--no-reconnect]"
+            )
+            transformed["options"] = [
+                option for option in action.get("options", []) if option["name"] != "--oauth"
+            ]
+            transformed["notes"] = [
+                *action.get("notes", []),
+                (
+                    "Interactive OAuth and environment-variable auth references are unavailable "
+                    "through model-facing commands."
+                ),
+                "Ad-hoc stdio targets require shell access.",
+                "Prefer configured credentials over passing secrets through model context.",
+            ]
+        elif detail["name"] == "skills":
+            if action["name"] == "registry":
+                transformed["notes"] = [
+                    *action.get("notes", []),
+                    (
+                        "Registry selection is scoped to the current harness tool instance and "
+                        "does not write configuration."
+                    ),
+                ]
+            elif action["name"] in {"available", "search"}:
+                usage = transformed.get("usage")
+                if usage is not None:
+                    transformed["usage"] = usage.replace(
+                        "[--compact|--full|--json]",
+                        "[--compact|--json]",
+                    )
+                transformed["options"] = [
+                    option for option in action.get("options", []) if option["name"] != "--full"
+                ]
+                transformed["notes"] = [
+                    *action.get("notes", []),
+                    "Model-facing listings default to compact output.",
+                ]
+            elif action["name"] == "add":
+                transformed["usage"] = (
+                    f"/skills add <{SKILLS_ADD_SELECTOR}> "
+                    "[--registry url|path|mcp-server] [--skills-dir path]"
+                )
+                transformed["arguments"] = [
+                    {**argument, "required": True} for argument in action.get("arguments", [])
+                ]
+                transformed["notes"] = [
+                    *action.get("notes", []),
+                    "A selector is required for model-facing installation.",
+                ]
+        actions.append(transformed)
+    return {**detail, "actions": actions}
+
+
+def _build_command_detail(
+    name: str,
+    *,
+    model_facing: bool = False,
+) -> CommandDetailEntry | None:
     normalized = normalize_action_token(name)
     spec = get_command_spec(normalized)
     if spec is not None:
-        return {
+        detail: CommandDetailEntry = {
             "name": spec.command,
             "summary": spec.summary,
             "usage": spec.usage,
             "actions": [_action_payload_from_catalog(action) for action in spec.actions],
             "examples": list(spec.examples),
         }
+        return _model_facing_command_detail(detail) if model_facing else detail
 
     for entry in _discovery_top_level_catalog():
         if entry["name"] != normalized:
             continue
-        return {
+        entry_detail: CommandDetailEntry = {
             "name": entry["name"],
             "summary": entry["summary"],
             "usage": entry["usage"],
             "actions": _structured_action_payloads(entry["actions"]),
             "examples": entry["examples"],
         }
+        return _model_facing_command_detail(entry_detail) if model_facing else entry_detail
     return None
 
 
@@ -708,13 +906,22 @@ def render_commands_index_markdown(*, command_names: Collection[str] | None = No
     return "\n".join(lines)
 
 
-def render_command_detail_markdown(command_name: str, action_name: str | None = None) -> str | None:
+def render_command_detail_markdown(
+    command_name: str,
+    action_name: str | None = None,
+    *,
+    model_facing: bool = False,
+) -> str | None:
     """Render markdown for /commands <name> [<action>]."""
 
     if action_name is not None:
-        return _render_command_action_detail_markdown(command_name, action_name)
+        return _render_command_action_detail_markdown(
+            command_name,
+            action_name,
+            model_facing=model_facing,
+        )
 
-    detail = _build_command_detail(command_name)
+    detail = _build_command_detail(command_name, model_facing=model_facing)
     if detail is None:
         return None
     return _render_command_detail_markdown(detail)
@@ -723,8 +930,10 @@ def render_command_detail_markdown(command_name: str, action_name: str | None = 
 def _render_command_action_detail_markdown(
     command_name: str,
     action_name: str,
+    *,
+    model_facing: bool = False,
 ) -> str | None:
-    detail = _build_command_detail(command_name)
+    detail = _build_command_detail(command_name, model_facing=model_facing)
     if detail is None:
         return None
 
@@ -804,6 +1013,7 @@ def render_commands_json(
     command_name: str | None = None,
     action_name: str | None = None,
     command_names: Collection[str] | None = None,
+    model_facing: bool = False,
 ) -> str:
     """Render JSON payload for /commands outputs."""
 
@@ -811,18 +1021,19 @@ def render_commands_json(
 
     if command_name is None:
         commands = [
-            _command_index_payload(item)
+            _command_index_payload(item, model_facing=model_facing)
             for item in _discovery_top_level_catalog()
             if allowed is None or item["name"] in allowed
         ]
         return _render_discovery_json("command_index", commands=commands)
 
-    detail = _build_command_detail(command_name)
+    detail = _build_command_detail(command_name, model_facing=model_facing)
     if detail is None:
+        suggestions = command_discovery_names() if allowed is None else tuple(sorted(allowed))
         return _render_discovery_json(
             "error",
             error=f"Unknown command: {command_name}",
-            suggestions=command_discovery_names(),
+            suggestions=suggestions,
         )
 
     if allowed is not None and detail["name"] not in allowed:

--- a/src/fast_agent/commands/context.py
+++ b/src/fast_agent/commands/context.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
+from weakref import ref
 
 from fast_agent.config import Settings, get_settings
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Iterable, Mapping, Sequence
+    from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
     from pathlib import Path
 
     from fast_agent.commands.results import CommandMessage
@@ -301,7 +302,42 @@ class NonInteractiveCommandIOBase(CommandIO):
         del agent_name, system_prompt, server_count
 
 
-_SESSION_SKILL_SOURCE_OVERRIDES: dict[tuple[str, str, str], str] = {}
+@dataclass(slots=True)
+class _ProviderSkillSourceState:
+    provider_ref: Callable[[], object | None]
+    sources: dict[str, str] = field(default_factory=dict)
+
+
+_ACP_SKILL_SOURCE_OVERRIDES: dict[tuple[str, str], str] = {}
+_PROVIDER_SKILL_SOURCE_OVERRIDES: dict[int, _ProviderSkillSourceState] = {}
+
+
+def _provider_skill_source_state(
+    provider: object,
+    *,
+    create: bool = False,
+) -> _ProviderSkillSourceState | None:
+    provider_id = id(provider)
+    state = _PROVIDER_SKILL_SOURCE_OVERRIDES.get(provider_id)
+    if state is not None and state.provider_ref() is provider:
+        return state
+    if not create:
+        return None
+
+    def remove_provider_state(_provider_ref: object) -> None:
+        _PROVIDER_SKILL_SOURCE_OVERRIDES.pop(provider_id, None)
+
+    try:
+        provider_ref: Callable[[], object | None] = ref(provider, remove_provider_state)
+    except TypeError:
+
+        def strong_provider_ref() -> object:
+            return provider
+
+        provider_ref = strong_provider_ref
+    state = _ProviderSkillSourceState(provider_ref=provider_ref)
+    _PROVIDER_SKILL_SOURCE_OVERRIDES[provider_id] = state
+    return state
 
 
 @dataclass(slots=True)
@@ -353,22 +389,35 @@ class CommandContext:
         active = self.skill_source_overrides.get(agent_name)
         if active is not None or not self.persist_skill_source_overrides:
             return active
-        return _SESSION_SKILL_SOURCE_OVERRIDES.get(self._skill_source_override_key(agent_name))
+        if self.acp_session_id is not None:
+            return _ACP_SKILL_SOURCE_OVERRIDES.get((self.acp_session_id, agent_name))
+        provider_state = _provider_skill_source_state(self.agent_provider)
+        return provider_state.sources.get(agent_name) if provider_state is not None else None
 
     def set_active_skill_source(self, agent_name: str, source: str) -> None:
         self.skill_source_overrides[agent_name] = source
-        if self.persist_skill_source_overrides:
-            _SESSION_SKILL_SOURCE_OVERRIDES[self._skill_source_override_key(agent_name)] = source
+        if not self.persist_skill_source_overrides:
+            return
+        if self.acp_session_id is not None:
+            _ACP_SKILL_SOURCE_OVERRIDES[(self.acp_session_id, agent_name)] = source
+            return
+        provider_state = _provider_skill_source_state(self.agent_provider, create=True)
+        if provider_state is not None:
+            provider_state.sources[agent_name] = source
 
     def clear_active_skill_source(self, agent_name: str) -> None:
         self.skill_source_overrides.pop(agent_name, None)
-        if self.persist_skill_source_overrides:
-            _SESSION_SKILL_SOURCE_OVERRIDES.pop(self._skill_source_override_key(agent_name), None)
-
-    def _skill_source_override_key(self, agent_name: str) -> tuple[str, str, str]:
+        if not self.persist_skill_source_overrides:
+            return
         if self.acp_session_id is not None:
-            return ("acp", self.acp_session_id, agent_name)
-        return ("provider", str(id(self.agent_provider)), agent_name)
+            _ACP_SKILL_SOURCE_OVERRIDES.pop((self.acp_session_id, agent_name), None)
+            return
+        provider_state = _provider_skill_source_state(self.agent_provider)
+        if provider_state is None:
+            return
+        provider_state.sources.pop(agent_name, None)
+        if not provider_state.sources:
+            _PROVIDER_SKILL_SOURCE_OVERRIDES.pop(id(self.agent_provider), None)
 
     def resolve_session_manager(self) -> "SessionManager":
         if self.session_runtime is not None:

--- a/src/fast_agent/commands/handlers/mcp_runtime.py
+++ b/src/fast_agent/commands/handlers/mcp_runtime.py
@@ -29,6 +29,7 @@ from fast_agent.mcp.failures import (
     render_mcp_failure,
 )
 from fast_agent.mcp.mcp_aggregator import MCPAttachOptions, MCPAttachResult, MCPDetachResult
+from fast_agent.skills.source_resolver import mcp_registry_source
 from fast_agent.utils.commandline import join_commandline
 from fast_agent.utils.count_display import format_count_parts
 from fast_agent.utils.numeric import nonnegative_int_or_none
@@ -135,6 +136,17 @@ def _resolve_configured_source_from_context(
     if server_config is None:
         return None
     return _describe_server_config_source(server_config)
+
+
+def _mcp_server_command(action: str, server_name: str) -> str:
+    return join_commandline(["/mcp", action, server_name], syntax="posix")
+
+
+def _skills_browse_command(server_name: str) -> str:
+    return join_commandline(
+        ["/skills", "available", "--registry", mcp_registry_source(server_name)],
+        syntax="posix",
+    )
 
 
 def _configured_connect_server(
@@ -336,8 +348,12 @@ async def handle_mcp_attach(
         return outcome
 
     if result.already_attached:
+        reconnect_command = _mcp_server_command("reconnect", server_name)
         outcome.add_message(
-            f"MCP server '{server_name}' is already attached.",
+            (
+                f"MCP server '{server_name}' is already attached via {result.transport}. "
+                f"Use `{reconnect_command}` to reconnect and refresh capabilities."
+            ),
             channel="warning",
             right_info="mcp",
             agent_name=agent_name,
@@ -346,7 +362,7 @@ async def handle_mcp_attach(
 
     source_suffix = f": {source}." if source else "."
     outcome.add_message(
-        f"Attached configured MCP server '{server_name}'{source_suffix}",
+        f"Attached configured MCP server '{server_name}' via {result.transport}{source_suffix}",
         right_info="mcp",
         agent_name=agent_name,
     )
@@ -355,6 +371,14 @@ async def handle_mcp_attach(
         right_info="mcp",
         agent_name=agent_name,
     )
+    if result.skills_total is not None and result.skills_total > 0:
+        browse_command = _skills_browse_command(server_name)
+        outcome.add_message(
+            f"Browse this server's skills with `{browse_command}`.",
+            channel="info",
+            right_info="mcp",
+            agent_name=agent_name,
+        )
     for warning in result.warnings:
         outcome.add_message(warning, channel="warning", right_info="mcp", agent_name=agent_name)
     return outcome
@@ -483,9 +507,10 @@ def _connect_success_message(
     mode: _McpConnectRuntimeMode,
     server_name: str,
     configured: bool,
+    transport: str,
 ) -> str:
     if configured:
-        return f"{action} configured MCP server '{server_name}'."
+        return f"{action} configured MCP server '{server_name}' via {transport}."
     return f"{action} MCP server '{server_name}' ({mode})."
 
 
@@ -529,6 +554,7 @@ async def _add_connect_success_messages(
         mode=mode,
         server_name=server_name,
         configured=configured,
+        transport=result.transport,
     )
     outcome.add_message(
         message_text,
@@ -541,6 +567,14 @@ async def _add_connect_success_messages(
     )
     summary = _format_refreshed_summary(counts) if reconnected else _format_added_summary(counts)
     outcome.add_message(summary, right_info="mcp", agent_name=agent_name)
+    if result.skills_total is not None and result.skills_total > 0:
+        browse_command = _skills_browse_command(server_name)
+        outcome.add_message(
+            f"Browse this server's skills with `{browse_command}`.",
+            channel="info",
+            right_info="mcp",
+            agent_name=agent_name,
+        )
     await _emit_connect_progress(on_progress, f"{action} MCP server '{server_name}'.")
 
 
@@ -744,10 +778,11 @@ async def handle_mcp_reconnect(
     if server_name not in attached_servers:
         configured = await manager.list_configured_detached_mcp_servers(agent_name)
         if server_name in configured:
+            attach_command = _mcp_server_command("attach", server_name)
             outcome.add_message(
                 (
                     f"MCP server '{server_name}' is configured but not attached. "
-                    f"Use `/mcp attach {server_name}`."
+                    f"Use `{attach_command}`."
                 ),
                 channel="warning",
                 right_info="mcp",
@@ -778,7 +813,7 @@ async def handle_mcp_reconnect(
 
     counts = _mcp_attach_counts(result)
 
-    message_text = f"Reconnected MCP server '{server_name}'."
+    message_text = f"Reconnected MCP server '{server_name}' via {result.transport}."
     outcome.add_message(
         message_text,
         right_info="mcp",

--- a/src/fast_agent/commands/handlers/skills.py
+++ b/src/fast_agent/commands/handlers/skills.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import re
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
@@ -44,6 +47,9 @@ from fast_agent.marketplace.update_status import is_update_applied
 from fast_agent.skills import SKILLS_DEFAULT
 from fast_agent.skills.command_support import (
     SKILLS_ADD_HINT_SLASH,
+    SkillsCatalogFormat,
+    marketplace_search_tokens,
+    parse_skills_catalog_options,
     skills_usage_lines,
 )
 from fast_agent.skills.configuration import (
@@ -69,10 +75,11 @@ from fast_agent.skills.scope import (
     resolve_skill_directories,
     resolve_skills_management_scope,
 )
-from fast_agent.skills.source_resolver import SkillSourceResolver
+from fast_agent.skills.source_resolver import SkillSourceResolver, mcp_registry_source
 from fast_agent.utils.action_normalization import is_help_flag
 from fast_agent.utils.collections import unique_preserve_order
-from fast_agent.utils.text import strip_to_none
+from fast_agent.utils.commandline import join_commandline
+from fast_agent.utils.text import strip_casefold, strip_to_none
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -87,6 +94,28 @@ REMOTE_ENVIRONMENT_SKILLS_WARNING = (
     "These are local skills and may not be available in your configured environment. "
     "Use /system to check"
 )
+MODEL_SKILLS_CATALOG_LIMIT = 50
+COMPACT_SKILL_DESCRIPTION_LIMIT = 180
+
+
+@dataclass(frozen=True, slots=True)
+class _SkillCatalogPage:
+    entries: list["SkillCatalogEntry"]
+    source_indices: list[int]
+    page: int
+    limit: int
+    total: int
+    result_start: int
+
+    @property
+    def result_end(self) -> int:
+        return self.result_start + len(self.entries) - 1
+
+    @property
+    def next_page(self) -> int | None:
+        if not self.entries:
+            return None
+        return self.page + 1 if self.result_end < self.total else None
 
 
 @runtime_checkable
@@ -158,11 +187,11 @@ def _format_local_skills_by_directory(manifests_by_dir: dict[Path, list[SkillMan
             skill_index += 1
             _append_manifest_entry(content, manifest, skill_index)
 
-    content.append_text(Text("Browse marketplace skills with /skills available", style="dim"))
+    content.append_text(Text("Browse available skills with /skills available", style="dim"))
     if total_skills > 0:
         content.append("\n")
         content.append_text(
-            Text("Search marketplace skills with /skills search <query>", style="dim")
+            Text("Search available skills with /skills search <query>", style="dim")
         )
         content.append("\n")
         content.append_text(Text("Remove a skill with /skills remove <number|name>", style="dim"))
@@ -198,11 +227,17 @@ def _format_agent_skills_override(
     return content
 
 
-def _format_marketplace_skills(marketplace: Sequence[SkillCatalogEntry]) -> Text:
+def _format_marketplace_skills(
+    marketplace: Sequence[SkillCatalogEntry],
+    *,
+    start_index: int = 1,
+    source_indices: Sequence[int] | None = None,
+) -> Text:
     content = Text()
     current_bundle = None
 
-    for index, entry in enumerate(marketplace, 1):
+    indices = source_indices or range(start_index, start_index + len(marketplace))
+    for index, entry in zip(indices, marketplace, strict=True):
         bundle_name = None
         bundle_description = None
         revision = None
@@ -269,6 +304,8 @@ def _format_skill_source_list(
     entries: list[SkillCatalogEntry],
     *,
     query: str | None = None,
+    start_index: int = 1,
+    source_indices: Sequence[int] | None = None,
 ) -> Text:
     content = Text()
     append_heading(content, source.list_heading(query=query))
@@ -281,7 +318,13 @@ def _format_skill_source_list(
             )
         )
         content.append("\n\n")
-    content.append_text(_format_marketplace_skills(entries))
+    content.append_text(
+        _format_marketplace_skills(
+            entries,
+            start_index=start_index,
+            source_indices=source_indices,
+        )
+    )
     if source.ref.kind == "mcp":
         content.append(
             "Integrity checks compare downloaded files with server-supplied digests. "
@@ -291,6 +334,191 @@ def _format_skill_source_list(
         )
         content.append("\n")
     return content
+
+
+def _compact_description(description: str | None) -> str | None:
+    if description is None:
+        return None
+    normalized = re.sub(r"\s+", " ", description).strip()
+    if not normalized:
+        return None
+    if len(normalized) <= COMPACT_SKILL_DESCRIPTION_LIMIT:
+        return normalized
+    return normalized[: COMPACT_SKILL_DESCRIPTION_LIMIT - 1].rstrip() + "…"
+
+
+def _catalog_page(
+    indexed_entries: list[tuple[int, SkillCatalogEntry]],
+    *,
+    page: int,
+    limit: int,
+) -> _SkillCatalogPage:
+    start = (page - 1) * limit
+    selected = indexed_entries[start : start + limit]
+    return _SkillCatalogPage(
+        entries=[entry for _index, entry in selected],
+        source_indices=[index for index, _entry in selected],
+        page=page,
+        limit=limit,
+        total=len(indexed_entries),
+        result_start=start + 1,
+    )
+
+
+def _skills_catalog_command(
+    *,
+    action: str,
+    query: str | None,
+    registry: str | None,
+    page: int,
+    limit: int,
+    output: SkillsCatalogFormat,
+) -> str:
+    argv = ["/skills", action]
+    if query is not None:
+        argv.append(query)
+    if registry is not None:
+        argv.extend(("--registry", registry))
+    if page > 1:
+        argv.extend(("--page", str(page)))
+    argv.extend(("--limit", str(limit)))
+    if output != "auto":
+        argv.append(f"--{output}")
+    return join_commandline(argv, syntax="posix")
+
+
+def _skills_install_command(registry: str | None) -> str:
+    placeholder = "SKILL_SELECTOR"
+    argv = ["/skills", "add", placeholder]
+    if registry is not None:
+        argv.extend(("--registry", registry))
+    return join_commandline(argv, syntax="posix").replace(
+        placeholder,
+        "<number|name>",
+    )
+
+
+def skills_available_command(registry: str | None) -> str:
+    argv = ["/skills", "available"]
+    if registry is not None:
+        argv.extend(("--registry", registry))
+    return join_commandline(argv, syntax="posix")
+
+
+def _format_compact_skill_catalog(
+    source: SkillInstallSource,
+    catalog_page: _SkillCatalogPage,
+    *,
+    query: str | None,
+    registry: str | None,
+    action: str,
+    output: SkillsCatalogFormat,
+) -> Text:
+    content = Text()
+    content.append(f"Source: {source.ref.display_name}", style="bold")
+    content.append("\n")
+    if query is not None:
+        content.append(f"Search: {query}", style="dim")
+        content.append("\n")
+    content.append(
+        f"Showing {catalog_page.result_start}-{catalog_page.result_end} "
+        f"of {catalog_page.total} skills.",
+        style="dim",
+    )
+    content.append("\n\n")
+    for index, entry in zip(
+        catalog_page.source_indices,
+        catalog_page.entries,
+        strict=True,
+    ):
+        content.append(f"{index}. ", style="dim cyan")
+        content.append(entry.name, style="bright_blue bold")
+        description = _compact_description(entry.description)
+        if description is not None:
+            content.append(f" — {description}")
+        content.append("\n")
+
+    if catalog_page.next_page is not None:
+        content.append("\n")
+        next_command = _skills_catalog_command(
+            action=action,
+            query=query,
+            registry=registry,
+            page=catalog_page.next_page,
+            limit=catalog_page.limit,
+            output=output,
+        )
+        content.append(f"Next: {next_command}", style="dim")
+        content.append("\n")
+    content.append("\n")
+    content.append(f"Install: {_skills_install_command(registry)}", style="dim")
+    return content
+
+
+def _skill_catalog_json(
+    source: SkillInstallSource,
+    catalog_page: _SkillCatalogPage,
+    *,
+    query: str | None,
+    registry: str | None,
+    action: str,
+    output: SkillsCatalogFormat,
+) -> str:
+    return json.dumps(
+        {
+            "schema_version": "1",
+            "kind": "skill_catalog",
+            "source": {
+                "kind": source.ref.kind,
+                "display_name": source.ref.display_name,
+                "source_url": (
+                    format_marketplace_display_url(source.ref.source_url)
+                    if source.ref.source_url is not None
+                    else None
+                ),
+                "server_name": source.ref.server_name,
+            },
+            "query": query,
+            "page": catalog_page.page,
+            "limit": catalog_page.limit,
+            "total": catalog_page.total,
+            "next_page": catalog_page.next_page,
+            "commands": {
+                "install": _skills_install_command(registry),
+                "next_page": (
+                    _skills_catalog_command(
+                        action=action,
+                        query=query,
+                        registry=registry,
+                        page=catalog_page.next_page,
+                        limit=catalog_page.limit,
+                        output=output,
+                    )
+                    if catalog_page.next_page is not None
+                    else None
+                ),
+            },
+            "skills": [
+                {
+                    "index": index,
+                    "name": entry.name,
+                    "description": _compact_description(entry.description),
+                    "source_url": (
+                        format_marketplace_display_url(entry.source_url)
+                        if entry.source_url is not None
+                        else None
+                    ),
+                }
+                for index, entry in zip(
+                    catalog_page.source_indices,
+                    catalog_page.entries,
+                    strict=True,
+                )
+            ],
+        },
+        indent=2,
+        sort_keys=True,
+    )
 
 
 def _format_skill_selection_list(
@@ -314,8 +542,8 @@ def _add_noninteractive_add_skill_hints(
         outcome,
         (
             SKILLS_ADD_HINT_SLASH,
-            "Browse marketplace with `/skills available`.",
-            "Search marketplace with `/skills search <query>`.",
+            "Browse available skills with `/skills available`.",
+            "Search available skills with `/skills search <query>`.",
             "Change registry with `/skills registry`.",
         ),
         right_info="skills",
@@ -554,38 +782,184 @@ def handle_skills_help(*, agent_name: str) -> CommandOutcome:
     return outcome
 
 
+def _skill_matches_query(entry: SkillCatalogEntry, query: str) -> bool:
+    values = [entry.name, entry.description or ""]
+    if isinstance(entry, MarketplaceSkill):
+        values.extend(
+            (
+                entry.install_dir_name,
+                entry.bundle_name or "",
+                entry.bundle_description or "",
+            )
+        )
+    haystack = strip_casefold(" ".join(value for value in values if value))
+    return all(token in haystack for token in marketplace_search_tokens(query))
+
+
+def _skill_catalog_error(message: str) -> CommandOutcome:
+    payload = json.dumps(
+        {
+            "schema_version": "1",
+            "kind": "error",
+            "error": message,
+        },
+        indent=2,
+        sort_keys=True,
+    )
+    outcome = CommandOutcome(direct_response=payload)
+    outcome.add_message(payload, verbatim=True, right_info="skills")
+    return outcome
+
+
 async def handle_list_marketplace_skills(
     ctx: CommandContext,
     *,
     agent_name: str,
     query: str | None = None,
     marketplace_url_override: str | None = None,
+    page: int = 1,
+    paginate: bool = False,
+    limit: int | None = None,
+    output: SkillsCatalogFormat = "full",
+    action: str = "available",
 ) -> CommandOutcome:
     outcome = CommandOutcome()
 
     resolver = SkillSourceResolver(ctx, agent_name=agent_name)
     resolution = await resolver.active_source(override=marketplace_url_override)
     if resolution.source is None:
-        outcome.add_message(resolution.error or "Skill source is not available.", channel="error")
+        message = resolution.error or "Skill source is not available."
+        if output == "json":
+            return _skill_catalog_error(message)
+        outcome.add_message(message, channel="error")
         return outcome
     source = resolution.source
+    command_registry = (
+        mcp_registry_source(source.ref.server_name)
+        if source.ref.kind == "mcp" and source.ref.server_name is not None
+        else marketplace_url_override
+    )
     try:
-        entries = await source.list_skills(query=query)
+        all_entries = await source.list_skills()
     except Exception as exc:
-        outcome.add_message(f"Failed to load marketplace: {exc}", channel="error")
+        message = f"Failed to load skills: {exc}"
+        if output == "json":
+            return _skill_catalog_error(message)
+        outcome.add_message(message, channel="error")
         return outcome
 
+    indexed_entries = list(enumerate(all_entries, 1))
+    if query is not None:
+        indexed_entries = [
+            (index, entry) for index, entry in indexed_entries if _skill_matches_query(entry, query)
+        ]
+    entries = [entry for _index, entry in indexed_entries]
     if not entries:
+        if output == "json":
+            empty_page = _SkillCatalogPage(
+                entries=[],
+                source_indices=[],
+                page=1,
+                limit=limit or MODEL_SKILLS_CATALOG_LIMIT,
+                total=0,
+                result_start=0,
+            )
+            payload = _skill_catalog_json(
+                source,
+                empty_page,
+                query=query,
+                registry=command_registry,
+                action=action,
+                output=output,
+            )
+            outcome.direct_response = payload
+            outcome.add_message(payload, verbatim=True, right_info="skills")
+            return outcome
         outcome.add_message(source.empty_message(), channel="warning")
         return outcome
 
-    content = _format_skill_source_list(source, entries, query=query)
+    effective_limit = limit
+    if effective_limit is None and output in {"compact", "json"}:
+        effective_limit = MODEL_SKILLS_CATALOG_LIMIT
+    if effective_limit is None and (paginate or page > 1):
+        effective_limit = MODEL_SKILLS_CATALOG_LIMIT
+
+    if effective_limit is not None:
+        catalog_page = _catalog_page(
+            indexed_entries,
+            page=page,
+            limit=effective_limit,
+        )
+        if not catalog_page.entries:
+            message = f"Page {page} is out of range for {len(entries)} available skills."
+            if output == "json":
+                return _skill_catalog_error(message)
+            outcome.add_message(message, channel="warning")
+            return outcome
+    else:
+        catalog_page = _SkillCatalogPage(
+            entries=entries,
+            source_indices=[index for index, _entry in indexed_entries],
+            page=1,
+            limit=len(entries),
+            total=len(entries),
+            result_start=1,
+        )
+
+    if output == "json":
+        payload = _skill_catalog_json(
+            source,
+            catalog_page,
+            query=query,
+            registry=command_registry,
+            action=action,
+            output=output,
+        )
+        outcome.direct_response = payload
+        outcome.add_message(payload, verbatim=True, right_info="skills", agent_name=agent_name)
+        return outcome
+
+    content = (
+        _format_compact_skill_catalog(
+            source,
+            catalog_page,
+            query=query,
+            registry=command_registry,
+            action=action,
+            output=output,
+        )
+        if output == "compact"
+        else _format_skill_source_list(
+            source,
+            catalog_page.entries,
+            query=query,
+            start_index=catalog_page.result_start,
+            source_indices=catalog_page.source_indices,
+        )
+    )
     outcome.add_message(content, right_info="skills", agent_name=agent_name)
+    if output == "full" and catalog_page.next_page is not None:
+        next_command = _skills_catalog_command(
+            action=action,
+            query=query,
+            registry=command_registry,
+            page=catalog_page.next_page,
+            limit=catalog_page.limit,
+            output=output,
+        )
+        outcome.add_message(
+            f"Next page: `{next_command}`.",
+            channel="info",
+            right_info="skills",
+            agent_name=agent_name,
+        )
+    if output == "compact":
+        return outcome
     add_info_messages(
         outcome,
         (
-            SKILLS_ADD_HINT_SLASH,
-            "Search with `/skills search <query>`.",
+            f"Install with `{_skills_install_command(command_registry)}`.",
+            "Search available skills with `/skills search <query>`.",
         ),
         right_info="skills",
         agent_name=agent_name,
@@ -608,13 +982,29 @@ async def handle_add_skill(
         outcome.add_message(parsed.error, channel="warning")
         return outcome
 
+    selection = parsed.selector
+    marketplace_url = parsed.registry or marketplace_url_override
+    if selection is None and not interactive:
+        browse_command = skills_available_command(marketplace_url)
+        outcome.add_message(
+            "A skill selector is required for model-facing installation.",
+            channel="warning",
+            right_info="skills",
+            agent_name=agent_name,
+        )
+        outcome.add_message(
+            f"Browse with `{browse_command}` or use `/skills search <query>`.",
+            channel="info",
+            right_info="skills",
+            agent_name=agent_name,
+        )
+        return outcome
+
     management_scope = resolve_skills_management_scope(
         ctx.resolve_settings(),
         managed_directory_override=parsed.skills_dir or managed_directory_override,
     )
     managed_skills_dir = management_scope.managed_directory
-    selection = parsed.selector
-    marketplace_url = parsed.registry or marketplace_url_override
     resolver = SkillSourceResolver(ctx, agent_name=agent_name)
     resolution = await resolver.active_source(override=marketplace_url)
     if resolution.source is None:
@@ -635,7 +1025,7 @@ async def handle_add_skill(
     try:
         entries = await source.list_skills()
     except Exception as exc:
-        outcome.add_message(f"Failed to load marketplace: {exc}", channel="error")
+        outcome.add_message(f"Failed to load skills: {exc}", channel="error")
         return outcome
 
     if not entries:
@@ -870,10 +1260,97 @@ async def _handle_skills_list_action(
 async def _handle_skills_available_action(
     ctx: "CommandContext",
     agent_name: str,
-    _argument: str | None,
-    _interactive: bool,
+    argument: str | None,
+    interactive: bool,
 ) -> CommandOutcome:
-    return await handle_list_marketplace_skills(ctx, agent_name=agent_name, query=None)
+    parsed = parse_skills_catalog_options(argument)
+    if parsed.error is not None:
+        if parsed.output == "json":
+            return _skill_catalog_error(parsed.error)
+        outcome = CommandOutcome()
+        outcome.add_message(parsed.error, channel="warning", right_info="skills")
+        return outcome
+    if strip_to_none(parsed.argument) is not None:
+        message = (
+            "Usage: /skills available [--registry source] [--page N] [--limit N] "
+            "[--compact|--full|--json]"
+        )
+        if parsed.output == "json":
+            return _skill_catalog_error(message)
+        outcome = CommandOutcome()
+        outcome.add_message(
+            message,
+            channel="warning",
+            right_info="skills",
+        )
+        return outcome
+    if not interactive and parsed.output == "full":
+        return _skill_catalog_error(
+            "Full skills listings are unavailable to model-facing commands; "
+            "use compact or paginated JSON output."
+        )
+    output: SkillsCatalogFormat = (
+        "compact" if parsed.output == "auto" and not interactive else parsed.output
+    )
+    if output == "auto":
+        output = "full"
+    return await handle_list_marketplace_skills(
+        ctx,
+        agent_name=agent_name,
+        query=None,
+        marketplace_url_override=parsed.registry,
+        page=parsed.page,
+        paginate=parsed.page_explicit,
+        limit=parsed.limit,
+        output=output,
+        action="available",
+    )
+
+
+async def _handle_skills_search_action(
+    ctx: "CommandContext",
+    agent_name: str,
+    argument: str | None,
+    interactive: bool,
+) -> CommandOutcome:
+    parsed = parse_skills_catalog_options(argument)
+    query = strip_to_none(parsed.argument)
+    if parsed.error is not None or query is None:
+        message = parsed.error or (
+            "Usage: /skills search <query> [--registry source] [--page N] [--limit N] "
+            "[--compact|--full|--json]"
+        )
+        if parsed.output == "json":
+            return _skill_catalog_error(message)
+        outcome = CommandOutcome()
+        outcome.add_message(
+            message,
+            channel="warning",
+            right_info="skills",
+            agent_name=agent_name,
+        )
+        return outcome
+    if not interactive and parsed.output == "full":
+        return _skill_catalog_error(
+            "Full skills listings are unavailable to model-facing commands; "
+            "use compact or paginated JSON output."
+        )
+    output: SkillsCatalogFormat = (
+        "compact" if parsed.output == "auto" and not interactive else parsed.output
+    )
+    if output == "auto":
+        output = "full"
+    return await handle_list_marketplace_skills(
+        ctx,
+        agent_name=agent_name,
+        query=query,
+        marketplace_url_override=parsed.registry,
+        page=parsed.page,
+        paginate=parsed.page_explicit,
+        limit=parsed.limit,
+        output=output,
+        action="search",
+    )
 
 
 async def _handle_skills_add_action(
@@ -925,6 +1402,7 @@ async def _handle_skills_update_action(
 _SKILLS_ACTION_HANDLERS: dict[str, _SkillsActionHandler] = {
     "list": _handle_skills_list_action,
     "available": _handle_skills_available_action,
+    "search": _handle_skills_search_action,
     "add": _handle_skills_add_action,
     "registry": _handle_skills_registry_action,
     "remove": _handle_skills_remove_action,
@@ -944,19 +1422,6 @@ async def handle_skills_command(
 
     if is_help_flag(action) or is_help_flag(argument):
         return handle_skills_help(agent_name=agent_name)
-
-    if normalized == "search":
-        query = strip_to_none(argument) or ""
-        if not query:
-            outcome = CommandOutcome()
-            outcome.add_message(
-                "Usage: /skills search <query>",
-                channel="warning",
-                right_info="skills",
-                agent_name=agent_name,
-            )
-            return outcome
-        return await handle_list_marketplace_skills(ctx, agent_name=agent_name, query=query)
 
     handler = _SKILLS_ACTION_HANDLERS.get(normalized)
     if handler is not None:

--- a/src/fast_agent/commands/handlers/skills_registry.py
+++ b/src/fast_agent/commands/handlers/skills_registry.py
@@ -117,7 +117,10 @@ def _format_registry_set_success(
     content.append_text(Text(f"Registry set to: {display_name}", style="green"))
     content.append("\n")
     content.append_text(
-        Text(f"Skills discovered: {skill_count}. Use /skills add to list.", style="dim")
+        Text(
+            f"Skills discovered: {skill_count}. Browse with /skills available.",
+            style="dim",
+        )
     )
     return content
 

--- a/src/fast_agent/commands/harness.py
+++ b/src/fast_agent/commands/harness.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from fast_agent.commands.command_discovery import render_commands_index_markdown
+from fast_agent.commands.command_discovery import (
+    parse_commands_discovery_arguments,
+    render_command_detail_markdown,
+    render_commands_index_markdown,
+    render_commands_json,
+)
 from fast_agent.commands.context import (
     CommandContext,
     NonInteractiveCommandIOBase,
@@ -48,7 +53,6 @@ if TYPE_CHECKING:
     )
 
 _COMMAND_HANDLERS = {
-    "tools": tools_handlers.handle_list_tools,
     "prompts": prompt_handlers.handle_list_prompts,
     "usage": display_handlers.handle_show_usage,
     "system": display_handlers.handle_show_system,
@@ -276,7 +280,7 @@ def _mcp_usage_text() -> str:
             (
                 "- /mcp connect <target> [--name <server>] [--auth <token>] "
                 "[--timeout <seconds>] [--protocol auto|modern|legacy] "
-                "[--reconnect|--no-reconnect]"
+                "[--no-oauth] [--reconnect|--no-reconnect]"
             ),
             "  Model-initiated OAuth is unavailable; use a user-facing command.",
             "- /mcp disconnect <server_name>",
@@ -300,13 +304,21 @@ def _render_outcome(
     heading: str,
     io: _HarnessCommandIO,
 ) -> str:
+    if any(message.channel == "error" for message in outcome.messages):
+        rendered = render_command_outcome_markdown(
+            outcome,
+            heading=heading,
+            extra_messages=io.messages,
+        )
+        raise AgentConfigError(f"/{heading} command failed", rendered)
+    if outcome.direct_response is not None:
+        return outcome.direct_response
+
     rendered = render_command_outcome_markdown(
         outcome,
         heading=heading,
         extra_messages=io.messages,
     )
-    if any(message.channel == "error" for message in outcome.messages):
-        raise AgentConfigError(f"/{heading} command failed", rendered)
     return rendered
 
 
@@ -460,6 +472,58 @@ async def _execute_skills_command(
     return _render_outcome(outcome, heading="skills", io=io)
 
 
+def _execute_commands_command(arguments: str) -> str:
+    try:
+        request = parse_commands_discovery_arguments(arguments)
+    except ValueError as exc:
+        raise AgentConfigError("Invalid /commands arguments", str(exc)) from exc
+
+    if request.as_json:
+        return render_commands_json(
+            command_name=request.command_name,
+            action_name=request.action_name,
+            command_names=_COMMAND_NAMES,
+            model_facing=True,
+        )
+    if request.command_name is None:
+        return render_commands_index_markdown(command_names=_COMMAND_NAMES)
+    if request.command_name not in _COMMAND_NAMES:
+        available = ", ".join(f"`/{name}`" for name in _COMMAND_NAMES)
+        raise AgentConfigError(
+            "Unsupported /commands target",
+            f"Command '/{request.command_name}' is unavailable. Supported commands: {available}.",
+        )
+
+    rendered = render_command_detail_markdown(
+        request.command_name,
+        request.action_name,
+        model_facing=True,
+    )
+    if rendered is not None:
+        return rendered
+
+    target = f"/{request.command_name}"
+    if request.action_name is not None:
+        target = f"{target} {request.action_name}"
+    raise AgentConfigError(
+        "Unknown command action",
+        f"No discovery metadata is available for `{target}`.",
+    )
+
+
+def _parse_tools_argument(arguments: str) -> str | None:
+    try:
+        tokens = split_commandline(arguments, syntax="posix")
+    except ValueError as exc:
+        raise AgentConfigError("Invalid /tools arguments", str(exc)) from exc
+    if len(tokens) > 1:
+        raise AgentConfigError(
+            "Invalid /tools arguments",
+            "Usage: /tools [summary|<tool-name>]",
+        )
+    return tokens[0] if tokens else None
+
+
 async def execute_harness_command(
     agent: ToolAgent,
     command: str,
@@ -469,12 +533,7 @@ async def execute_harness_command(
     """Execute an allow-listed model-visible harness command."""
     command_name, arguments = _parse_command(command)
     if command_name in {"help", "?", "commands"}:
-        if arguments.strip():
-            raise AgentConfigError(
-                "Unsupported /commands arguments",
-                "The harness tool currently supports only `/commands`.",
-            )
-        return render_commands_index_markdown(command_names=_COMMAND_NAMES)
+        return _execute_commands_command(arguments)
 
     if command_name == "status":
         if arguments.strip():
@@ -495,6 +554,15 @@ async def execute_harness_command(
                 skill_source_overrides if skill_source_overrides is not None else {}
             ),
         )
+
+    if command_name == "tools":
+        context, io = _command_context(agent)
+        outcome = await tools_handlers.handle_list_tools(
+            context,
+            agent_name=agent.name,
+            argument=_parse_tools_argument(arguments),
+        )
+        return _render_outcome(outcome, heading=command_name, io=io)
 
     handler = _COMMAND_HANDLERS.get(command_name)
     if handler is None:

--- a/src/fast_agent/commands/renderers/skills_markdown.py
+++ b/src/fast_agent/commands/renderers/skills_markdown.py
@@ -81,7 +81,7 @@ def render_skill_list(manifests: Sequence[SkillManifest], *, cwd: Path | None = 
 
 def _skills_browse_guidance() -> list[str]:
     return [
-        "Use `/skills available` to browse marketplace skills.",
+        "Use `/skills available` to browse available skills.",
         "",
         "Search with `/skills search <query>`.",
     ]
@@ -90,7 +90,7 @@ def _skills_browse_guidance() -> list[str]:
 def _skills_marketplace_guidance() -> list[str]:
     return [
         SKILLS_ADD_HINT_SLASH,
-        "Search with `/skills search <query>`.",
+        "Search available skills with `/skills search <query>`.",
         "Change registry with `/skills registry`.",
     ]
 

--- a/src/fast_agent/commands/results.py
+++ b/src/fast_agent/commands/results.py
@@ -58,6 +58,7 @@ class CommandOutcome:
     switch_agent: str | None = None
     requires_refresh: bool = False
     halt_loop: bool = False
+    direct_response: str | None = None
 
     def add_message(
         self,

--- a/src/fast_agent/core/agent_capabilities.py
+++ b/src/fast_agent/core/agent_capabilities.py
@@ -1,0 +1,70 @@
+"""Runtime presets for fast-agent built-in tools."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TypeGuard
+
+from fast_agent.agents.subagent_tool import (
+    set_subagent_tool_enabled,
+    subagent_tool_enabled,
+)
+from fast_agent.agents.tool_agent import ToolAgent
+from fast_agent.core.exceptions import AgentConfigError
+from fast_agent.core.harness_tools import harness_tools_enabled, set_harness_tools
+
+
+class AgentCapabilityMode(StrEnum):
+    STANDARD = "standard"
+    DELEGATE = "delegate"
+    ORCHESTRATE = "orchestrate"
+    HARNESS_ONLY = "harness_only"
+
+
+def agent_capability_mode_supported(agent: object) -> TypeGuard[ToolAgent]:
+    return (
+        isinstance(agent, ToolAgent)
+        and not agent.config.tool_only
+        and not agent.config.subagent_child
+    )
+
+
+def resolve_agent_capability_mode(agent: object) -> AgentCapabilityMode:
+    subagents = subagent_tool_enabled(agent)
+    harness = harness_tools_enabled(agent)
+    if subagents and harness:
+        return AgentCapabilityMode.ORCHESTRATE
+    if subagents:
+        return AgentCapabilityMode.DELEGATE
+    if harness:
+        return AgentCapabilityMode.HARNESS_ONLY
+    return AgentCapabilityMode.STANDARD
+
+
+def cycle_agent_capability_mode(agent: object) -> AgentCapabilityMode:
+    """Cycle Standard → Delegate → Orchestrate → Harness-only → Standard."""
+    if not agent_capability_mode_supported(agent):
+        return resolve_agent_capability_mode(agent)
+
+    mode = resolve_agent_capability_mode(agent)
+    if mode is AgentCapabilityMode.STANDARD:
+        _enable_subagents(agent)
+    elif mode is AgentCapabilityMode.DELEGATE:
+        set_harness_tools(agent, True)
+    elif mode is AgentCapabilityMode.ORCHESTRATE:
+        set_subagent_tool_enabled(agent, False)
+    else:
+        set_harness_tools(agent, False)
+    return resolve_agent_capability_mode(agent)
+
+
+def _enable_subagents(agent: ToolAgent) -> None:
+    if set_subagent_tool_enabled(agent, True):
+        return
+    source = agent.config.subagent_activation_source
+    details = (
+        f"Subagents are disabled by {source}."
+        if source in {"configuration", "cli"}
+        else "The built-in subagent tool is unavailable."
+    )
+    raise AgentConfigError("Unable to enable Delegate mode", details)

--- a/src/fast_agent/core/harness_tools.py
+++ b/src/fast_agent/core/harness_tools.py
@@ -29,6 +29,12 @@ def _is_harness_tool(agent: ToolAgent, name: str) -> bool:
     return tool is not None and tool.meta == HARNESS_TOOL_METADATA
 
 
+def harness_tools_enabled(agent: object) -> bool:
+    return isinstance(agent, ToolAgent) and all(
+        _is_harness_tool(agent, name) for name in HARNESS_TOOL_NAMES
+    )
+
+
 def _resource_text(result: ReadResourceResult, *, max_chars: int = 4000) -> str:
     lines: list[str] = []
     for index, content in enumerate(result.contents, start=1):
@@ -65,9 +71,9 @@ def set_harness_tools(agent: object, enabled: bool | None = None) -> bool:
         return False
     if enabled is None:
         enabled = agent.config.harness_tools
-    agent.config.harness_tools = enabled
 
     if not enabled or agent.config.tool_only:
+        agent.config.harness_tools = enabled
         for name in HARNESS_TOOL_NAMES:
             if _is_harness_tool(agent, name):
                 agent.remove_tool(name)
@@ -78,6 +84,7 @@ def set_harness_tools(agent: object, enabled: bool | None = None) -> bool:
         if existing is not None and existing.meta != HARNESS_TOOL_METADATA:
             raise AgentConfigError(f"Tool name '{name}' is reserved by fast-agent")
 
+    agent.config.harness_tools = True
     skill_source_overrides: dict[str, str] = {}
 
     async def slash_command(command: str) -> str:
@@ -98,7 +105,8 @@ def set_harness_tools(agent: object, enabled: bool | None = None) -> bool:
                 description=(
                     "Execute an allow-listed fast-agent slash command, including model-managed "
                     "MCP servers and skills. "
-                    "Use `/commands` to list the supported command surface."
+                    "Use `/commands` for help or `/commands --json` for the machine-readable "
+                    "command surface."
                 ),
                 metadata=HARNESS_TOOL_METADATA,
             )

--- a/src/fast_agent/skills/command_support.py
+++ b/src/fast_agent/skills/command_support.py
@@ -12,7 +12,11 @@ from fast_agent.commands.command_catalog import (
 from fast_agent.commands.option_parsing import ParsedValueOption, ValueOption, read_value_option
 from fast_agent.marketplace import formatting as marketplace_formatting
 from fast_agent.utils.action_normalization import normalize_action_token
-from fast_agent.utils.commandline import join_commandline, split_commandline
+from fast_agent.utils.commandline import (
+    join_commandline,
+    split_commandline,
+    split_posix_like_preserving_backslashes,
+)
 from fast_agent.utils.text import strip_casefold
 
 if TYPE_CHECKING:
@@ -21,6 +25,8 @@ if TYPE_CHECKING:
     from fast_agent.skills.models import MarketplaceSkill
 
 type _SkillsSlashValueName = Literal["registry", "skills_dir"]
+type _SkillsCatalogValueName = Literal["registry", "page", "limit"]
+type SkillsCatalogFormat = Literal["auto", "compact", "full", "json"]
 
 
 SKILLS_ADD_HINT_CLI = f"Install with: fast-agent skills add <{SKILLS_ADD_SELECTOR}>"
@@ -35,10 +41,33 @@ class SkillsSlashOptions:
     error: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class SkillsCatalogOptions:
+    argument: str = ""
+    registry: str | None = None
+    page: int = 1
+    page_explicit: bool = False
+    limit: int | None = None
+    output: SkillsCatalogFormat = "auto"
+    error: str | None = None
+
+
 _SKILLS_SLASH_VALUE_OPTIONS: tuple[ValueOption[_SkillsSlashValueName], ...] = (
     ValueOption("registry", ("--registry", "-r"), error_name="--registry"),
     ValueOption("skills_dir", ("--skills-dir", "--skills"), error_name="--skills-dir"),
 )
+_SKILLS_CATALOG_VALUE_OPTIONS: tuple[ValueOption[_SkillsCatalogValueName], ...] = (
+    ValueOption("registry", ("--registry", "-r"), error_name="--registry"),
+    ValueOption("page", ("--page",), error_name="--page"),
+    ValueOption("limit", ("--limit",), error_name="--limit"),
+)
+_SKILLS_CATALOG_FORMAT_OPTIONS: dict[str, SkillsCatalogFormat] = {
+    "--compact": "compact",
+    "--full": "full",
+    "--json": "json",
+}
+MAX_SKILLS_CATALOG_LIMIT = 100
+MAX_SKILLS_CATALOG_PAGE = 1_000_000
 
 
 def skills_usage_lines() -> list[str]:
@@ -98,6 +127,110 @@ def parse_skills_slash_options(argument: str | None) -> SkillsSlashOptions:
         argument=argument,
         registry=registry,
         skills_dir=skills_dir,
+    )
+
+
+def _positive_catalog_integer(
+    value: str,
+    *,
+    option_name: str,
+    maximum: int | None = None,
+) -> tuple[int | None, str | None]:
+    if not value.isascii() or not value.isdecimal():
+        return None, f"Invalid value for {option_name}: expected a positive integer"
+    if maximum is not None and len(value) > len(str(maximum)):
+        return None, f"Invalid value for {option_name}: maximum is {maximum}"
+    parsed = int(value)
+    if parsed < 1:
+        return None, f"Invalid value for {option_name}: expected a positive integer"
+    if maximum is not None and parsed > maximum:
+        return None, f"Invalid value for {option_name}: maximum is {maximum}"
+    return parsed, None
+
+
+def parse_skills_catalog_options(argument: str | None) -> SkillsCatalogOptions:
+    """Parse available/search catalog options and preserve the remaining query."""
+    raw_argument = argument or ""
+    requested_output: SkillsCatalogFormat = "json" if "--json" in raw_argument.split() else "auto"
+    try:
+        tokens = split_posix_like_preserving_backslashes(raw_argument)
+    except ValueError as exc:
+        return SkillsCatalogOptions(
+            output=requested_output,
+            error=f"Invalid /skills arguments: {exc}",
+        )
+
+    requested_output = "json" if "--json" in tokens else "auto"
+
+    def failure(error: str) -> SkillsCatalogOptions:
+        return SkillsCatalogOptions(output=requested_output, error=error)
+
+    registry: str | None = None
+    page = 1
+    limit: int | None = None
+    output: SkillsCatalogFormat = "auto"
+    remaining: list[str] = []
+    seen_values: set[_SkillsCatalogValueName] = set()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        format_option = _SKILLS_CATALOG_FORMAT_OPTIONS.get(token)
+        if format_option is not None:
+            if output != "auto":
+                return failure(f"Conflicting output option: {token}")
+            output = format_option
+            index += 1
+            continue
+
+        value_option = read_value_option(tokens, index, _SKILLS_CATALOG_VALUE_OPTIONS)
+        if value_option.error is not None:
+            return failure(value_option.error)
+        if value_option.next_index != index:
+            name = value_option.require_name()
+            value = value_option.require_value()
+            if name in seen_values:
+                return failure(f"Duplicate option: {value_option.display_name}")
+            seen_values.add(name)
+            if name == "registry":
+                registry = value
+            elif name == "page":
+                parsed, error = _positive_catalog_integer(
+                    value,
+                    option_name="--page",
+                    maximum=MAX_SKILLS_CATALOG_PAGE,
+                )
+                if error is not None or parsed is None:
+                    return failure(error or "Invalid value for --page")
+                page = parsed
+            else:
+                parsed, error = _positive_catalog_integer(
+                    value,
+                    option_name="--limit",
+                    maximum=MAX_SKILLS_CATALOG_LIMIT,
+                )
+                if error is not None or parsed is None:
+                    return failure(error or "Invalid value for --limit")
+                limit = parsed
+            index = value_option.next_index
+            continue
+
+        if token == "--":
+            remaining.extend(tokens[index + 1 :])
+            break
+        if token.startswith("-") and token != "-":
+            return failure(f"Unknown option: {token.split('=', 1)[0]}")
+        remaining.append(token)
+        index += 1
+
+    return SkillsCatalogOptions(
+        argument=join_commandline(remaining, syntax="posix")
+        if len(remaining) > 1
+        else (remaining[0] if remaining else ""),
+        registry=registry,
+        page=page,
+        page_explicit="page" in seen_values,
+        limit=limit,
+        output=output,
     )
 
 

--- a/src/fast_agent/skills/configuration.py
+++ b/src/fast_agent/skills/configuration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
 from fast_agent.config import Settings, get_settings
 from fast_agent.marketplace import registry_urls as marketplace_registry_urls
 from fast_agent.skills.models import DEFAULT_MARKETPLACE_URL, DEFAULT_SKILL_REGISTRIES
@@ -28,4 +30,19 @@ def resolve_skill_registries(settings: Settings | None = None) -> list[str]:
 
 
 def format_marketplace_display_url(url: str) -> str:
-    return marketplace_registry_urls.format_marketplace_display_url(url)
+    return marketplace_registry_urls.format_marketplace_display_url(_redact_registry_url(url))
+
+
+def _redact_registry_url(url: str) -> str:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return "[REDACTED INVALID URL]"
+    if parsed.scheme not in {"http", "https"}:
+        return url
+    netloc = parsed.netloc
+    if "@" in netloc:
+        netloc = f"REDACTED@{netloc.rsplit('@', 1)[1]}"
+    query = urlencode([(key, "[REDACTED]") for key, _value in parse_qsl(parsed.query)])
+    fragment = "[REDACTED]" if parsed.fragment else ""
+    return urlunsplit((parsed.scheme, netloc, parsed.path, query, fragment))

--- a/src/fast_agent/skills/marketplace_source.py
+++ b/src/fast_agent/skills/marketplace_source.py
@@ -8,6 +8,7 @@ from fast_agent.skills.command_support import (
     filter_marketplace_skills,
     marketplace_repository_hint,
 )
+from fast_agent.skills.configuration import format_marketplace_display_url
 from fast_agent.skills.direct_sources import is_direct_skill_source
 from fast_agent.skills.models import MarketplaceSkill, SkillUpdateInfo
 from fast_agent.skills.operations import (
@@ -34,7 +35,7 @@ class MarketplaceSkillSource:
     def ref(self) -> SkillSourceRef:
         return SkillSourceRef(
             kind="marketplace",
-            display_name=self._source_url,
+            display_name=format_marketplace_display_url(self._source_url),
             source_url=self._source_url,
         )
 
@@ -80,11 +81,11 @@ class MarketplaceSkillSource:
     def list_heading(self, *, query: str | None = None) -> str:
         normalized_query = strip_to_none(query)
         if normalized_query is None:
-            return "Marketplace skills:"
-        return f"Marketplace skills (search: {normalized_query}):"
+            return "Available skills:"
+        return f"Available skills (search: {normalized_query}):"
 
     def empty_message(self) -> str:
-        return "No skills found in the marketplace."
+        return "No skills found in the registry."
 
     def selection_options(self, entries: Sequence[SkillCatalogEntry]) -> list[str]:
         options: list[str] = []

--- a/src/fast_agent/skills/source_resolver.py
+++ b/src/fast_agent/skills/source_resolver.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from urllib.parse import urlsplit
 
 from fast_agent.skills.configuration import get_marketplace_url
 from fast_agent.skills.marketplace_source import MarketplaceSkillSource
@@ -95,6 +97,11 @@ class SkillSourceResolver:
             or self._ctx.active_skill_source(self._agent_name)
             or get_marketplace_url(settings)
         )
+        if override is not None and _is_bare_source_name(source_url):
+            registry = find_mcp_registry(await self.mcp_registries(), source_url)
+            if registry is not None:
+                return self._mcp_source(registry)
+
         mcp_server_name = mcp_registry_server_name(source_url)
         if mcp_server_name is None:
             return SkillSourceResolution(source=MarketplaceSkillSource(source_url))
@@ -107,6 +114,9 @@ class SkillSourceResolver:
                 error=f"MCP skill registry is not available: {mcp_server_name}",
             )
 
+        return self._mcp_source(registry)
+
+    def _mcp_source(self, registry: "McpSkillRegistry") -> SkillSourceResolution:
         agent = self._ctx.agent_provider._agent(self._agent_name)
         if not isinstance(agent, McpSkillRegistryAgent):
             return SkillSourceResolution(
@@ -191,3 +201,10 @@ class SkillSourceResolver:
             groups.append(SkillUpdateSourceGroup(source=source, updates=source_updates))
 
         return groups
+
+
+def _is_bare_source_name(source: str) -> bool:
+    value = source.strip()
+    if not value or urlsplit(value).scheme or Path(value).expanduser().exists():
+        return False
+    return not any(separator in value for separator in ("/", "\\"))

--- a/src/fast_agent/tools/shell_output.py
+++ b/src/fast_agent/tools/shell_output.py
@@ -36,6 +36,7 @@ class ShellOutputBuffer:
     retained_output_max_bytes: int = 0
     retained_output_bytes: int = 0
     retained_output_complete: bool = True
+    retained_output_via_process: bool = False
     extended_guidance: bool = False
 
     def append(self, text: str) -> None:
@@ -134,6 +135,20 @@ class ShellOutputBuffer:
     def _truncation_guidance(self) -> str:
         if self.retained_output_path is None or not self.retained_output_path.exists():
             return _OUTPUT_LIMIT_GUIDANCE
+        if self.retained_output_via_process:
+            completeness = (
+                "The complete output"
+                if self.retained_output_complete
+                else (
+                    f"The first {self.retained_output_bytes} bytes retained before "
+                    "the temporary-output quota was reached"
+                )
+            )
+            return (
+                f"{completeness} can be read through the managed process handle. "
+                "Use the process tool with action='read_output' and the process_id "
+                "from this result."
+            )
         notice = format_retained_artifact_notice(
             path=str(self.retained_output_path),
             retained_bytes=self.retained_output_bytes,

--- a/src/fast_agent/tools/shell_runtime.py
+++ b/src/fast_agent/tools/shell_runtime.py
@@ -228,6 +228,9 @@ class ShellRuntime:
         self._retained_output_directory: Path | None = None
         self._retained_output_max_bytes = 0
         self._retained_output_next_id = 1
+        self._retained_output_via_process = False
+        retain_truncated_output = False
+        retained_output_parent: Path | None = None
         if config is not None:
             shell_config = config.shell_execution
             self._output_display_lines = shell_config.output_display_lines
@@ -236,17 +239,8 @@ class ShellRuntime:
             self._max_process_poll_seconds = shell_config.process_poll_max_wait_seconds
             configured_profile = tool_profile or shell_config.tool_profile
             self._retained_output_max_bytes = shell_config.retained_output_max_bytes
-            if shell_config.retain_truncated_output and self.runtime_info().kind == "local":
-                parent = shell_config.retained_output_temp_directory
-                if parent is not None:
-                    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-                self._retained_output_directory = Path(
-                    tempfile.mkdtemp(
-                        prefix="fast-agent-output-",
-                        dir=str(parent) if parent is not None else None,
-                    )
-                )
-                self._retained_output_directory.chmod(0o700)
+            retain_truncated_output = shell_config.retain_truncated_output
+            retained_output_parent = shell_config.retained_output_temp_directory
         self._minimal_process_profile = False
         self._grok_shell_profile = False
         self._luna_exec_profile = False
@@ -261,6 +255,27 @@ class ShellRuntime:
             configured_profile,
             model_profile=model_tool_profile,
         )
+        process_readback_supported = (
+            self._minimal_process_profile or self._grok_shell_profile or self._luna_exec_profile
+        )
+        runtime_kind = self.runtime_info().kind
+        if retain_truncated_output and (runtime_kind == "local" or process_readback_supported):
+            if retained_output_parent is not None:
+                retained_output_parent.mkdir(
+                    mode=0o700,
+                    parents=True,
+                    exist_ok=True,
+                )
+            self._retained_output_directory = Path(
+                tempfile.mkdtemp(
+                    prefix="fast-agent-output-",
+                    dir=(
+                        str(retained_output_parent) if retained_output_parent is not None else None
+                    ),
+                )
+            )
+            self._retained_output_directory.chmod(0o700)
+            self._retained_output_via_process = runtime_kind != "local"
 
     @property
     def tool(self) -> Tool | None:
@@ -1089,6 +1104,7 @@ class ShellRuntime:
             output_byte_limit_requested=output_byte_limit is not None,
             retained_output_path=self._next_retained_output_path(),
             retained_output_max_bytes=self._retained_output_max_bytes,
+            retained_output_via_process=self._retained_output_via_process,
             extended_guidance=self._extended_guidance,
         )
         display_state = self._build_display_state(
@@ -1131,6 +1147,7 @@ class ShellRuntime:
             output_byte_limit_requested=parsed.output_byte_limit is not None,
             retained_output_path=self._next_retained_output_path(),
             retained_output_max_bytes=self._retained_output_max_bytes,
+            retained_output_via_process=self._retained_output_via_process,
             extended_guidance=self._extended_guidance,
         )
         display_state = self._build_display_state(

--- a/src/fast_agent/tools/shell_tool_definitions.py
+++ b/src/fast_agent/tools/shell_tool_definitions.py
@@ -447,12 +447,18 @@ def build_luna_exec_tool(*, shell_name: str) -> Tool:
     return Tool(
         name=LUNA_EXEC_TOOL_NAME,
         description=(
-            f"Run one shell command in {shell_name}. Keep commands whose result or "
-            "exit status matters in the foreground. Long foreground commands yield a "
-            "managed process ID; use process to inspect, wait for, or stop them. Set "
-            "`background=true` only for a server or service that must remain running. "
-            "`timeout` is a foreground hard deadline. Do not use shell `&`, `nohup`, "
-            "or `disown`."
+            f"Run one shell command in {shell_name}. Keep finite commands whose "
+            "result or exit status matters in the foreground. Omit `timeout` for "
+            "ordinary commands, including builds, tests, installs, downloads, "
+            "compilation, training, and scripts, even when they may be slow; long "
+            "foreground commands auto-yield a managed process ID for process "
+            "wait/status. Set `background=true` only for a server or service that "
+            "must remain running. Use `timeout` only when the user explicitly "
+            "requests a hard deadline or when intentionally bounding disposable "
+            "exploratory work whose termination is acceptable. Timeout expiry "
+            "terminates the process group; inspect useful partial output or "
+            "artifacts, and complete required work without blindly repeating the "
+            "destructive deadline. Do not use shell `&`, `nohup`, or `disown`."
         ),
         input_schema={
             "type": "object",

--- a/src/fast_agent/ui/prompt/command_help.py
+++ b/src/fast_agent/ui/prompt/command_help.py
@@ -106,6 +106,7 @@ def render_help_lines(*, show_webclear_help: bool) -> list[str]:
             "  Ctrl+Space     - Open completion menu",
             "  Tab / Shift+Tab - Next/previous completion item (when menu is open)",
             "  Shift+Tab      - Cycle service tier (when completion menu is closed)",
+            "  F5             - Cycle mode (Standard / Delegate / Orchestrate / Harness-only)",
             "  F6             - Cycle reasoning (when supported)",
             "  F7             - Cycle verbosity (when supported)",
             "  F8             - Toggle web search (when supported)",

--- a/src/fast_agent/ui/prompt/completion_sources.py
+++ b/src/fast_agent/ui/prompt/completion_sources.py
@@ -62,6 +62,7 @@ def _catalog_action_tokens(command_name: str, action_name: str) -> frozenset[str
 
 
 _SKILLS_ADD_ACTIONS = _catalog_action_tokens("skills", "add")
+_SKILLS_AVAILABLE_ACTIONS = _catalog_action_tokens("skills", "available")
 _SKILLS_REMOVE_ACTIONS = _catalog_action_tokens("skills", "remove")
 _SKILLS_UPDATE_ACTIONS = _catalog_action_tokens("skills", "update")
 _SKILLS_REGISTRY_ACTIONS = _catalog_action_tokens("skills", "registry")
@@ -799,13 +800,23 @@ def _skills_search_completions(
     argument: str,
     results: list[Completion],
 ) -> list[Completion]:
+    results.extend(_catalog_option_completions("skills", "search", argument))
     if not argument:
         results.extend(
             [
-                _hint_completion("<query>", "filter marketplace skills by name/description"),
+                _hint_completion("<query>", "filter available skills by name/description"),
                 _hint_completion("(empty)", "no arg lists all; run /skills available to browse"),
             ]
         )
+    return results
+
+
+def _skills_available_completions(
+    _completer: "AgentCompleter",
+    argument: str,
+    results: list[Completion],
+) -> list[Completion]:
+    results.extend(_catalog_option_completions("skills", "available", argument))
     return results
 
 
@@ -858,6 +869,7 @@ def _skills_registry_completions(
 
 _SKILLS_COMPLETION_DISPATCH: MarketplaceCompletionDispatch = (
     (_SKILLS_ADD_ACTIONS, _skills_add_completions),
+    (_SKILLS_AVAILABLE_ACTIONS, _skills_available_completions),
     (_SKILLS_SEARCH_ACTIONS, _skills_search_completions),
     (_SKILLS_REMOVE_ACTIONS, _skills_remove_completions),
     (_SKILLS_UPDATE_ACTIONS, _skills_update_completions),

--- a/src/fast_agent/ui/prompt/input.py
+++ b/src/fast_agent/ui/prompt/input.py
@@ -33,6 +33,8 @@ from fast_agent.commands.model_capabilities import (
     set_service_tier,
     set_text_verbosity,
 )
+from fast_agent.core.agent_capabilities import cycle_agent_capability_mode
+from fast_agent.core.exceptions import AgentConfigError, format_fast_agent_error
 from fast_agent.core.logging.logger import get_logger
 from fast_agent.mcp.types import McpAgentProtocol
 from fast_agent.ui.agent_identity import is_default_agent_name
@@ -265,6 +267,7 @@ class ResolvedShellInput:
 @dataclass(slots=True)
 class InputCycleCallbacks:
     on_cycle_service_tier: "Callable[[], None]"
+    on_cycle_agent_mode: "Callable[[], None]"
     on_cycle_reasoning: "Callable[[], None]"
     on_cycle_verbosity: "Callable[[], None]"
     on_cycle_web_search: "Callable[[], None]"
@@ -368,6 +371,26 @@ def _cycle_active_llm(
     return resolve_active_llm(agent_provider, agent_name)
 
 
+def _cycle_active_agent(
+    *,
+    agent_name: str,
+    agent_provider: "AgentApp | None",
+) -> object | None:
+    if agent_provider is None:
+        return None
+    try:
+        return agent_provider._agent(agent_name)
+    except Exception:
+        return None
+
+
+def _cycle_agent_mode(agent: object | None) -> None:
+    try:
+        cycle_agent_capability_mode(agent)
+    except AgentConfigError as exc:
+        rich_print(Text(format_fast_agent_error(exc), style="red"))
+
+
 def _cycle_service_tier(llm: "FastAgentLLMProtocol | None") -> None:
     if llm is None or not resolve_service_tier_supported(llm):
         return
@@ -430,6 +453,9 @@ def _build_cycle_callbacks(
     def on_cycle_service_tier() -> None:
         _cycle_service_tier(_cycle_active_llm(agent_name=agent_name, agent_provider=agent_provider))
 
+    def on_cycle_agent_mode() -> None:
+        _cycle_agent_mode(_cycle_active_agent(agent_name=agent_name, agent_provider=agent_provider))
+
     def on_cycle_reasoning() -> None:
         _cycle_reasoning(_cycle_active_llm(agent_name=agent_name, agent_provider=agent_provider))
 
@@ -450,6 +476,7 @@ def _build_cycle_callbacks(
 
     return InputCycleCallbacks(
         on_cycle_service_tier=on_cycle_service_tier,
+        on_cycle_agent_mode=on_cycle_agent_mode,
         on_cycle_reasoning=on_cycle_reasoning,
         on_cycle_verbosity=on_cycle_verbosity,
         on_cycle_web_search=on_cycle_web_search,
@@ -809,6 +836,7 @@ async def get_enhanced_input(
     bindings = create_keybindings(
         on_toggle_multiline=_build_multiline_toggle(session_factory),
         on_cycle_service_tier=cycle_callbacks.on_cycle_service_tier,
+        on_cycle_agent_mode=cycle_callbacks.on_cycle_agent_mode,
         on_cycle_reasoning=cycle_callbacks.on_cycle_reasoning,
         on_cycle_verbosity=cycle_callbacks.on_cycle_verbosity,
         on_cycle_web_search=cycle_callbacks.on_cycle_web_search,

--- a/src/fast_agent/ui/prompt/input_startup.py
+++ b/src/fast_agent/ui/prompt/input_startup.py
@@ -270,6 +270,7 @@ def show_input_help_banner(
         """CTRL+T [dim]multiline, [/dim]CTRL+Y[dim] copy last message, [/dim]CTRL+E[dim] external editor.[/dim]\n"""
         """CTRL+C[dim] to interrupt generation or background waiting, [/dim]CTRL+D[dim] to exit.[/dim]\n"""
         """CTRL+Space[dim] or [/dim]Tab[dim] for path completion.[/dim]\n"""
+        """F5[dim] to cycle subagents and harness tools.[/dim]\n"""
         f"""{attachment_hint} F10[dim] to clear.[/dim]\n"""
         """[dim]Use '[/dim][bold]/[/bold][dim]' for commands, '[/dim][bold]![/bold][dim]' for shell. '[/dim][bold]#[/bold][dim]' to query, '[/dim][bold]@[/bold][dim]' to switch agents[/dim]\n"""
     )

--- a/src/fast_agent/ui/prompt/keybindings.py
+++ b/src/fast_agent/ui/prompt/keybindings.py
@@ -302,11 +302,17 @@ def _add_cycle_keybindings(
     kb: AgentKeyBindings,
     *,
     app: Any | None,
+    on_cycle_agent_mode: Callable[[], None] | None,
     on_cycle_reasoning: Callable[[], None] | None,
     on_cycle_verbosity: Callable[[], None] | None,
     on_cycle_web_search: Callable[[], None] | None,
     on_cycle_web_fetch: Callable[[], None] | None,
 ) -> None:
+    @kb.add("f5")
+    def _(event) -> None:
+        if _invoke_key_callback(on_cycle_agent_mode, event, app):
+            return
+
     @kb.add("f6")
     def _(event) -> None:
         if _invoke_key_callback(on_cycle_reasoning, event, app):
@@ -436,6 +442,7 @@ def create_keybindings(
     app: Any | None = None,
     agent_provider: "AgentApp | None" = None,
     agent_name: str | None = None,
+    on_cycle_agent_mode: Callable[[], None] | None = None,
 ) -> AgentKeyBindings:
     """Create custom key bindings."""
     kb = AgentKeyBindings()
@@ -447,6 +454,7 @@ def create_keybindings(
     _add_cycle_keybindings(
         kb,
         app=app,
+        on_cycle_agent_mode=on_cycle_agent_mode,
         on_cycle_reasoning=on_cycle_reasoning,
         on_cycle_verbosity=on_cycle_verbosity,
         on_cycle_web_search=on_cycle_web_search,

--- a/src/fast_agent/ui/prompt/status_bar/agent_capabilities.py
+++ b/src/fast_agent/ui/prompt/status_bar/agent_capabilities.py
@@ -1,0 +1,27 @@
+"""Agent capability indicator rendering for the TUI toolbar."""
+
+from __future__ import annotations
+
+from fast_agent.core.agent_capabilities import AgentCapabilityMode
+from fast_agent.ui.binary_indicator import (
+    TOOLBAR_BINARY_DISABLED_COLOR,
+    TOOLBAR_BINARY_ENABLED_COLOR,
+    render_glyph_indicator,
+)
+
+SUBAGENT_GLYPH = "↳"
+HARNESS_GLYPH = "⌘"
+
+
+def render_agent_capability_indicator(mode: AgentCapabilityMode) -> str:
+    subagents = mode in {AgentCapabilityMode.DELEGATE, AgentCapabilityMode.ORCHESTRATE}
+    harness = mode in {AgentCapabilityMode.HARNESS_ONLY, AgentCapabilityMode.ORCHESTRATE}
+    subagent_indicator = render_glyph_indicator(
+        glyph=SUBAGENT_GLYPH,
+        color=TOOLBAR_BINARY_ENABLED_COLOR if subagents else TOOLBAR_BINARY_DISABLED_COLOR,
+    )
+    harness_indicator = render_glyph_indicator(
+        glyph=f"{HARNESS_GLYPH} ",
+        color=TOOLBAR_BINARY_ENABLED_COLOR if harness else TOOLBAR_BINARY_DISABLED_COLOR,
+    )
+    return f"{subagent_indicator}{harness_indicator}"

--- a/src/fast_agent/ui/prompt/status_bar/renderer.py
+++ b/src/fast_agent/ui/prompt/status_bar/renderer.py
@@ -25,6 +25,11 @@ from fast_agent.commands.model_capabilities import (
     resolve_web_search_enabled,
     resolve_web_search_supported,
 )
+from fast_agent.core.agent_capabilities import (
+    AgentCapabilityMode,
+    agent_capability_mode_supported,
+    resolve_agent_capability_mode,
+)
 from fast_agent.llm.model_display_name import resolve_model_display_name
 from fast_agent.llm.model_info import ModelInfo
 from fast_agent.llm.provider_types import Provider
@@ -32,6 +37,9 @@ from fast_agent.ui import notification_tracker
 from fast_agent.ui.context_usage_display import (
     ContextUsageAccumulator,
     resolve_context_usage_percent,
+)
+from fast_agent.ui.prompt.status_bar.agent_capabilities import (
+    render_agent_capability_indicator,
 )
 from fast_agent.ui.prompt.status_bar.alert_flags import _resolve_alert_flags_from_history
 from fast_agent.ui.prompt.status_bar.attachment import (
@@ -113,6 +121,7 @@ class ToolbarAgentState:
     service_tier_indicator: str | None = None
     web_search_indicator: str | None = None
     web_fetch_indicator: str | None = None
+    capability_mode: AgentCapabilityMode | None = None
     active_process_count: int = 0
 
 
@@ -398,6 +407,9 @@ def _build_toolbar_agent_state(
         service_tier_indicator=model_visuals.service_tier_indicator,
         web_search_indicator=model_visuals.web_search_indicator,
         web_fetch_indicator=model_visuals.web_fetch_indicator,
+        capability_mode=(
+            resolve_agent_capability_mode(agent) if agent_capability_mode_supported(agent) else None
+        ),
         active_process_count=_active_process_count_for_agent(agent),
     )
 
@@ -434,6 +446,7 @@ def _build_toolbar_agent_state_cache_key(
         _safe_cache_value(resolve_service_tier(llm)),
         _safe_cache_value(resolve_web_search_enabled(llm)),
         _safe_cache_value(resolve_web_fetch_enabled(llm)),
+        (resolve_agent_capability_mode(agent) if agent_capability_mode_supported(agent) else None),
         _active_process_count_for_agent(agent),
         _parallel_fan_out_model_cache_key(agent),
     )
@@ -697,6 +710,11 @@ def _build_middle_segment(
         model_label = f"{model_prefix}{agent_state.model_display}"
         attachment_indicator = render_attachment_indicator(attachment_summary)
         process_indicator = render_managed_process_indicator(agent_state.active_process_count)
+        capability_indicator = (
+            render_agent_capability_indicator(agent_state.capability_mode)
+            if agent_state.capability_mode is not None
+            else ""
+        )
         model_chip = render_model_chip(
             model_label=model_label,
             web_search_indicator=agent_state.web_search_indicator,
@@ -711,7 +729,9 @@ def _build_middle_segment(
         if agent_state.model_gauges:
             prefix += agent_state.model_gauges
         model_segment = f"{prefix} {model_chip}" if prefix else model_chip
-        middle_segments.append(f"{process_indicator}| {model_segment} {context_or_turns}")
+        middle_segments.append(
+            f"{process_indicator}{capability_indicator}| {model_segment} {context_or_turns}"
+        )
     else:
         middle_segments.append(context_or_turns)
     if shortcut_text:

--- a/tests/integration/acp/test_acp_skills_manager.py
+++ b/tests/integration/acp/test_acp_skills_manager.py
@@ -170,7 +170,7 @@ skills:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_skills_add_lists_marketplace(tmp_path: Path) -> None:
+async def test_skills_add_requires_selector(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     skill_dir = repo_root / "skills" / "test-skill"
     skill_dir.mkdir(parents=True)
@@ -219,9 +219,10 @@ skills:
         handler = _handler(instance, "test-agent")
 
         response = await handler.execute_command("skills", "add")
-        assert "test-skill" in response
-        assert escape_markdown_text("MAGIC_SKILL") in response
-        assert repo_root.as_posix() in response
+        assert "A skill selector is required." in response
+        assert (
+            "Browse with `/skills available` or search with `/skills search <query>`." in response
+        )
     finally:
         get_settings(config_path=str(Path(__file__).parent / "fastagent.config.yaml"))
 
@@ -279,7 +280,7 @@ skills:
         response = await handler.execute_command("skills", "available")
         assert "test-skill" in response
         assert escape_markdown_text("MAGIC_SKILL") in response
-        assert repo_root.as_posix() in response
+        assert escape_markdown_text(marketplace_path.as_posix()) in response
     finally:
         get_settings(config_path=str(Path(__file__).parent / "fastagent.config.yaml"))
 

--- a/tests/integration/tools/test_docker_shell_output_spool.py
+++ b/tests/integration/tools/test_docker_shell_output_spool.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 import os
+from typing import TYPE_CHECKING
 
 import pytest
+from mcp_types import TextContent
 
+from fast_agent.config import Settings, ShellSettings
 from fast_agent.tools.docker_shell_environment import DockerShellEnvironment
 from fast_agent.tools.execution_environment import ShellExecutionRequest
+from fast_agent.tools.shell_process import process_result_metadata
+from fast_agent.tools.shell_runtime import ShellRuntime
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pytestmark = pytest.mark.integration
 
@@ -73,3 +83,63 @@ async def test_detached_docker_process_streams_spooled_output() -> None:
         await asyncio.gather(task, return_exceptions=True)
 
     assert request.output_spool_path is None
+
+
+@pytest.mark.asyncio
+async def test_docker_runtime_reads_host_retained_output_through_process(
+    tmp_path: Path,
+) -> None:
+    container = os.getenv("FAST_AGENT_TEST_DOCKER_CONTAINER")
+    if not container:
+        pytest.skip("set FAST_AGENT_TEST_DOCKER_CONTAINER to a running container")
+
+    environment = DockerShellEnvironment(
+        container=container,
+        shell=os.getenv("FAST_AGENT_TEST_DOCKER_SHELL", "sh"),
+        cwd=os.getenv("FAST_AGENT_TEST_DOCKER_CWD", "/tmp"),
+    )
+    runtime = ShellRuntime(
+        activation_reason="docker-retained-output-test",
+        logger=logging.getLogger("docker-retained-output-test"),
+        shell_environment=environment,
+        output_byte_limit=256,
+        config=Settings(
+            shell_execution=ShellSettings(
+                tool_profile="luna_exec",
+                retain_truncated_output=True,
+                retained_output_max_bytes=4096,
+                retained_output_temp_directory=tmp_path,
+            )
+        ),
+    )
+
+    completed = await runtime.call_tool(
+        "exec",
+        {"command": ("python -c \"print('a'*300); print('retained-marker'); print('b'*300)\"")},
+    )
+    metadata = process_result_metadata(completed)
+    assert metadata is not None
+    completed_text = "\n".join(
+        block.text for block in completed.content if isinstance(block, TextContent)
+    )
+    assert str(tmp_path) not in completed_text
+    assert "action='read_output'" in completed_text
+
+    readback = await runtime.call_tool(
+        "process",
+        {
+            "process_id": metadata["process_id"],
+            "action": "read_output",
+            "query": "retained-marker",
+        },
+    )
+    readback_text = "\n".join(
+        block.text for block in readback.content if isinstance(block, TextContent)
+    )
+    payload = json.loads(readback_text)
+
+    assert readback.is_error is False
+    assert payload["match_count"] == 1
+    assert payload["content"] == "retained-marker\n"
+
+    await runtime.close()

--- a/tests/unit/fast_agent/acp/test_slash_commands_mcp.py
+++ b/tests/unit/fast_agent/acp/test_slash_commands_mcp.py
@@ -257,7 +257,7 @@ async def test_slash_command_mcp_inventory_status_attach_connect_reconnect_disco
     assert "Connected MCP server 'demo'" in connected
 
     alias_connected = await handler.execute_command("connect", "docs")
-    assert "Connected configured MCP server 'docs'." in alias_connected
+    assert "Connected configured MCP server 'docs' via stdio." in alias_connected
     assert app.attached_configs[-1] is None
 
     explicit_connected = await handler.execute_command("mcp", "connect docs")

--- a/tests/unit/fast_agent/acp/test_slash_skills_commands.py
+++ b/tests/unit/fast_agent/acp/test_slash_skills_commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
@@ -73,6 +74,18 @@ class _App:
     pass
 
 
+def _slash_handler() -> SlashCommandHandler:
+    return SlashCommandHandler(
+        session_id="s1",
+        instance=AgentInstance(
+            app=cast("AgentApp", _App()),
+            agents={},
+            registry_version=0,
+        ),
+        primary_agent_name="main",
+    )
+
+
 class _SkillsOverrideHandler:
     def __init__(self, agent: object) -> None:
         self.agent = agent
@@ -121,20 +134,18 @@ async def test_handle_skills_accepts_help_alias() -> None:
 
 @pytest.mark.asyncio
 async def test_handle_skills_accepts_available_alias(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    called_urls: list[str] = []
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text('{"plugins": []}', encoding="utf-8")
 
-    async def fetch_marketplace(url: str) -> list[MarketplaceSkill]:
-        called_urls.append(url)
-        return []
+    message = await handle_skills(
+        _slash_handler(),
+        f"marketplace --registry {marketplace_path}",
+    )
 
-    monkeypatch.setattr(skills_handler_module, "fetch_marketplace_skills", fetch_marketplace)
-
-    message = await handle_skills(cast("SlashCommandHandler", None), "marketplace")
-
-    assert called_urls
-    assert message == "# skills available\n\nNo skills found in the marketplace."
+    assert message.startswith("# skills available")
+    assert "No skills found in the registry." in message
 
 
 @pytest.mark.asyncio
@@ -173,32 +184,52 @@ async def test_handle_skills_search_escapes_backticks_in_no_match_query(
 
 @pytest.mark.asyncio
 async def test_handle_skills_search_consumes_registry_option(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    captured_url: str | None = None
-
-    async def fetch_marketplace(url: str) -> list[MarketplaceSkill]:
-        nonlocal captured_url
-        captured_url = url
-        return [
-            MarketplaceSkill(
-                name="alpha",
-                description=None,
-                repo_url="https://github.com/example/skills",
-                repo_ref="main",
-                repo_path="skills/alpha",
-            )
-        ]
-
-    monkeypatch.setattr(skills_handler_module, "fetch_marketplace_skills", fetch_marketplace)
-
-    message = await handle_skills(
-        cast("SlashCommandHandler", None),
-        "search alpha --registry ./marketplace.json",
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text(
+        json.dumps(
+            {
+                "plugins": [
+                    {
+                        "name": "alpha",
+                        "repo_url": "https://github.com/example/skills",
+                        "repo_ref": "main",
+                        "repo_path": "skills/alpha",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
     )
 
-    assert captured_url == "./marketplace.json"
+    message = await handle_skills(
+        _slash_handler(),
+        f"search alpha --registry {marketplace_path}",
+    )
+
     assert "alpha" in message
+
+
+@pytest.mark.parametrize(
+    ("arguments", "error"),
+    [
+        ("available --page 0 --json", "Invalid value for --page"),
+        ("available stray --json", "Usage: /skills available"),
+        ('available --json "', "Invalid /skills arguments"),
+        ("search --json", "Usage: /skills search"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_skills_catalog_validation_errors_honor_json(
+    arguments: str,
+    error: str,
+) -> None:
+    response = await handle_skills(_slash_handler(), arguments)
+
+    payload = json.loads(response)
+    assert payload["kind"] == "error"
+    assert error in payload["error"]
 
 
 @pytest.mark.asyncio
@@ -242,15 +273,7 @@ async def test_handle_skills_registry_uses_shared_registry_resolution(
         "fetch_marketplace_skills_with_source",
         fetch_marketplace,
     )
-    handler = SlashCommandHandler(
-        session_id="s1",
-        instance=AgentInstance(
-            app=cast("AgentApp", _App()),
-            agents={},
-            registry_version=0,
-        ),
-        primary_agent_name="main",
-    )
+    handler = _slash_handler()
 
     try:
         message = await handle_skills_registry(handler, "2")
@@ -265,25 +288,14 @@ async def test_handle_skills_registry_uses_shared_registry_resolution(
 
 
 @pytest.mark.asyncio
-async def test_bare_skills_add_browses_marketplace_without_install_tool_call(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_bare_skills_add_requires_selector_without_install_tool_call() -> None:
     acp = _RecordingACPContext()
     handler = _SkillsAddHandler(_ACPAwareAgent(acp))
 
-    async def render_marketplace(*, registry: str | None = None) -> str:
-        del registry
-        return "# skills add\n\nMarketplace"
-
-    monkeypatch.setattr(
-        skills_handler_module,
-        "_render_skills_add_marketplace",
-        render_marketplace,
-    )
-
     message = await handle_skills_add(cast("SlashCommandHandler", handler), "")
 
-    assert message == "# skills add\n\nMarketplace"
+    assert "A skill selector is required." in message
+    assert "/skills available" in message
     assert acp.updates == []
 
 

--- a/tests/unit/fast_agent/commands/test_command_discovery.py
+++ b/tests/unit/fast_agent/commands/test_command_discovery.py
@@ -30,6 +30,7 @@ def test_render_command_detail_markdown_contains_registry_action() -> None:
     assert rendered is not None
     assert "`registry`" in rendered
     assert "/skills registry [<number|url|path|mcp-server>]" in rendered
+    assert "`target` (`number|url|path|mcp-server`)" in rendered
 
 
 def test_render_commands_json_detail_has_schema_version() -> None:
@@ -54,8 +55,8 @@ def test_render_commands_json_action_detail_has_schema_version() -> None:
     assert '"schema_version": "1"' in rendered
     assert '"kind": "command_action_detail"' in rendered
     assert (
-        '"/skills add [<number|name|github-url|path>] [--registry url] [--skills-dir path]"'
-        in rendered
+        '"/skills add <number|name|github-url|path> '
+        '[--registry url|path|mcp-server] [--skills-dir path]"' in rendered
     )
     assert '"name": "--skills-dir"' in rendered
 
@@ -86,3 +87,68 @@ def test_render_commands_index_markdown_has_tree_actions() -> None:
     assert "- `/cards`" not in rendered
     assert "- `/models`" not in rendered
     assert "  - list, available, search, add, remove, update, registry, help" in rendered
+
+
+def test_render_mcp_action_detail_contains_executable_contract() -> None:
+    rendered = render_command_detail_markdown("mcp", "attach")
+
+    assert rendered is not None
+    assert "Usage: `/mcp attach <server-name>`" in rendered
+    assert "`server_name` (`server-name`)" in rendered
+    assert "Run /mcp list" in rendered
+
+
+def test_render_mcp_connect_detail_contains_model_restrictions() -> None:
+    rendered = render_command_detail_markdown("mcp", "connect", model_facing=True)
+
+    assert rendered is not None
+    assert "`--no-oauth`" in rendered
+    assert "--oauth" not in rendered
+    assert "`--protocol auto|modern|legacy`" in rendered
+    assert "Interactive OAuth" in rendered
+    assert "stdio targets require shell access" in rendered
+
+
+def test_render_mcp_connect_detail_keeps_interactive_oauth_for_shared_surfaces() -> None:
+    rendered = render_command_detail_markdown("mcp", "connect")
+
+    assert rendered is not None
+    assert "`--oauth`" in rendered
+    assert "model-facing commands" not in rendered
+
+
+def test_filtered_discovery_includes_status_and_scopes_unknown_suggestions() -> None:
+    command_names = {"commands", "mcp", "status"}
+
+    index = render_commands_index_markdown(command_names=command_names)
+    unknown = render_commands_json(command_name="missing", command_names=command_names)
+
+    assert "- `/status`" in index
+    assert '"suggestions": [' in unknown
+    assert '"commands"' in unknown
+    assert '"mcp"' in unknown
+    assert '"status"' in unknown
+    assert '"packs"' not in unknown
+
+
+def test_model_skills_discovery_exposes_registry_browse_without_ambiguous_add() -> None:
+    available = render_command_detail_markdown(
+        "skills",
+        "available",
+        model_facing=True,
+    )
+    add = render_commands_json(
+        command_name="skills",
+        action_name="add",
+        model_facing=True,
+    )
+
+    assert available is not None
+    assert "`--registry url|path|mcp-server`, `-r`" in available
+    assert "`--compact`" in available
+    assert "`--json`" in available
+    assert "--full" not in available
+    assert "default to compact output" in available
+    assert '"/skills add <number|name|github-url|path>' in add
+    assert '"required": true' in add
+    assert "A selector is required for model-facing installation." in add

--- a/tests/unit/fast_agent/commands/test_context.py
+++ b/tests/unit/fast_agent/commands/test_context.py
@@ -1,6 +1,32 @@
+import gc
+import weakref
+from dataclasses import dataclass
+
 import pytest
 
-from fast_agent.commands.context import StaticAgentProvider
+from fast_agent.commands.context import (
+    CommandContext,
+    NonInteractiveCommandIOBase,
+    StaticAgentProvider,
+)
+
+
+@dataclass
+class _UnhashableProvider(StaticAgentProvider):
+    pass
+
+
+def _context(
+    provider: StaticAgentProvider,
+    *,
+    acp_session_id: str | None = None,
+) -> CommandContext:
+    return CommandContext(
+        agent_provider=provider,
+        current_agent_name="main",
+        io=NonInteractiveCommandIOBase(),
+        acp_session_id=acp_session_id,
+    )
 
 
 def test_static_agent_provider_exposes_mapping_backed_agents() -> None:
@@ -18,3 +44,53 @@ async def test_static_agent_provider_list_prompts_defaults_to_empty_mapping() ->
     provider = StaticAgentProvider()
 
     assert await provider.list_prompts(namespace=None) == {}
+
+
+def test_skill_source_override_persists_for_provider_lifetime() -> None:
+    provider = StaticAgentProvider()
+    _context(provider).set_active_skill_source("main", "mcp://skills")
+
+    assert _context(provider).active_skill_source("main") == "mcp://skills"
+    assert _context(StaticAgentProvider()).active_skill_source("main") is None
+
+
+def test_skill_source_override_supports_unhashable_provider() -> None:
+    provider = _UnhashableProvider()
+    context = _context(provider)
+
+    context.set_active_skill_source("main", "mcp://skills")
+
+    assert context.active_skill_source("main") == "mcp://skills"
+
+
+def test_skill_source_override_does_not_retain_provider() -> None:
+    provider = StaticAgentProvider()
+    provider_ref = weakref.ref(provider)
+    context = _context(provider)
+    context.set_active_skill_source("main", "mcp://skills")
+
+    del context, provider
+    gc.collect()
+
+    assert provider_ref() is None
+
+
+def test_skill_source_override_persists_for_acp_session() -> None:
+    _context(StaticAgentProvider(), acp_session_id="session-1").set_active_skill_source(
+        "main", "mcp://skills"
+    )
+
+    assert (
+        _context(
+            StaticAgentProvider(),
+            acp_session_id="session-1",
+        ).active_skill_source("main")
+        == "mcp://skills"
+    )
+    assert (
+        _context(
+            StaticAgentProvider(),
+            acp_session_id="session-2",
+        ).active_skill_source("main")
+        is None
+    )

--- a/tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py
+++ b/tests/unit/fast_agent/commands/test_mcp_runtime_handlers.py
@@ -182,6 +182,26 @@ class _AlreadyAttachedManager(_Manager):
         )
 
 
+class _SkillsManager(_Manager):
+    async def attach_mcp_server(self, agent_name, server_name, server_config=None, options=None):
+        result = await super().attach_mcp_server(
+            agent_name,
+            server_name,
+            server_config=server_config,
+            options=options,
+        )
+        return MCPAttachResult(
+            server_name=result.server_name,
+            transport=result.transport,
+            attached=result.attached,
+            already_attached=result.already_attached,
+            tools_added=result.tools_added,
+            prompts_added=result.prompts_added,
+            warnings=result.warnings,
+            skills_total=25,
+        )
+
+
 class _OAuthEventManager(_Manager):
     async def attach_mcp_server(self, agent_name, server_name, server_config=None, options=None):
         if options and options.oauth_event_handler is not None:
@@ -353,6 +373,39 @@ def test_runtime_rejects_missing_auth_env_reference(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_mcp_attach_reports_transport_and_reconnect_recovery() -> None:
+    manager = _AlreadyAttachedManager()
+    ctx = CommandContext(agent_provider=_Provider(), current_agent_name="main", io=_IO())
+
+    outcome = await mcp_runtime.handle_mcp_attach(
+        ctx,
+        manager=cast("mcp_runtime.McpRuntimeManager", manager),
+        agent_name="main",
+        server_name="docs server",
+    )
+
+    message_text = "\n".join(str(message.text) for message in outcome.messages)
+    assert "already attached via stdio" in message_text
+    assert "/mcp reconnect 'docs server'" in message_text
+
+
+@pytest.mark.asyncio
+async def test_handle_mcp_attach_points_to_one_shot_skills_registry_browse() -> None:
+    manager = _SkillsManager()
+    ctx = CommandContext(agent_provider=_Provider(), current_agent_name="main", io=_IO())
+
+    outcome = await mcp_runtime.handle_mcp_attach(
+        ctx,
+        manager=cast("mcp_runtime.McpRuntimeManager", manager),
+        agent_name="main",
+        server_name="docs server",
+    )
+
+    message_text = "\n".join(str(message.text) for message in outcome.messages)
+    assert "/skills available --registry 'mcp://docs server'" in message_text
+
+
+@pytest.mark.asyncio
 async def test_handle_mcp_connect_and_disconnect() -> None:
     manager = _Manager()
     ctx = CommandContext(agent_provider=_Provider(), current_agent_name="main", io=_IO())
@@ -401,7 +454,7 @@ async def test_handle_mcp_reconnect_attached_server() -> None:
     )
 
     message_text = "\n".join(str(message.text) for message in outcome.messages)
-    assert "Reconnected MCP server 'demo'." in message_text
+    assert "Reconnected MCP server 'demo' via stdio." in message_text
     assert outcome.messages[0].metadata["mcp_connect_status"] == "reconnected"
     assert "Refreshed 2 tools and 4 prompts (0 new)." in message_text
     assert manager.last_options is not None
@@ -503,7 +556,8 @@ async def test_connect_alias_attaches_matching_central_config() -> None:
     )
 
     assert any(
-        "Attached configured MCP server 'docs': https://docs.example.com/mcp." in str(msg.text)
+        "Attached configured MCP server 'docs' via stdio: https://docs.example.com/mcp."
+        in str(msg.text)
         for msg in attach_outcome.messages
     )
     assert manager.last_config is None
@@ -517,7 +571,7 @@ async def test_connect_alias_attaches_matching_central_config() -> None:
     )
 
     assert any(
-        "Connected configured MCP server 'docs'." in str(msg.text)
+        "Connected configured MCP server 'docs' via stdio." in str(msg.text)
         for msg in connect_outcome.messages
     )
     assert manager.last_config is None
@@ -650,7 +704,8 @@ async def test_connect_alias_attaches_configured_name_that_looks_like_target_syn
     )
 
     assert any(
-        "Connected configured MCP server 'npx'." in str(msg.text) for msg in outcome.messages
+        "Connected configured MCP server 'npx' via stdio." in str(msg.text)
+        for msg in outcome.messages
     )
     assert manager.last_config is None
 

--- a/tests/unit/fast_agent/commands/test_skills_markdown.py
+++ b/tests/unit/fast_agent/commands/test_skills_markdown.py
@@ -73,7 +73,7 @@ def test_render_skills_by_directory_emits_browse_guidance_once(tmp_path: Path) -
     manifests = SkillRegistry.load_directory(skills_root)
     rendered = render_skills_by_directory({skills_root: manifests}, heading="skills", cwd=tmp_path)
 
-    assert rendered.count("Use `/skills available` to browse marketplace skills.") == 1
+    assert rendered.count("Use `/skills available` to browse available skills.") == 1
     assert rendered.count("Search with `/skills search <query>`.") == 1
 
 
@@ -142,8 +142,8 @@ def test_render_marketplace_skills_footer_has_clean_guidance() -> None:
         heading="skills available",
     )
 
-    assert "Search with `/skills search <query>`.\n" in rendered
-    assert "Search with `/skills search <query>`. \n" not in rendered
+    assert "Search available skills with `/skills search <query>`.\n" in rendered
+    assert "Search available skills with `/skills search <query>`. \n" not in rendered
     assert "Change registry with `/skills registry`." in rendered
 
 

--- a/tests/unit/fast_agent/commands/test_skills_mcp_registry_handlers.py
+++ b/tests/unit/fast_agent/commands/test_skills_mcp_registry_handlers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from hashlib import sha256
 
 import pytest
@@ -14,6 +15,7 @@ from fast_agent.commands.handlers.skills import (
     _format_install_result,
     handle_list_marketplace_skills,
     handle_set_skills_registry,
+    handle_skills_command,
     handle_update_skill,
 )
 from fast_agent.config import Settings, SkillsSettings
@@ -79,6 +81,30 @@ class _Agent:
     aggregator = _Aggregator()
 
 
+class _ManyAggregator(_Aggregator):
+    async def list_mcp_skill_registries(self) -> list[McpSkillRegistry]:
+        return [
+            McpSkillRegistry(
+                server_name="hf",
+                server_version="1.2.3",
+                skills=[
+                    McpRegistrySkill(
+                        name=f"skill-{index:02}",
+                        description=(f"Description for skill {index}. " * 30),
+                        uri=f"skill://skill-{index:02}/SKILL.md",
+                        server_name="hf",
+                        server_version="1.2.3",
+                    )
+                    for index in range(1, 26)
+                ],
+            )
+        ]
+
+
+class _ManyAgent:
+    aggregator = _ManyAggregator()
+
+
 def _ctx(
     settings: Settings,
     *,
@@ -134,7 +160,7 @@ async def test_skills_registry_can_select_mcp_server_by_name() -> None:
     assert settings.skills.marketplace_url is None
     assert ctx.active_skill_source("main") == "mcp://hf"
     assert "Registry set to: mcp-server hf@1.2.3" in rendered
-    assert "Skills discovered: 1. Use /skills add to list." in rendered
+    assert "Skills discovered: 1. Browse with /skills available." in rendered
 
 
 @pytest.mark.asyncio
@@ -204,6 +230,163 @@ async def test_skills_available_uses_selected_mcp_registry() -> None:
     assert "hub-search" in rendered
     assert "integrity: SHA-256 manifest; checked on install" in rendered
     assert "They do not verify the server or publisher" in rendered
+
+
+@pytest.mark.asyncio
+async def test_skills_available_uses_one_shot_mcp_registry_without_changing_active_source() -> None:
+    settings = Settings()
+    ctx = _ctx(settings)
+
+    outcome = await handle_list_marketplace_skills(
+        ctx,
+        agent_name="main",
+        marketplace_url_override="hf",
+        output="compact",
+    )
+
+    rendered = "\n".join(_plain(message.text) for message in outcome.messages)
+    assert "Source: mcp-server hf@1.2.3" in rendered
+    assert "hub-search" in rendered
+    assert ctx.active_skill_source("main") is None
+    assert settings.skills.marketplace_url is None
+
+
+@pytest.mark.asyncio
+async def test_model_skills_available_is_compact_complete_and_bounded() -> None:
+    settings = Settings()
+    ctx = _ctx(
+        settings,
+        agent_provider=StaticAgentProvider({"main": _ManyAgent()}),
+    )
+
+    outcome = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="available",
+        argument="--registry hf",
+        interactive=False,
+    )
+
+    rendered = "\n".join(_plain(message.text) for message in outcome.messages)
+    assert "Showing 1-25 of 25 skills." in rendered
+    assert "skill-01" in rendered
+    assert "skill-25" in rendered
+    assert "Install: /skills add <number|name> --registry mcp://hf" in rendered
+    assert rendered.count("/skills add <number|name> --registry mcp://hf") == 1
+    assert len(rendered) < 16_000
+    assert ctx.active_skill_source("main") is None
+
+
+@pytest.mark.asyncio
+async def test_skills_available_json_is_paginated_and_machine_readable() -> None:
+    ctx = _ctx(
+        Settings(),
+        agent_provider=StaticAgentProvider({"main": _ManyAgent()}),
+    )
+
+    outcome = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="available",
+        argument="--registry hf --limit 10 --json",
+        interactive=False,
+    )
+
+    assert outcome.direct_response is not None
+    payload = json.loads(outcome.direct_response)
+    assert payload["kind"] == "skill_catalog"
+    assert payload["source"]["server_name"] == "hf"
+    assert payload["total"] == 25
+    assert payload["next_page"] == 2
+    assert len(payload["skills"]) == 10
+    assert payload["commands"]["install"] == "/skills add <number|name> --registry mcp://hf"
+    assert "--page 2" in payload["commands"]["next_page"]
+
+
+@pytest.mark.asyncio
+async def test_skills_json_remains_structured_for_empty_and_error_results() -> None:
+    ctx = _ctx(
+        Settings(),
+        agent_provider=StaticAgentProvider({"main": _ManyAgent()}),
+    )
+
+    empty = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="search",
+        argument="missing --registry hf --json",
+        interactive=False,
+    )
+    unavailable = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="available",
+        argument="--registry mcp://missing --json",
+        interactive=False,
+    )
+    invalid = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="available",
+        argument="--page 0 --json",
+        interactive=False,
+    )
+    unbounded = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="available",
+        argument="--registry hf --full",
+        interactive=False,
+    )
+
+    assert empty.direct_response is not None
+    empty_payload = json.loads(empty.direct_response)
+    assert empty_payload["skills"] == []
+    assert empty_payload["next_page"] is None
+    assert unavailable.direct_response is not None
+    assert json.loads(unavailable.direct_response)["kind"] == "error"
+    assert invalid.direct_response is not None
+    assert json.loads(invalid.direct_response)["kind"] == "error"
+    assert unbounded.direct_response is not None
+    assert json.loads(unbounded.direct_response)["kind"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_skills_search_accepts_one_shot_mcp_registry() -> None:
+    ctx = _ctx(
+        Settings(),
+        agent_provider=StaticAgentProvider({"main": _ManyAgent()}),
+    )
+
+    outcome = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="search",
+        argument="skill-12 --registry hf",
+        interactive=False,
+    )
+
+    rendered = "\n".join(_plain(message.text) for message in outcome.messages)
+    assert "12. skill-12" in rendered
+    assert "skill-11" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_model_skills_add_requires_selector_instead_of_listing_catalog() -> None:
+    ctx = _ctx(Settings())
+
+    outcome = await handle_skills_command(
+        ctx,
+        agent_name="main",
+        action="add",
+        argument="--registry hf",
+        interactive=False,
+    )
+
+    rendered = "\n".join(_plain(message.text) for message in outcome.messages)
+    assert "selector is required" in rendered
+    assert "/skills available --registry hf" in rendered
+    assert "MCP skills from" not in rendered
 
 
 def test_mcp_install_result_qualifies_integrity_check(tmp_path) -> None:

--- a/tests/unit/fast_agent/core/test_agent_capabilities.py
+++ b/tests/unit/fast_agent/core/test_agent_capabilities.py
@@ -1,0 +1,59 @@
+import pytest
+
+from fast_agent.agents.agent_types import AgentConfig
+from fast_agent.agents.tool_agent import ToolAgent
+from fast_agent.core.agent_capabilities import (
+    AgentCapabilityMode,
+    cycle_agent_capability_mode,
+    resolve_agent_capability_mode,
+)
+from fast_agent.core.exceptions import AgentConfigError
+from fast_agent.core.harness_tools import set_harness_tools
+from fast_agent.tools.function_tool_loader import build_default_function_tool
+
+
+def test_agent_capability_mode_cycles_all_four_states() -> None:
+    agent = ToolAgent(AgentConfig("dev"))
+
+    assert resolve_agent_capability_mode(agent) is AgentCapabilityMode.STANDARD
+    assert cycle_agent_capability_mode(agent) is AgentCapabilityMode.DELEGATE
+    assert cycle_agent_capability_mode(agent) is AgentCapabilityMode.ORCHESTRATE
+    assert cycle_agent_capability_mode(agent) is AgentCapabilityMode.HARNESS_ONLY
+    assert cycle_agent_capability_mode(agent) is AgentCapabilityMode.STANDARD
+
+
+def test_agent_capability_mode_cycles_harness_only_to_standard() -> None:
+    agent = ToolAgent(AgentConfig("dev", harness_tools=True))
+    set_harness_tools(agent)
+
+    assert resolve_agent_capability_mode(agent) is AgentCapabilityMode.HARNESS_ONLY
+    assert cycle_agent_capability_mode(agent) is AgentCapabilityMode.STANDARD
+
+
+def test_agent_capability_mode_respects_explicit_subagent_disable() -> None:
+    agent = ToolAgent(AgentConfig("dev", subagents=False))
+
+    with pytest.raises(AgentConfigError, match="disabled by configuration"):
+        cycle_agent_capability_mode(agent)
+
+    assert resolve_agent_capability_mode(agent) is AgentCapabilityMode.STANDARD
+    assert agent.config.subagent_activation_source == "configuration"
+
+
+def test_agent_capability_mode_preserves_user_subagent_tool() -> None:
+    def subagent() -> str:
+        return "custom"
+
+    custom_tool = build_default_function_tool(subagent)
+    agent = ToolAgent(AgentConfig("dev"), tools=[custom_tool])
+
+    with pytest.raises(AgentConfigError, match="built-in subagent tool is unavailable"):
+        cycle_agent_capability_mode(agent)
+
+    assert agent._execution_tools["subagent"] is custom_tool
+
+
+def test_agent_capability_mode_is_unavailable_to_tool_only_agents() -> None:
+    agent = ToolAgent(AgentConfig("dev", tool_only=True))
+
+    assert cycle_agent_capability_mode(agent) is AgentCapabilityMode.STANDARD

--- a/tests/unit/fast_agent/core/test_harness_tools.py
+++ b/tests/unit/fast_agent/core/test_harness_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -14,10 +15,12 @@ from fast_agent.core.harness_tools import (
     GET_RESOURCE_TOOL_NAME,
     HARNESS_TOOL_NAMES,
     SLASH_COMMAND_TOOL_NAME,
+    harness_tools_enabled,
     set_harness_tools,
 )
 from fast_agent.mcp.helpers.content_helpers import get_text
 from fast_agent.mcp.mcp_aggregator import MCPAttachResult, MCPDetachResult
+from fast_agent.skills.mcp_registry import McpRegistrySkill, McpSkillRegistry
 from fast_agent.tools.function_tool_loader import build_default_function_tool
 
 if TYPE_CHECKING:
@@ -86,11 +89,38 @@ class _SimulatedMcpAgent(McpAgent):
         return list(self.attached_servers)
 
 
+class _SkillsCatalogAggregator:
+    async def list_mcp_skill_registries(self) -> list[McpSkillRegistry]:
+        return [
+            McpSkillRegistry(
+                server_name="hf",
+                server_version="1.0",
+                skills=[
+                    McpRegistrySkill(
+                        name=f"skill-{index:02}",
+                        description=f"Skill {index} description. " * 30,
+                        uri=f"skill://skill-{index:02}/SKILL.md",
+                        server_name="hf",
+                    )
+                    for index in range(1, 26)
+                ],
+            )
+        ]
+
+
+class _SkillsCatalogAgent(ToolAgent):
+    @property
+    def aggregator(self) -> _SkillsCatalogAggregator:
+        return _SkillsCatalogAggregator()
+
+
 @pytest.mark.asyncio
 async def test_harness_tools_install_execute_and_disable() -> None:
     agent = ToolAgent(AgentConfig("dev", instruction="System details", harness_tools=True))
 
+    assert not harness_tools_enabled(agent)
     assert set_harness_tools(agent, True)
+    assert harness_tools_enabled(agent)
     assert HARNESS_TOOL_NAMES <= _tool_names(agent)
     assert agent._execution_tools[SLASH_COMMAND_TOOL_NAME].parameters["properties"]["command"] == {
         "type": "string"
@@ -112,7 +142,34 @@ async def test_harness_tools_install_execute_and_disable() -> None:
     assert "/usage" in commands_text
     assert "/mcp" in commands_text
     assert "/skills" in commands_text
+    assert "/status" in commands_text
     assert "AgentCard" in resource_text
+
+    for command, expected in (
+        ("/commands mcp", "Usage: `/mcp"),
+        ("/commands mcp attach", "Usage: `/mcp attach <server-name>`"),
+        ("/commands --json", '"kind": "command_index"'),
+        ("/commands mcp attach --json", '"kind": "command_action_detail"'),
+    ):
+        discovered = await agent.call_tool(SLASH_COMMAND_TOOL_NAME, {"command": command})
+        discovered_text = get_text(discovered.content[0])
+        assert not discovered.is_error
+        assert discovered_text is not None
+        assert expected in discovered_text
+
+    async def echo(value: str) -> str:
+        return value
+
+    agent.add_tool(build_default_function_tool(echo))
+    tool_detail = await agent.call_tool(
+        SLASH_COMMAND_TOOL_NAME,
+        {"command": "/tools echo"},
+    )
+    tool_detail_text = get_text(tool_detail.content[0])
+    assert not tool_detail.is_error
+    assert tool_detail_text is not None
+    assert "# Tool schema: echo" in tool_detail_text
+    assert '"value"' in tool_detail_text
 
     for command, expected in (
         ("/usage", "No usage data available."),
@@ -162,6 +219,7 @@ async def test_harness_tools_install_execute_and_disable() -> None:
     assert "/skills \\[list|available|search|add|remove|update|registry|help\\]" in skills_help_text
 
     assert not set_harness_tools(agent, False)
+    assert not harness_tools_enabled(agent)
     assert HARNESS_TOOL_NAMES.isdisjoint(_tool_names(agent))
 
 
@@ -178,6 +236,7 @@ async def test_harness_tools_manage_mcp_servers() -> None:
     assert not connected.is_error
     assert connected_text is not None
     assert "Connected MCP server 'demo'" in connected_text
+    assert "(npx)" in connected_text
     assert agent.attached_servers == ["demo"]
     assert agent.last_server_config is not None
     assert agent.last_options is not None
@@ -216,6 +275,7 @@ async def test_harness_tools_manage_mcp_servers() -> None:
     assert not reconnected.is_error
     assert reconnected_text is not None
     assert "Reconnected MCP server 'demo'" in reconnected_text
+    assert "via stdio" in reconnected_text
 
     disconnected = await agent.call_tool(
         SLASH_COMMAND_TOOL_NAME,
@@ -226,6 +286,69 @@ async def test_harness_tools_manage_mcp_servers() -> None:
     assert disconnected_text is not None
     assert "Disconnected MCP server 'demo'" in disconnected_text
     assert agent.attached_servers == []
+
+
+@pytest.mark.asyncio
+async def test_harness_command_discovery_drilldowns_are_available() -> None:
+    agent = ToolAgent(AgentConfig("dev", harness_tools=True))
+    set_harness_tools(agent, True)
+
+    index = await agent.call_tool(
+        SLASH_COMMAND_TOOL_NAME,
+        {"command": "/commands --json"},
+    )
+    index_text = get_text(index.content[0])
+    assert not index.is_error
+    assert index_text is not None
+    payload = json.loads(index_text)
+    assert isinstance(payload, dict)
+    assert '"name": "--oauth"' not in index_text
+    assert '"name": "--no-oauth"' in index_text
+    commands = payload["commands"]
+    assert isinstance(commands, list)
+
+    for command_entry in commands:
+        assert isinstance(command_entry, dict)
+        command_name = command_entry["name"]
+        assert isinstance(command_name, str)
+        detail = await agent.call_tool(
+            SLASH_COMMAND_TOOL_NAME,
+            {"command": f"/commands {command_name}"},
+        )
+        assert not detail.is_error, get_text(detail.content[0])
+
+        actions = command_entry["actions"]
+        assert isinstance(actions, list)
+        for action_entry in actions:
+            assert isinstance(action_entry, dict)
+            action_name = action_entry["name"]
+            assert isinstance(action_name, str)
+            action_detail = await agent.call_tool(
+                SLASH_COMMAND_TOOL_NAME,
+                {"command": f"/commands {command_name} {action_name}"},
+            )
+            assert not action_detail.is_error, get_text(action_detail.content[0])
+
+
+@pytest.mark.asyncio
+async def test_harness_skills_catalog_supports_one_shot_mcp_json() -> None:
+    agent = _SkillsCatalogAgent(AgentConfig("dev", harness_tools=True))
+    set_harness_tools(agent, True)
+
+    result = await agent.call_tool(
+        SLASH_COMMAND_TOOL_NAME,
+        {"command": ("/skills available --registry hf --limit 10 --page 2 --json")},
+    )
+    result_text = get_text(result.content[0])
+
+    assert not result.is_error
+    assert result_text is not None
+    payload = json.loads(result_text)
+    assert payload["source"]["server_name"] == "hf"
+    assert payload["page"] == 2
+    assert payload["total"] == 25
+    assert payload["skills"][0]["name"] == "skill-11"
+    assert not result_text.startswith("# skills")
 
 
 @pytest.mark.asyncio
@@ -340,6 +463,7 @@ def test_harness_tools_do_not_replace_user_tools() -> None:
     with pytest.raises(AgentConfigError, match="reserved"):
         set_harness_tools(agent, True)
 
+    assert agent.config.harness_tools is False
     assert SLASH_COMMAND_TOOL_NAME in _tool_names(agent)
 
 

--- a/tests/unit/fast_agent/skills/test_command_support.py
+++ b/tests/unit/fast_agent/skills/test_command_support.py
@@ -5,9 +5,12 @@ from fast_agent.skills.command_support import (
     filter_marketplace_skills,
     marketplace_repository_hint,
     marketplace_search_tokens,
+    parse_skills_catalog_options,
     parse_skills_slash_options,
     skills_usage_lines,
 )
+from fast_agent.skills.configuration import format_marketplace_display_url
+from fast_agent.skills.marketplace_source import MarketplaceSkillSource
 from fast_agent.skills.models import MarketplaceSkill
 
 
@@ -105,6 +108,65 @@ def test_parse_skills_slash_options_reports_split_errors() -> None:
     parsed = parse_skills_slash_options('alpha "unterminated')
 
     assert parsed.error == "Invalid /skills arguments: No closing quotation"
+
+
+def test_parse_skills_catalog_options_supports_registry_paging_and_json() -> None:
+    parsed = parse_skills_catalog_options(
+        'image "model trainer" --registry hf --page 2 --limit 25 --json'
+    )
+
+    assert parsed.error is None
+    assert parsed.argument == "image 'model trainer'"
+    assert parsed.registry == "hf"
+    assert parsed.page == 2
+    assert parsed.page_explicit is True
+    assert parsed.limit == 25
+    assert parsed.output == "json"
+
+
+def test_parse_skills_catalog_options_preserves_json_on_split_error() -> None:
+    parsed = parse_skills_catalog_options('--json "unterminated')
+
+    assert parsed.output == "json"
+    assert parsed.error == "Invalid /skills arguments: No closing quotation"
+
+
+def test_parse_skills_catalog_options_rejects_invalid_or_conflicting_options() -> None:
+    assert parse_skills_catalog_options("--page 0").error is not None
+    assert parse_skills_catalog_options("--limit 101").error == (
+        "Invalid value for --limit: maximum is 100"
+    )
+    assert parse_skills_catalog_options("--compact --json").error == (
+        "Conflicting output option: --json"
+    )
+    assert parse_skills_catalog_options("--registry hf -r other").error == (
+        "Duplicate option: --registry"
+    )
+    assert parse_skills_catalog_options("--page 1 --page 2").error == "Duplicate option: --page"
+    assert parse_skills_catalog_options("--unknown").error == "Unknown option: --unknown"
+    huge_page = "9" * 5_000
+    assert parse_skills_catalog_options(f"--page {huge_page}").error == (
+        "Invalid value for --page: maximum is 1000000"
+    )
+
+
+def test_parse_skills_catalog_options_preserves_paths_and_dash_queries() -> None:
+    windows = parse_skills_catalog_options(r"--registry C:\tmp\registry --compact")
+    dashed = parse_skills_catalog_options("-- --starts-with-dash")
+
+    assert windows.registry == r"C:\tmp\registry"
+    assert dashed.argument == "--starts-with-dash"
+
+
+def test_marketplace_source_display_redacts_registry_credentials() -> None:
+    url = "https://user:secret@example.test/skills.json?token=secret#private"
+
+    display = format_marketplace_display_url(url)
+    source = MarketplaceSkillSource(url)
+
+    assert "secret" not in display
+    assert "secret" not in source.ref.display_name
+    assert "REDACTED" in source.ref.display_name
 
 
 def test_filter_marketplace_skills_matches_bundle_and_description_fields() -> None:

--- a/tests/unit/fast_agent/tools/test_luna_timeout_guidance.py
+++ b/tests/unit/fast_agent/tools/test_luna_timeout_guidance.py
@@ -1,0 +1,24 @@
+from fast_agent.tools.shell_tool_definitions import build_luna_exec_tool
+
+
+def test_luna_timeout_guidance_changes_only_the_top_level_description() -> None:
+    tool = build_luna_exec_tool(shell_name="bash")
+
+    assert "Omit `timeout` for ordinary commands" in tool.description
+    assert "intentionally bounding disposable exploratory work" in tool.description
+    assert "complete required work without blindly repeating" in tool.description
+    assert set(tool.input_schema["properties"]) == {
+        "background",
+        "command",
+        "timeout",
+        "working_directory",
+    }
+    assert tool.input_schema["properties"]["timeout"] == {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 600,
+        "description": (
+            "Optional foreground hard deadline in seconds. Suppresses "
+            "normal auto-yield and terminates the process group on expiry."
+        ),
+    }

--- a/tests/unit/fast_agent/tools/test_luna_timeout_guidance.py
+++ b/tests/unit/fast_agent/tools/test_luna_timeout_guidance.py
@@ -3,10 +3,12 @@ from fast_agent.tools.shell_tool_definitions import build_luna_exec_tool
 
 def test_luna_timeout_guidance_changes_only_the_top_level_description() -> None:
     tool = build_luna_exec_tool(shell_name="bash")
+    description = tool.description
+    assert description is not None
 
-    assert "Omit `timeout` for ordinary commands" in tool.description
-    assert "intentionally bounding disposable exploratory work" in tool.description
-    assert "complete required work without blindly repeating" in tool.description
+    assert "Omit `timeout` for ordinary commands" in description
+    assert "intentionally bounding disposable exploratory work" in description
+    assert "complete required work without blindly repeating" in description
     assert set(tool.input_schema["properties"]) == {
         "background",
         "command",

--- a/tests/unit/fast_agent/tools/test_shell_runtime.py
+++ b/tests/unit/fast_agent/tools/test_shell_runtime.py
@@ -2518,7 +2518,7 @@ async def test_execute_retained_output_reports_quota(
 
 
 @pytest.mark.asyncio
-async def test_remote_execute_does_not_advertise_host_retained_output(
+async def test_remote_execute_routes_retained_output_through_process(
     tmp_path: Path,
 ) -> None:
     environment = _DirectShellEnvironment(
@@ -2545,9 +2545,28 @@ async def test_remote_execute_does_not_advertise_host_retained_output(
 
     assert result.content is not None
     assert isinstance(result.content[0], TextContent)
-    assert "Increase shell_execution.output_byte_limit to retain more." in (result.content[0].text)
+    assert "action='read_output'" in result.content[0].text
+    assert str(tmp_path) not in result.content[0].text
     assert "Use read_text_file for selected line ranges" not in result.content[0].text
-    assert runtime._retained_output_directory is None
+    assert runtime._retained_output_directory is not None
+    metadata = shell_runtime_module.process_result_metadata(result)
+    assert metadata is not None
+
+    readback = await runtime.call_tool(
+        "process",
+        {
+            "process_id": metadata["process_id"],
+            "action": "read_output",
+            "limit": 80,
+        },
+    )
+    assert readback.is_error is False
+    assert readback.content
+    assert isinstance(readback.content[0], TextContent)
+    payload = json.loads(readback.content[0].text)
+    assert payload["content"] == "x" * 80
+
+    await runtime.close()
 
 
 def test_shell_output_retention_continues_after_result_consumption(

--- a/tests/unit/fast_agent/ui/test_agent_completer.py
+++ b/tests/unit/fast_agent/ui/test_agent_completer.py
@@ -1461,7 +1461,7 @@ def test_marketplace_completion_dispatch_tables_cover_argument_actions() -> None
     assert completion_sources._SKILLS_COMPLETION_DISPATCH
     assert _completion_dispatch_tokens(completion_sources._SKILLS_COMPLETION_DISPATCH) == frozenset(
         token
-        for action in ("add", "search", "remove", "update", "registry")
+        for action in ("add", "available", "search", "remove", "update", "registry")
         for token in command_action_tokens("skills", action)
     )
 

--- a/tests/unit/fast_agent/ui/test_input_toolbar.py
+++ b/tests/unit/fast_agent/ui/test_input_toolbar.py
@@ -5,10 +5,18 @@ from typing import TYPE_CHECKING, cast
 from prompt_toolkit.formatted_text import HTML, to_formatted_text
 
 from fast_agent.agents.agent_types import AgentConfig
+from fast_agent.agents.tool_agent import ToolAgent
 from fast_agent.agents.workflow.parallel_agent import ParallelAgent
+from fast_agent.core.agent_capabilities import (
+    AgentCapabilityMode,
+    cycle_agent_capability_mode,
+)
 from fast_agent.llm.provider_types import Provider
 from fast_agent.ui import notification_tracker
 from fast_agent.ui.prompt.attachment_tokens import build_local_attachment_token
+from fast_agent.ui.prompt.status_bar.agent_capabilities import (
+    render_agent_capability_indicator,
+)
 from fast_agent.ui.prompt.status_bar.attachment import DraftAttachmentSummary
 from fast_agent.ui.prompt.status_bar.renderer import (
     AttachmentResourceSnapshot,
@@ -264,6 +272,35 @@ def test_build_middle_segment_renders_muted_process_indicator_when_idle() -> Non
     assert "ansibrightblack" in middle
 
 
+def test_agent_capability_indicator_styles_each_capability_independently() -> None:
+    assert render_agent_capability_indicator(AgentCapabilityMode.STANDARD) == (
+        "<style bg='ansibrightblack'>↳</style><style bg='ansibrightblack'>⌘ </style>"
+    )
+    assert render_agent_capability_indicator(AgentCapabilityMode.DELEGATE) == (
+        "<style bg='ansigreen'>↳</style><style bg='ansibrightblack'>⌘ </style>"
+    )
+    assert render_agent_capability_indicator(AgentCapabilityMode.HARNESS_ONLY) == (
+        "<style bg='ansibrightblack'>↳</style><style bg='ansigreen'>⌘ </style>"
+    )
+    assert render_agent_capability_indicator(AgentCapabilityMode.ORCHESTRATE) == (
+        "<style bg='ansigreen'>↳</style><style bg='ansigreen'>⌘ </style>"
+    )
+
+
+def test_build_middle_segment_leaves_space_after_harness_indicator() -> None:
+    middle = _build_middle_segment(
+        ToolbarAgentState(
+            model_display="gpt-4.1",
+            capability_mode=AgentCapabilityMode.ORCHESTRATE,
+            turn_count=3,
+        ),
+        shortcut_text="",
+    )
+
+    plain = "".join(fragment[1] for fragment in to_formatted_text(HTML(middle)))
+    assert "↻ ↳⌘ |" in plain
+
+
 def test_build_middle_segment_warns_when_process_capacity_exceeds_seventy_five_percent() -> None:
     at_threshold = _build_middle_segment(
         ToolbarAgentState(
@@ -367,6 +404,22 @@ def test_toolbar_agent_state_cache_refreshes_when_active_process_count_changes()
     assert cached.cache_hit is True
     assert active.cache_hit is False
     assert active.state.active_process_count == 1
+
+
+def test_toolbar_agent_state_cache_refreshes_when_capability_mode_changes() -> None:
+    agent = ToolAgent(AgentConfig("dev", model="unknown.custom"))
+    provider = cast("AgentApp", _StubAgentProvider(agent))
+    cache = ToolbarRenderCache()
+
+    standard = _resolve_toolbar_agent_state_cached("agent", provider, cache=cache)
+    cached = _resolve_toolbar_agent_state_cached("agent", provider, cache=cache)
+    cycle_agent_capability_mode(agent)
+    delegate = _resolve_toolbar_agent_state_cached("agent", provider, cache=cache)
+
+    assert standard.state.capability_mode is AgentCapabilityMode.STANDARD
+    assert cached.cache_hit is True
+    assert delegate.cache_hit is False
+    assert delegate.state.capability_mode is AgentCapabilityMode.DELEGATE
 
 
 def test_toolbar_agent_state_uses_protocol_default_capabilities() -> None:

--- a/tests/unit/fast_agent/ui/test_prompt_input.py
+++ b/tests/unit/fast_agent/ui/test_prompt_input.py
@@ -7,6 +7,8 @@ import pytest
 if TYPE_CHECKING:
     from prompt_toolkit import PromptSession
 
+from fast_agent.agents.agent_types import AgentConfig
+from fast_agent.agents.tool_agent import ToolAgent
 from fast_agent.ui.prompt import input as prompt_input
 
 
@@ -46,6 +48,12 @@ def test_build_prompt_text_resolver_shows_named_non_default_agent() -> None:
     )
 
     assert resolver().value == "<ansibrightblue>review</ansibrightblue> ❯ "
+
+
+def test_cycle_agent_mode_reports_explicit_subagent_disable(capsys) -> None:
+    prompt_input._cycle_agent_mode(ToolAgent(AgentConfig("dev", subagents=False)))
+
+    assert "Subagents are disabled by configuration." in capsys.readouterr().out
 
 
 @pytest.mark.asyncio

--- a/tests/unit/fast_agent/ui/test_prompt_keybindings.py
+++ b/tests/unit/fast_agent/ui/test_prompt_keybindings.py
@@ -130,6 +130,7 @@ def test_function_key_callbacks_fire_when_configured() -> None:
             events.append("invalidate")
 
     kb = create_keybindings(
+        on_cycle_agent_mode=lambda: events.append("agent_mode"),
         on_cycle_reasoning=lambda: events.append("reasoning"),
         on_cycle_verbosity=lambda: events.append("verbosity"),
         on_cycle_web_search=lambda: events.append("web_search"),
@@ -137,6 +138,7 @@ def test_function_key_callbacks_fire_when_configured() -> None:
     )
 
     for key, label in (
+        (Keys.F5, "agent_mode"),
         (Keys.F6, "reasoning"),
         (Keys.F7, "verbosity"),
         (Keys.F8, "web_search"),

--- a/uv.lock
+++ b/uv.lock
@@ -873,7 +873,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- expand skills registry browsing with MCP one-shot sources, search, paging, compact output, and raw JSON contracts
- expose richer model-facing command/tool discovery and preserve registry state safely across TUI and ACP contexts
- add F5 agent capability modes for delegation, orchestration, and harness-only operation
- redact credentials from displayed registry URLs and update docs, completions, and integration coverage
- bump the package version to 0.10.4

## Validation

- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `uv run scripts/cpd.py --check`
- `uv run scripts/check_internal_resources.py`
- Python 3.14 unit suite: 7,307 passed, 1 skipped
- focused changed-surface tests: 56 passed
- isolated plugin and package smoke tests

## Required question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it and would prefer a non-animal alternative.
