### PR TITLE
Release 0.10.8: Muse Glimmer and runtime reliability fixes

### DIFF
--- a/docs/docs/_generated/model_aliases_hf.md
+++ b/docs/docs/_generated/model_aliases_hf.md
@@ -12,6 +12,7 @@
 | `deepseek4pro-hf` | `hf.deepseek-ai/DeepSeek-V4-Pro:together` |
 | `deepseekv4pro-hf` | `hf.deepseek-ai/DeepSeek-V4-Pro:together` |
 | `gemma4` | `hf.google/gemma-4-31B-it:cerebras?temperature=1.0&top_p=0.95` |
+| `glimmer` | `hf.meta-models/Muse-Glimmer-30B:together?temperature=1.0&top_p=0.95&top_k=64` |
 | `glm` | `hf.zai-org/GLM-5.2:zai-org` |
 | `GLM 5.2 (deepinfra)` | `hf.zai-org/GLM-5.2:deepinfra` |
 | `GLM 5.2 (fireworks-ai)` | `hf.zai-org/GLM-5.2:fireworks-ai` |
@@ -35,6 +36,7 @@
 | `kimi27` | `hf.moonshotai/Kimi-K2.7-Code:fireworks-ai?temperature=1.0&top_p=0.95&reasoning=on` |
 | `kimi27code` | `hf.moonshotai/Kimi-K2.7-Code:fireworks-ai?temperature=1.0&top_p=0.95&reasoning=on` |
 | `kimithink` | `hf.moonshotai/Kimi-K2.6:novita?temperature=1.0&top_p=0.95&reasoning=on` |
+| `meta-models/muse-glimmer-30b` | `meta-models/muse-glimmer-30b` |
 | `minimax` | `hf.MiniMaxAI/MiniMax-M3:together?temperature=1.0&top_p=0.95&top_k=40` |
 | `minimax2.5` | `hf.MiniMaxAI/MiniMax-M2.5:novita?temperature=1.0&top_p=0.95&top_k=40` |
 | `minimax21` | `hf.MiniMaxAI/MiniMax-M2.1:novita` |

--- a/docs/docs/_generated/models_reference.md
+++ b/docs/docs/_generated/models_reference.md
@@ -59,6 +59,7 @@
 | `deepseek-hf` | `hf` | Text | `json` (schema) | — | — | — |
 | `deepseek32` | `hf` | Text | `json` (schema) | — | — | — |
 | `gemma4` | `hf` | Text, Vision | `json` (schema) | effort: `none`, `low`, `medium`, `high`, `off`<br>Example: `gemma4?reasoning=none` | — | — |
+| `glimmer` | `hf` | Text, Vision | — | effort: `low`, `medium`, `high`, `xhigh`<br>Example: `glimmer?reasoning=high` | — | — |
 | `glm47` | `hf` | Text | `json` (schema) | toggle: `on`, `off`<br>Example: `glm47?reasoning=off` | — | — |
 | `glm51` | `hf` | Text | `json` (schema) | toggle: `on`, `off`<br>Example: `glm51?reasoning=off` | — | — |
 | `glm5` | `hf` | Text | `json` (schema) | toggle: `on`, `off`<br>Example: `glm5?reasoning=off` | — | — |

--- a/docs/docs/models/providers/huggingface.md
+++ b/docs/docs/models/providers/huggingface.md
@@ -29,6 +29,36 @@ fast-agent --model "hf.moonshotai/Kimi-K2.6:novita?reasoning=on"
 
 Curated aliases such as `kimi`, `deepseek-hf`, `glm`, and `minimax` include provider choices and request defaults tested with fast-agent features such as structured outputs and tool use. Capability can still vary by backing provider.
 
+## Muse Glimmer via Together
+
+`glimmer` routes [Muse Glimmer 30B](https://huggingface.co/meta-models/Muse-Glimmer-30B)
+through the Hugging Face Inference Providers router using Together:
+
+```bash
+fast-agent --model glimmer
+fast-agent --model "glimmer?reasoning=xhigh"
+```
+
+The preset resolves to `hf.meta-models/Muse-Glimmer-30B:together` and applies
+Meta's recommended sampling defaults: `temperature=1.0`, `top_p=0.95`, and
+`top_k=64`.
+
+Muse Glimmer supports text and image input with text output and a 131,072-token
+context window. Its reasoning control is a chat-template setting rather than an
+OpenAI `reasoning_effort` field. Fast-agent maps `low`, `medium`, `high`, and
+`xhigh` to `chat_template_kwargs.reasoning_strength`; the default is `high`.
+
+Meta's released chat template and [Together's model page](https://www.together.ai/models/muse-glimmer)
+describe tool calling, while Together's serverless model catalog currently marks
+function calling and structured outputs as unavailable for this endpoint. Live
+fast-agent testing confirms regular streamed tool calls and tool-result
+continuation work; the Hugging Face adapter uses manual stream accumulation for
+Together's null-valued tool-call continuation fragments.
+
+Fast-agent does not advertise structured JSON support for `glimmer`. Prompted
+JSON and tool-assisted JSON can succeed, but native Pydantic structured output
+was not reliable in live testing.
+
 ## Kimi instant mode
 
 Kimi models that support instant mode can disable reasoning with the `instant` query parameter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.10.7"
+version = "0.10.8"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/llm/model_aliases.py
+++ b/src/fast_agent/llm/model_aliases.py
@@ -61,6 +61,7 @@ BUILTIN_MODEL_ALIASES: Final[dict[str, str]] = {
     "muse": "metaai.muse-spark-1.2",
     "musecontrib": "metaai.muse-spark-1.2-contributor",
     "muse-spark": "metaai.muse-spark-1.2",
+    "glimmer": ("hf.meta-models/Muse-Glimmer-30B:together?temperature=1.0&top_p=0.95&top_k=64"),
     "minimax": "hf.MiniMaxAI/MiniMax-M3:together?temperature=1.0&top_p=0.95&top_k=40",
     "minimax25": "hf.MiniMaxAI/MiniMax-M2.5:fireworks-ai?temperature=1.0&top_p=0.95&top_k=40",
     "minimax27": "hf.MiniMaxAI/MiniMax-M2.7:fireworks-ai?temperature=1.0&top_p=0.95&top_k=40",

--- a/src/fast_agent/llm/model_database.py
+++ b/src/fast_agent/llm/model_database.py
@@ -407,6 +407,12 @@ class ModelDatabase:
         default=ReasoningEffortSetting(kind="effort", value="medium"),
     )
 
+    MUSE_GLIMMER_REASONING_EFFORT_SPEC = ReasoningEffortSpec(
+        kind="effort",
+        allowed_efforts=["low", "medium", "high", "xhigh"],
+        default=ReasoningEffortSetting(kind="effort", value="high"),
+    )
+
     ANTHROPIC_WEB_SEARCH_LEGACY = "web_search_20250305"
     ANTHROPIC_WEB_FETCH_LEGACY = "web_fetch_20250910"
     ANTHROPIC_WEB_SEARCH_46 = "web_search_20260209"
@@ -884,6 +890,20 @@ class ModelDatabase:
         }
     )
 
