### PR TITLE
test: stabilize Python 3.14 UI checks

### DIFF
--- a/tests/unit/fast_agent/ui/test_command_help.py
+++ b/tests/unit/fast_agent/ui/test_command_help.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from io import StringIO
 from typing import TYPE_CHECKING
 
 from prompt_toolkit.document import Document
+from rich.console import Console
 
 from fast_agent.ui.command_payloads import CommandError
+from fast_agent.ui.prompt import special_commands
 from fast_agent.ui.prompt.completer import AgentCompleter
 from fast_agent.ui.prompt.parser import parse_special_input
 from fast_agent.ui.prompt.special_commands import handle_special_commands
@@ -21,11 +24,15 @@ def test_parse_help_status_topic() -> None:
     assert invalid == CommandError(message="Unexpected arguments for /help: unknown")
 
 
-def test_help_status_renders_tree_legend(capsys: pytest.CaptureFixture[str]) -> None:
+def test_help_status_renders_tree_legend(monkeypatch: pytest.MonkeyPatch) -> None:
+    output_buffer = StringIO()
+    output_console = Console(file=output_buffer, color_system=None)
+    monkeypatch.setattr(special_commands, "rich_print", output_console.print)
+
     result = handle_special_commands(parse_special_input("/help status"))
 
     assert result is True
-    output = capsys.readouterr().out
+    output = output_buffer.getvalue()
     assert "Interactive Status Bar (left → right):" in output
     assert "├─ Activity" in output
     assert "├─ Model" in output

--- a/tests/unit/fast_agent/ui/test_terminal_images.py
+++ b/tests/unit/fast_agent/ui/test_terminal_images.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from mcp_types import ImageContent, TextContent
-from rich.console import Console
+from rich.console import Console, Group
 from rich.measure import Measurement
 from textual_image._terminal import CellSize
 from textual_image.renderable import sixel as textual_sixel_renderer
@@ -259,7 +259,7 @@ def test_herdr_auto_halfcell_warning_follows_image(monkeypatch) -> None:
         terminal_image_renderer.extract_image_render_items([_image_content()]),
     )
 
-    assert renderable is not None
+    assert isinstance(renderable, Group)
     assert len(renderable.renderables) == 3
     assert isinstance(renderable.renderables[2], terminal_image_renderer.Text)
     assert renderable.renderables[2].plain == terminal_image_renderer.HERDR_HALFCELL_NOTICE


### PR DESCRIPTION
## Root cause

The Python 3.14 checks on #915 expose two test-harness compatibility issues:

- the `/help status` test relies on `capsys` intercepting Rich's previously initialized console stream, so the rendered legend can bypass pytest capture;
- the terminal-image test only narrows the returned renderable away from `None`, which is insufficient for Python 3.14's stricter type-checking path before accessing `Group.renderables`.

## Changes

- capture `/help status` through a dedicated `StringIO`-backed Rich `Console`, patched at the `special_commands.rich_print` lookup point, while retaining all legend-content assertions;
- assert that the terminal-image result is a Rich `Group`, strengthening the runtime contract and providing valid narrowing before checking its children.

This is intentionally test-only; production behavior is unchanged.

## Testing

- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `uv run pytest tests/unit/fast_agent/ui/test_command_help.py tests/unit/fast_agent/ui/test_terminal_images.py -q` — 23 passed
- `uv run pytest tests/unit -q` — 7350 passed, 1 skipped (2 existing `forkpty()` deprecation warnings)
- `git diff --check`
- independent security/logic review: passed with no concerns

Related: #915

## Required contributor question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it because it is made from calfskin, and I would prefer to exchange or donate it and use a non-animal alternative.