+    MUSE_GLIMMER_HF = ModelParameters(
+        context_window=131_072,
+        # Together does not publish a separate output-token limit.
+        max_output_tokens=16_384,
+        tokenizes=OPENAI_VISION,
+        json_mode=None,
+        reasoning="stream",
+        reasoning_effort_spec=MUSE_GLIMMER_REASONING_EFFORT_SPEC,
+        # Together emits null id/type/name continuation fragments for streamed tool calls.
+        stream_mode="manual",
+        default_provider=Provider.HUGGINGFACE,
+        model_specific="You have image understanding capabilities.",
+    )
+
     GROK_43 = ModelParameters(
         context_window=1_000_000,
         max_output_tokens=65535,
@@ -1250,6 +1270,7 @@ class ModelDatabase:
         "moonshotai/kimi-k2.6": KIMI_MOONSHOT_26,
         "moonshotai/kimi-k2.7-code": KIMI_MOONSHOT_27_CODE,
         "moonshotai/kimi-k3": KIMI_K3_HF,
+        "meta-models/muse-glimmer-30b": MUSE_GLIMMER_HF,
         "kimi-k3": KIMI_K3,
         "qwen/qwen3-32b": QWEN3_REASONER,
         "openai/gpt-oss-120b": OPENAI_GPT_OSS_SERIES,  # https://cookbook.openai.com/articles/openai-harmony

--- a/src/fast_agent/llm/model_selection.py
+++ b/src/fast_agent/llm/model_selection.py
@@ -147,6 +147,10 @@ class ModelSelectionCatalog:
         ),
         Provider.HUGGINGFACE: (
             _builtin_entry(
+                "glimmer",
+                display_label="Muse Glimmer 30B (together)",
+            ),
+            _builtin_entry(
                 "Kimi K3 (fireworks-ai)",
                 display_label="Kimi K3 (fireworks-ai)",
                 description="image-only HF route",

--- a/src/fast_agent/llm/provider/openai/huggingface_router_profiles.py
+++ b/src/fast_agent/llm/provider/openai/huggingface_router_profiles.py
@@ -164,6 +164,31 @@ class ChatTemplateReasoningToggle:
 
 
 @dataclass(frozen=True, slots=True)
+class ChatTemplateReasoningStrength:
+    default_strength: str
+
+    def apply(
+        self,
+        arguments: dict[str, Any],
+        *,
+        setting: ReasoningEffortSetting | None,
+        spec: ReasoningEffortSpec | None,
+    ) -> None:
+        effective = _effective_setting(setting, spec)
+        strength = self.default_strength
+        if (
+            effective is not None
+            and effective.kind == "effort"
+            and isinstance(effective.value, str)
+        ):
+            strength = effective.value
+
+        extra_body = _extra_body(arguments)
+        _set_chat_template_kwarg(extra_body, "reasoning_strength", strength)
+        arguments["extra_body"] = extra_body
+
+
+@dataclass(frozen=True, slots=True)
 class GenericDisableReasoningToggle:
     def apply(
         self,
@@ -194,6 +219,7 @@ _DEEPSEEK_V4_FLASH = "deepseek-ai/deepseek-v4-flash-0731"
 _GLM_52 = "zai-org/glm-5.2"
 _KIMI_K3 = "moonshotai/kimi-k3"
 _GEMMA_4 = "google/gemma-4-31b-it"
+_MUSE_GLIMMER = "meta-models/muse-glimmer-30b"
 
 _DEEPSEEK_REASONING = TopLevelReasoningEffort(default_effort="max")
 _KIMI_K3_REASONING = TopLevelReasoningEffort(
@@ -218,6 +244,7 @@ _GEMMA_4_CEREBRAS_REASONING = TopLevelReasoningEffort(
     default_effort="none",
     cleanup_extra_body=frozenset({"chat_template_kwargs"}),
 )
+_MUSE_GLIMMER_REASONING = ChatTemplateReasoningStrength(default_strength="high")
 
 HUGGINGFACE_ROUTE_PROFILES = RouterProfileRegistry(
     (
@@ -254,6 +281,11 @@ HUGGINGFACE_ROUTE_PROFILES = RouterProfileRegistry(
             model=_GEMMA_4,
             backends=frozenset({"cerebras"}),
             profile=HuggingFaceRouteProfile(reasoning=_GEMMA_4_CEREBRAS_REASONING),
+        ),
+        RouterProfileRule(
+            model=_MUSE_GLIMMER,
+            backends=frozenset({"together"}),
+            profile=HuggingFaceRouteProfile(reasoning=_MUSE_GLIMMER_REASONING),
         ),
         RouterProfileRule(
             model="moonshotai/kimi-k2.5",

--- a/src/fast_agent/llm/provider/openai/responses.py
+++ b/src/fast_agent/llm/provider/openai/responses.py
@@ -1219,6 +1219,7 @@ class ResponsesLLM(
                 response.usage,
                 context.model_name,
                 requested_service_tier=context.requested_service_tier,
+                service_tier=getattr(response, "service_tier", None),
             )
         self.history.set(result.input_items)
 

--- a/src/fast_agent/llm/provider/openai/responses_content.py
+++ b/src/fast_agent/llm/provider/openai/responses_content.py
@@ -91,21 +91,24 @@ class ResponsesContentMixin:
         return self._dedupe_input_items(items)
 
     def _dedupe_input_items(self, items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        seen_ids: set[str] = set()
+        seen_keys: set[tuple[str, ...]] = set()
         deduped: list[dict[str, Any]] = []
         for item in items:
-            item_id = item.get("id")
-            if item_id:
-                item_id_str = str(item_id)
-                if item_id_str in seen_ids:
+            key = self._input_item_dedupe_key(item)
+            if key is not None:
+                if key in seen_keys:
                     self.logger.debug(
                         "Dropping duplicate Responses item id",
-                        duplicate_id=item_id_str,
+                        duplicate_id=str(item.get("id")),
                     )
                     continue
-                seen_ids.add(item_id_str)
+                seen_keys.add(key)
             deduped.append(item)
         return deduped
+
+    def _input_item_dedupe_key(self, item: dict[str, Any]) -> tuple[str, ...] | None:
+        item_id = item.get("id")
+        return (str(item_id),) if item_id else None
 
     def _convert_message_to_items(self, msg: PromptMessageExtended) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []

--- a/src/fast_agent/llm/provider/openai/responses_output.py
+++ b/src/fast_agent/llm/provider/openai/responses_output.py
@@ -249,6 +249,7 @@ class ResponsesOutputMixin:
         model_name: str,
         *,
         requested_service_tier: Literal["fast", "flex"] | None = None,
+        service_tier: str | None = None,
     ) -> None:
         try:
             provider_value = getattr(self, "provider", Provider.RESPONSES)
@@ -260,6 +261,7 @@ class ResponsesOutputMixin:
                 provider=provider,
                 model=model_name,
             )
+            turn_usage.service_tier = service_tier
             self._finalize_turn_usage(
                 turn_usage,
                 requested_service_tier=requested_service_tier,

--- a/src/fast_agent/llm/provider/openai/responses_websocket.py
+++ b/src/fast_agent/llm/provider/openai/responses_websocket.py
@@ -23,7 +23,7 @@ from fast_agent.llm.provider.openai.tool_event_helpers import (
     item_type_is_responses_function_tool_call,
 )
 from fast_agent.utils.numeric import int_or_none
-from fast_agent.utils.text import strip_str_to_none
+from fast_agent.utils.text import collapse_whitespace, strip_str_to_none
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -35,6 +35,7 @@ RESPONSES_WEBSOCKET_BETA_HEADER_NAME = "OpenAI-Beta"
 RESPONSES_CREATE_EVENT_TYPE = "response.create"
 RESPONSES_WEBSOCKET_MAX_MESSAGE_BYTES = 4 * 1024 * 1024
 RESPONSES_WEBSOCKET_CLOSE_TIMEOUT_SECONDS = 0.25
+RESPONSES_WEBSOCKET_ERROR_DETAIL_LENGTH = 1000
 _STREAM_START_EVENT_TYPES = {
     "response.output_item.added",
     "response.function_call_arguments.delta",
@@ -133,6 +134,38 @@ def _stream_event_started(event_type: str | None) -> bool:
 
 def _non_empty_string(value: Any) -> str | None:
     return strip_str_to_none(value)
+
+
+def _websocket_handshake_error_detail(body: bytes) -> str:
+    text = body.decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, RecursionError):
+        payload = None
+
+    values: list[str] = []
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, str):
+            values.append(error)
+        elif isinstance(error, dict):
+            values.extend(
+                value
+                for key in ("code", "message", "detail")
+                if isinstance(value := error.get(key), str)
+            )
+        values.extend(
+            value
+            for key in ("error_description", "message", "detail")
+            if isinstance(value := payload.get(key), str)
+        )
+
+    normalized_values = (collapse_whitespace(value) for value in values)
+    detail = ": ".join(dict.fromkeys(value for value in normalized_values if value))
+
+    if len(detail) > RESPONSES_WEBSOCKET_ERROR_DETAIL_LENGTH:
+        return f"{detail[: RESPONSES_WEBSOCKET_ERROR_DETAIL_LENGTH - 1]}…"
+    return detail
 
 
 def resolve_responses_ws_url(base_url: str) -> str:
@@ -496,8 +529,12 @@ async def connect_websocket(
                 connection = await manager.enter()
     except InvalidStatus as exc:
         await asyncio.shield(_close_connection_attempt(client, manager))
+        message = str(exc)
+        detail = _websocket_handshake_error_detail(exc.response.body)
+        if detail:
+            message = f"{message}: {detail}"
         raise ResponsesWebSocketError(
-            str(exc),
+            message,
             status=exc.response.status_code,
         ) from exc
     except BaseException:

--- a/src/fast_agent/llm/provider/openai/xai_oauth.py
+++ b/src/fast_agent/llm/provider/openai/xai_oauth.py
@@ -15,6 +15,7 @@ from fast_agent.auth.credentials import (
 )
 from fast_agent.core.exceptions import ProviderKeyError
 from fast_agent.ui import console
+from fast_agent.utils.text import collapse_whitespace
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -28,6 +29,8 @@ XAI_DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
 REFRESH_SKEW_SECONDS = 300
 DEFAULT_TOKEN_LIFETIME_SECONDS = 3600
 DEFAULT_POLL_INTERVAL_SECONDS = 5
+MAX_OAUTH_ERROR_DETAIL_LENGTH = 1000
+MAX_OAUTH_ERROR_BODY_BYTES = 16 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,27 +46,59 @@ class _InvalidGrantError(ProviderKeyError):
     pass
 
 
-def _oauth_error(action: str, response: httpx.Response) -> ProviderKeyError:
+def _oauth_error_payload(response: httpx.Response) -> dict[str, Any] | None:
+    if len(response.content) > MAX_OAUTH_ERROR_BODY_BYTES:
+        return None
     try:
         payload = response.json()
-    except ValueError:
-        payload = {}
-    error = payload.get("error") if isinstance(payload, dict) else None
-    description = payload.get("error_description") if isinstance(payload, dict) else None
-    detail = ": ".join(value for value in (error, description) if isinstance(value, str))
+    except (ValueError, RecursionError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _oauth_error_detail(payload: dict[str, Any] | None) -> str:
+    values: list[str] = []
+    if payload is not None:
+        error = payload.get("error")
+        if isinstance(error, str):
+            values.append(error)
+        elif isinstance(error, dict):
+            values.extend(
+                value
+                for key in ("code", "message", "detail")
+                if isinstance(value := error.get(key), str)
+            )
+        values.extend(
+            value
+            for key in ("error_description", "message", "detail")
+            if isinstance(value := payload.get(key), str)
+        )
+
+    normalized_values = (
+        collapse_whitespace(value[:MAX_OAUTH_ERROR_DETAIL_LENGTH]) for value in values
+    )
+    detail = ": ".join(dict.fromkeys(value for value in normalized_values if value))
+    if len(detail) > MAX_OAUTH_ERROR_DETAIL_LENGTH:
+        return f"{detail[: MAX_OAUTH_ERROR_DETAIL_LENGTH - 1]}…"
+    return detail
+
+
+def _oauth_error(
+    action: str,
+    response: httpx.Response,
+    payload: dict[str, Any] | None,
+) -> ProviderKeyError:
+    detail = _oauth_error_detail(payload)
     suffix = f": {detail}" if detail else ""
+    punctuation = "" if detail.endswith((".", "!", "?")) else "."
     return ProviderKeyError(
         f"xAI OAuth {action} failed",
-        f"The xAI OAuth server returned HTTP {response.status_code}{suffix}.",
+        f"The xAI OAuth server returned HTTP {response.status_code}{suffix}{punctuation}",
     )
 
 
-def _oauth_error_code(response: httpx.Response) -> str | None:
-    try:
-        payload = response.json()
-    except ValueError:
-        return None
-    error = payload.get("error") if isinstance(payload, dict) else None
+def _oauth_error_code(payload: dict[str, Any] | None) -> str | None:
+    error = payload.get("error") if payload is not None else None
     return error if isinstance(error, str) else None
 
 
@@ -117,7 +152,11 @@ def request_xai_device_code(client: httpx.Client) -> XaiDeviceCode:
         data={"client_id": XAI_CLIENT_ID, "scope": XAI_SCOPE, "referrer": "fast-agent"},
     )
     if not response.is_success:
-        raise _oauth_error("device authorization", response)
+        raise _oauth_error(
+            "device authorization",
+            response,
+            _oauth_error_payload(response),
+        )
     payload = response.json()
     if not isinstance(payload, dict):
         raise ProviderKeyError("Invalid xAI OAuth response", "Expected a JSON object.")
@@ -160,11 +199,10 @@ def poll_xai_device_code(
             if not isinstance(payload, dict):
                 raise ProviderKeyError("Invalid xAI OAuth response", "Expected a JSON object.")
             return _credential_from_payload(payload)
-        try:
-            payload = response.json()
-        except ValueError:
-            raise _oauth_error("device token polling", response) from None
-        error = payload.get("error") if isinstance(payload, dict) else None
+        payload = _oauth_error_payload(response)
+        if payload is None:
+            raise _oauth_error("device token polling", response, payload)
+        error = _oauth_error_code(payload)
         if error == "authorization_pending":
             continue
         if error == "slow_down":
@@ -177,7 +215,7 @@ def poll_xai_device_code(
             )
         if error == "expired_token":
             break
-        raise _oauth_error("device token polling", response)
+        raise _oauth_error("device token polling", response, payload)
     raise ProviderKeyError("xAI OAuth login expired", "The xAI device code expired.")
 
 
@@ -203,8 +241,9 @@ def refresh_xai_credential(
             },
         )
         if not response.is_success:
-            error = _oauth_error("token refresh", response)
-            if _oauth_error_code(response) == "invalid_grant":
+            payload = _oauth_error_payload(response)
+            error = _oauth_error("token refresh", response, payload)
+            if _oauth_error_code(payload) == "invalid_grant":
                 raise _InvalidGrantError(error.message, error.details)
             raise error
         payload = response.json()

--- a/src/fast_agent/llm/provider/openai/xai_responses.py
+++ b/src/fast_agent/llm/provider/openai/xai_responses.py
@@ -243,6 +243,18 @@ class XAIResponsesLLM(ResponsesLLM):
             item.pop("id", None)
         return items
 
+    def _input_item_dedupe_key(self, item: dict[str, Any]) -> tuple[str, ...] | None:
+        key = super()._input_item_dedupe_key(item)
+        encrypted_content = item.get("encrypted_content")
+        if (
+            key is not None
+            and item.get("type") == "reasoning"
+            and isinstance(encrypted_content, str)
+            and encrypted_content
+        ):
+            return (*key, encrypted_content)
+        return key
+
     def _websocket_keepalive_options(self) -> ResponsesWebSocketKeepaliveOptions:
         # xAI currently doesn't reliably answer client-generated Ping frames.
         # Keep automatic Pong replies enabled while restoring the previous

--- a/src/fast_agent/session/session_manager.py
+++ b/src/fast_agent/session/session_manager.py
@@ -436,15 +436,25 @@ class Session:
         return str(current_path)
 
     def _save_metadata(self) -> None:
-        """Save session metadata."""
-        self._save_snapshot(snapshot_from_session_info(self.info))
+        """Save session metadata without replacing persisted runtime state."""
+        updated = snapshot_from_session_info(self.info)
+        with self._metadata_lock():
+            snapshot = self._load_snapshot_or_compatibility()
+            snapshot.created_at = updated.created_at
+            snapshot.last_activity = updated.last_activity
+            snapshot.metadata = updated.metadata
+            _merge_compatibility_continuation(snapshot, updated)
+            self._write_snapshot(snapshot)
 
     def _save_snapshot(self, snapshot: SessionSnapshot) -> None:
         """Save a typed snapshot payload."""
+        with self._metadata_lock():
+            self._write_snapshot(snapshot)
+
+    def _write_snapshot(self, snapshot: SessionSnapshot) -> None:
         metadata_file = self.directory / "session.json"
         payload = snapshot.model_dump(mode="json")
-        with self._metadata_lock():
-            self._atomic_write_json(metadata_file, payload)
+        self._atomic_write_json(metadata_file, payload)
 
     def _default_save_identity(self) -> "SessionSaveIdentity":
         """Build a compatibility save identity when a caller does not supply one."""
@@ -674,6 +684,32 @@ class Session:
             reverse=True,
         )
         return candidates[0] if candidates else None
+
+
+def _merge_compatibility_continuation(
+    snapshot: SessionSnapshot,
+    updated: SessionSnapshot,
+) -> None:
+    continuation = snapshot.continuation
+    updated_continuation = updated.continuation
+
+    if updated_continuation.active_agent is not None:
+        continuation.active_agent = updated_continuation.active_agent
+    if updated_continuation.cwd is not None:
+        continuation.cwd = updated_continuation.cwd
+    if updated_continuation.git is not None:
+        continuation.git = updated_continuation.git
+    if updated_continuation.lineage.forked_from is not None:
+        continuation.lineage.forked_from = updated_continuation.lineage.forked_from
+    if updated_continuation.lineage.acp_session_id is not None:
+        continuation.lineage.acp_session_id = updated_continuation.lineage.acp_session_id
+
+    for agent_name, updated_agent in updated_continuation.agents.items():
+        agent = continuation.agents.get(agent_name)
+        if agent is None:
+            continuation.agents[agent_name] = updated_agent
+        elif updated_agent.history_file is not None:
+            agent.history_file = updated_agent.history_file
 
 
 class SessionManager:

--- a/tests/e2e/llm/test_responses_websocket_local_e2e.py
+++ b/tests/e2e/llm/test_responses_websocket_local_e2e.py
@@ -177,7 +177,10 @@ async def test_sdk_websocket_handshake_timeout(unused_tcp_port: int) -> None:
 async def test_sdk_websocket_handshake_preserves_http_status(unused_tcp_port: int) -> None:
     async def _handler(request: web.Request) -> web.Response:
         del request
-        return web.Response(status=401, text="expired")
+        return web.json_response(
+            status=403,
+            data={"error": {"message": "Inference blocked by spending limit."}},
+        )
 
     app = web.Application()
     app.router.add_get("/v1/responses", _handler)
@@ -193,7 +196,8 @@ async def test_sdk_websocket_handshake_preserves_http_status(unused_tcp_port: in
                 headers={"Authorization": "Bearer expired"},
                 timeout_seconds=1.0,
             )
-        assert exc_info.value.status == 401
+        assert exc_info.value.status == 403
+        assert str(exc_info.value).endswith("Inference blocked by spending limit.")
     finally:
         await runner.cleanup()
 

--- a/tests/unit/fast_agent/llm/providers/test_llm_huggingface_router_profiles.py
+++ b/tests/unit/fast_agent/llm/providers/test_llm_huggingface_router_profiles.py
@@ -1,4 +1,7 @@
+from collections.abc import AsyncIterator
+
 import pytest
+from openai.types.chat import ChatCompletionChunk
 
 from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.llm_agent import LlmAgent
@@ -80,6 +83,137 @@ def test_deepseek_picker_aliases_apply_reasoning_override(alias: str) -> None:
     request = _factory_request(f"{alias}?reasoning=none")
 
     assert request["reasoning_effort"] == "none"
+
+
+@pytest.mark.parametrize(
+    ("model", "reasoning_strength"),
+    (
+        ("glimmer", "high"),
+        ("glimmer?reasoning=low", "low"),
+        ("glimmer?reasoning=xhigh", "xhigh"),
+    ),
+)
+def test_muse_glimmer_together_applies_chat_template_contract(
+    model: str,
+    reasoning_strength: str,
+) -> None:
+    request = _factory_request(model)
+    extra_body = request.get("extra_body")
+
+    assert request["model"] == "meta-models/Muse-Glimmer-30B:together"
+    assert request["temperature"] == 1.0
+    assert request["top_p"] == 0.95
+    assert "reasoning_effort" not in request
+    assert isinstance(extra_body, dict)
+    assert extra_body == {
+        "top_k": 64,
+        "chat_template_kwargs": {
+            "reasoning_strength": reasoning_strength,
+        },
+    }
+
+
+async def _stream_chunks(
+    chunks: list[ChatCompletionChunk],
+) -> AsyncIterator[ChatCompletionChunk]:
+    for chunk in chunks:
+        yield chunk
+
+
+def _glimmer_chunk(
+    *,
+    delta: dict[str, object],
+    finish_reason: str | None = None,
+    usage: dict[str, int] | None = None,
+) -> ChatCompletionChunk:
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "glimmer-chunk",
+            "created": 0,
+            "model": "meta-models/Muse-Glimmer-30B",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": delta,
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": usage,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_muse_glimmer_manual_stream_reassembles_together_tool_fragments() -> None:
+    llm = HuggingFaceLLM(
+        context=Context(config=Settings()),
+        model="meta-models/Muse-Glimmer-30B:together",
+    )
+    chunks = [
+        _glimmer_chunk(delta={"role": "assistant"}),
+        _glimmer_chunk(delta={"reasoning": "Use the shell tool."}),
+        _glimmer_chunk(
+            delta={
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "chatcmpl-tool-glimmer",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{"},
+                    }
+                ]
+            }
+        ),
+        _glimmer_chunk(
+            delta={
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": None,
+                        "type": None,
+                        "function": {
+                            "name": None,
+                            "arguments": '"command":"printf glimmer-tool-ok"',
+                        },
+                    }
+                ]
+            }
+        ),
+        _glimmer_chunk(
+            delta={
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": None,
+                        "type": None,
+                        "function": {"name": None, "arguments": "}"},
+                    }
+                ]
+            },
+            finish_reason="tool_calls",
+            usage={
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120,
+            },
+        ),
+    ]
+
+    completion, reasoning = await llm._process_stream_manual(
+        _stream_chunks(chunks),
+        "meta-models/Muse-Glimmer-30B",
+    )
+
+    message = completion.choices[0].message
+    assert reasoning == ["Use the shell tool."]
+    assert completion.choices[0].finish_reason == "tool_calls"
+    assert completion.usage.prompt_tokens == 100
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.tool_calls[0].id == "chatcmpl-tool-glimmer"
+    assert message.tool_calls[0].function.name == "bash"
+    assert message.tool_calls[0].function.arguments == ('{"command":"printf glimmer-tool-ok"}')
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/fast_agent/llm/providers/test_responses_helpers.py
+++ b/tests/unit/fast_agent/llm/providers/test_responses_helpers.py
@@ -2183,7 +2183,7 @@ def test_request_service_tier_overrides_configured_default() -> None:
     assert args["service_tier"] == "flex"
 
 
-def test_request_service_tier_override_is_recorded_in_turn_usage() -> None:
+def test_requested_and_effective_service_tiers_are_recorded_in_turn_usage() -> None:
     llm = _build_responses_family_llm(
         Provider.RESPONSES,
         model_name="gpt-5.4",
@@ -2204,9 +2204,12 @@ def test_request_service_tier_override_is_recorded_in_turn_usage() -> None:
         usage,
         context.model_name,
         requested_service_tier=context.requested_service_tier,
+        service_tier="default",
     )
 
-    assert llm.usage_accumulator.turns[-1].requested_service_tier == "flex"
+    turn = llm.usage_accumulator.turns[-1]
+    assert turn.requested_service_tier == "flex"
+    assert turn.service_tier == "default"
 
 
 def test_codexresponses_request_service_tier_rejects_flex() -> None:

--- a/tests/unit/fast_agent/llm/providers/test_responses_websocket.py
+++ b/tests/unit/fast_agent/llm/providers/test_responses_websocket.py
@@ -32,6 +32,7 @@ from fast_agent.llm.provider.openai.responses_websocket import (
     WebSocketResponsesStream,
     _AttrObjectView,
     _SdkWebSocket,
+    _websocket_handshake_error_detail,
     build_ws_headers,
     connect_websocket,
     resolve_responses_ws_url,
@@ -105,6 +106,44 @@ class _HangingWebSocket(_FakeWebSocket):
         del timeout
         await asyncio.Event().wait()
         raise AssertionError("unreachable")
+
+
+def test_websocket_handshake_error_detail_is_bounded() -> None:
+    detail = _websocket_handshake_error_detail(
+        json.dumps({"message": "Access denied\n" + "x" * 1200}).encode()
+    )
+
+    assert detail.startswith("Access denied ")
+    assert detail.endswith("…")
+    assert len(detail) == 1000
+
+
+def test_websocket_handshake_error_detail_does_not_render_unrecognized_json() -> None:
+    detail = _websocket_handshake_error_detail(
+        b'{"access_token":"secret-access","refresh_token":"secret-refresh"}'
+    )
+
+    assert detail == ""
+
+
+def test_websocket_handshake_error_detail_does_not_render_malformed_json() -> None:
+    detail = _websocket_handshake_error_detail(b'{"access_token":"secret-access",')
+
+    assert detail == ""
+
+
+def test_websocket_handshake_error_detail_handles_pathologically_nested_json() -> None:
+    detail = _websocket_handshake_error_detail(b"[" * 2000 + b"0" + b"]" * 2000)
+
+    assert detail == ""
+
+
+def test_websocket_handshake_error_detail_ignores_whitespace_only_fields() -> None:
+    detail = _websocket_handshake_error_detail(
+        json.dumps({"error": " \n\t", "message": "Denied"}).encode()
+    )
+
+    assert detail == "Denied"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/fast_agent/llm/providers/test_xai_oauth.py
+++ b/tests/unit/fast_agent/llm/providers/test_xai_oauth.py
@@ -5,13 +5,19 @@ import time
 from typing import TYPE_CHECKING
 
 import httpx
+import pytest
 
 from fast_agent.auth.credentials import OAuthCredential, save_oauth_credential
+from fast_agent.core.exceptions import ProviderKeyError
 from fast_agent.llm.provider.openai.xai_oauth import (
     XAI_DEVICE_CODE_URL,
     XAI_TOKEN_URL,
+    XaiDeviceCode,
     get_xai_access_token,
     login_xai_oauth,
+    poll_xai_device_code,
+    refresh_xai_credential,
+    request_xai_device_code,
 )
 from fast_agent.llm.provider_key_manager import ProviderKeyManager
 
@@ -63,6 +69,136 @@ class XaiOAuthSimulator:
                 "token_type": "Bearer",
             },
         )
+
+
+def test_device_authorization_includes_xai_json_error_detail() -> None:
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"message": "Device authorization is unavailable for this account."},
+        )
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(forbidden)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        request_xai_device_code(client)
+
+    assert exc_info.value.details == (
+        "The xAI OAuth server returned HTTP 403: "
+        "Device authorization is unavailable for this account."
+    )
+
+
+def test_device_authorization_does_not_render_malformed_json() -> None:
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text='{"access_token":"secret-access",')
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(forbidden)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        request_xai_device_code(client)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 403."
+    assert "secret-access" not in str(exc_info.value)
+
+
+def test_device_authorization_does_not_render_unrecognized_json() -> None:
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"access_token": "secret-access", "refresh_token": "secret-refresh"},
+        )
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(forbidden)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        request_xai_device_code(client)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 403."
+    assert "secret" not in str(exc_info.value)
+
+
+def test_device_authorization_handles_pathologically_nested_json() -> None:
+    body = b"[" * 2000 + b"0" + b"]" * 2000
+
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, content=body)
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(forbidden)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        request_xai_device_code(client)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 403."
+
+
+def test_device_token_polling_handles_pathologically_nested_json() -> None:
+    body = b"[" * 2000 + b"0" + b"]" * 2000
+
+    def rejected(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, content=body)
+
+    device = XaiDeviceCode(
+        device_code="device",
+        user_code="CODE",
+        verification_uri="https://accounts.x.ai/device",
+        expires_in=60,
+        interval=1,
+    )
+    with (
+        httpx.Client(transport=httpx.MockTransport(rejected)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        poll_xai_device_code(client, device, sleep=lambda _: None, monotonic=lambda: 0)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 400."
+
+
+def test_token_refresh_handles_pathologically_nested_json() -> None:
+    body = b"[" * 2000 + b"0" + b"]" * 2000
+
+    def rejected(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, content=body)
+
+    credential = OAuthCredential(access_token="expired", refresh_token="refresh")
+    with (
+        httpx.Client(transport=httpx.MockTransport(rejected)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        refresh_xai_credential(credential, client=client)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 400."
+
+
+def test_device_authorization_ignores_oversized_error_body() -> None:
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"message": "sensitive-" + "x" * 20_000})
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(forbidden)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        request_xai_device_code(client)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 403."
+    assert "sensitive" not in str(exc_info.value)
+
+
+def test_device_authorization_ignores_whitespace_only_error_fields() -> None:
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": " \n\t", "message": "Denied"})
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(forbidden)) as client,
+        pytest.raises(ProviderKeyError) as exc_info,
+    ):
+        request_xai_device_code(client)
+
+    assert exc_info.value.details == "The xAI OAuth server returned HTTP 403: Denied."
 
 
 def test_xai_device_login_persists_portable_credential(

--- a/tests/unit/fast_agent/llm/providers/test_xai_responses.py
+++ b/tests/unit/fast_agent/llm/providers/test_xai_responses.py
@@ -8,7 +8,7 @@ from openai.types.responses import ResponseUsage
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from fast_agent.config import Settings, XAISettings, XAIWebSearchSettings
-from fast_agent.constants import OPENAI_ASSISTANT_MESSAGE_ITEMS
+from fast_agent.constants import OPENAI_ASSISTANT_MESSAGE_ITEMS, OPENAI_REASONING_ENCRYPTED
 from fast_agent.context import Context
 from fast_agent.core.exceptions import ModelConfigError
 from fast_agent.llm.provider.openai.responses import ResponsesLLM
@@ -447,6 +447,46 @@ def test_xai_replays_distinct_assistant_messages_when_provider_reuses_item_id(
         "Yes.",
     ]
     assert all("id" not in item for item in replayed if item["role"] == "assistant")
+
+
+@pytest.mark.parametrize("model", ["grok-4.5", "grok-4.6"])
+def test_xai_replays_distinct_reasoning_when_provider_reuses_item_id(model: str) -> None:
+    llm = XAIResponsesLLM(
+        context=Context(config=Settings(xai=XAISettings(api_key="test-key"))),
+        model=model,
+    )
+    messages = [
+        PromptMessageExtended(
+            role="assistant",
+            content=[],
+            channels={
+                OPENAI_REASONING_ENCRYPTED: [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "type": "reasoning",
+                                "id": "rs_reused",
+                                "encrypted_content": ciphertext,
+                            }
+                        ),
+                    )
+                ]
+            },
+        )
+        for ciphertext in ("cipher-turn-1", "cipher-turn-2", "cipher-turn-2")
+    ]
+
+    input_items = llm._convert_to_provider_format(messages)
+    args = llm._build_response_args(input_items, llm.default_request_params, tools=None)
+    planned = llm._new_ws_request_planner().plan(args)
+    reasoning = [item for item in planned.arguments["input"] if item["type"] == "reasoning"]
+
+    assert [item["encrypted_content"] for item in reasoning] == [
+        "cipher-turn-1",
+        "cipher-turn-2",
+    ]
+    assert [item["id"] for item in reasoning] == ["rs_reused", "rs_reused"]
 
 
 def test_xai_responses_advertises_web_search() -> None:

--- a/tests/unit/fast_agent/llm/test_model_database.py
+++ b/tests/unit/fast_agent/llm/test_model_database.py
@@ -526,6 +526,23 @@ def test_model_database_metaai_muse_spark_metadata():
         assert ModelDatabase.supports_mime(model, "video/mp4")
 
 
+def test_model_database_muse_glimmer_huggingface_metadata() -> None:
+    model = "meta-models/Muse-Glimmer-30B:together"
+    params = ModelDatabase.get_model_params(model, provider=Provider.HUGGINGFACE)
+
+    assert params is not None
+    assert params.default_provider == Provider.HUGGINGFACE
+    assert params.context_window == 131_072
+    assert params.max_output_tokens == 16_384
+    assert params.json_mode is None
+    assert params.reasoning == "stream"
+    assert params.stream_mode == "manual"
+    assert params.reasoning_effort_spec == ModelDatabase.MUSE_GLIMMER_REASONING_EFFORT_SPEC
+    assert ModelDatabase.supports_mime(model, "image/png")
+    assert not ModelDatabase.supports_mime(model, "application/pdf")
+    assert not ModelDatabase.supports_mime(model, "video/mp4")
+
+
 def test_model_database_google_video_audio_mime_types():
     """Test that Google models support expanded video/audio MIME types."""
     # Video formats (MP4, AVI, FLV, MOV, MPEG, MPG, WebM)

--- a/tests/unit/fast_agent/llm/test_model_factory.py
+++ b/tests/unit/fast_agent/llm/test_model_factory.py
@@ -902,6 +902,16 @@ def test_huggingface_alias_without_provider():
     assert config.model_name == "moonshotai/Kimi-K2-Instruct-0905"
 
 
+def test_glimmer_alias_uses_together_with_recommended_sampling() -> None:
+    config = ModelFactory.parse_model_string("glimmer")
+
+    assert config.provider == Provider.HUGGINGFACE
+    assert config.model_name == "meta-models/Muse-Glimmer-30B:together"
+    assert config.temperature == 1.0
+    assert config.top_p == 0.95
+    assert config.top_k == 64
+
+
 def test_builtin_glm_alias_uses_glm_52_default() -> None:
     config = ModelFactory.parse_model_string("glm")
     assert config.provider == Provider.HUGGINGFACE

--- a/tests/unit/fast_agent/llm/test_model_selection_catalog.py
+++ b/tests/unit/fast_agent/llm/test_model_selection_catalog.py
@@ -353,6 +353,17 @@ def test_huggingface_curated_catalog_includes_both_kimi_k3_routes() -> None:
     assert all(entry.current for entry in kimi_k3_entries)
 
 
+def test_huggingface_curated_catalog_includes_muse_glimmer_together() -> None:
+    entries = ModelSelectionCatalog.CATALOG_ENTRIES_BY_PROVIDER[Provider.HUGGINGFACE]
+    glimmer = next(entry for entry in entries if entry.alias == "glimmer")
+
+    assert glimmer.display_label == "Muse Glimmer 30B (together)"
+    assert glimmer.model == (
+        "hf.meta-models/Muse-Glimmer-30B:together?temperature=1.0&top_p=0.95&top_k=64"
+    )
+    assert glimmer.current is True
+
+
 def test_huggingface_curated_catalog_includes_deepseek_v4_flash_0731_routes() -> None:
     entries = ModelSelectionCatalog.CATALOG_ENTRIES_BY_PROVIDER[Provider.HUGGINGFACE]
     aliases = {

--- a/tests/unit/fast_agent/session/test_session_manager.py
+++ b/tests/unit/fast_agent/session/test_session_manager.py
@@ -111,6 +111,43 @@ def test_prune_sessions_skips_pinned(tmp_path) -> None:
         reset_session_manager()
 
 
+@pytest.mark.asyncio
+async def test_metadata_updates_preserve_persisted_runtime_state(tmp_path) -> None:
+    manager = SessionManager(
+        cwd=tmp_path,
+        home_override=tmp_path / ".fast-agent",
+        respect_env_override=False,
+    )
+    session = manager.create_session(metadata={"custom": "value"})
+    agent = _Agent(
+        name="main",
+        instruction="Stored prompt",
+        history=[_message("user", "hello"), _message("assistant", "done")],
+    )
+    await session.save_history(cast("AgentProtocol", agent))
+    session.set_execution_status("running")
+    before = session.load_snapshot()
+    updated_cwd = tmp_path / "updated-workspace"
+    session.info.metadata["cwd"] = str(updated_cwd)
+    session.info.metadata["acp_session_id"] = "acp-updated"
+
+    session.set_title("Renamed")
+    session.set_pinned(True)
+
+    after = session.load_snapshot()
+    assert after.metadata.title == "Renamed"
+    assert after.metadata.pinned is True
+    assert after.metadata.extras == {"custom": "value"}
+    assert after.continuation.active_agent == before.continuation.active_agent
+    assert after.continuation.cwd == str(updated_cwd)
+    assert after.continuation.lineage.acp_session_id == "acp-updated"
+    assert after.continuation.agents == before.continuation.agents
+    assert after.analysis == before.analysis
+    assert after.execution == before.execution
+    assert after.created_at == before.created_at
+    assert after.last_activity >= before.last_activity
+
+
 def test_session_history_window_rejects_boolean_config(tmp_path) -> None:
     old_settings = get_settings()
     override = old_settings.model_copy(

--- a/uv.lock
+++ b/uv.lock
@@ -172,9 +172,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -699,8 +699,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "aiologic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -873,7 +873,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.10.7"
+version = "0.10.8"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- add Muse Glimmer 30B via the Hugging Face Together route
- preserve xAI encrypted reasoning snapshots when persistent WebSockets reuse item IDs
- surface bounded, allowlisted WebSocket and xAI OAuth error details
- record effective Responses service tiers in usage data
- preserve persisted session runtime state during metadata updates
- bump the package version to 0.10.8

## Verification

- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- 297 affected local tests
- live Grok 4.3 and Grok 4.5 persistent-WebSocket replay probes

## Required question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it and would prefer a non-animal alternative.