### PR TITLE
fix(cli): read and write config files as UTF-8

### DIFF
--- a/src/fast_agent/cli/commands/check_config.py
+++ b/src/fast_agent/cli/commands/check_config.py
@@ -279,7 +279,7 @@ def get_secrets_summary(secrets_path: Path | None) -> dict:
 
     # File exists, attempt to parse
     try:
-        with secrets_path.open("r") as f:
+        with secrets_path.open("r", encoding="utf-8") as f:
             secrets = yaml.safe_load(f)
 
         # Mark as successfully parsed
@@ -715,7 +715,7 @@ def get_config_summary(config_path: Path | None) -> dict:
 
     # File exists, attempt to parse
     try:
-        with config_path.open("r") as f:
+        with config_path.open("r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         result["status"] = "parsed"
@@ -2265,7 +2265,7 @@ def show(
     console.print(f"\n[bold]{file_type.capitalize()} file:[/bold] {config_path}\n")
 
     try:
-        with config_path.open("r") as f:
+        with config_path.open("r", encoding="utf-8") as f:
             content = f.read()
 
         # Try to parse as YAML to check validity

--- a/src/fast_agent/cli/commands/config.py
+++ b/src/fast_agent/cli/commands/config.py
@@ -107,7 +107,7 @@ def _load_config(config_path: Path | None = None) -> tuple[dict[str, Any], Path]
         # Use explicit path
         resolved_path = config_path.resolve()
         if resolved_path.exists():
-            with resolved_path.open() as f:
+            with resolved_path.open(encoding="utf-8") as f:
                 config = _yaml.load(f) or {}
             return config, resolved_path
         # File doesn't exist yet - will be created
@@ -116,7 +116,7 @@ def _load_config(config_path: Path | None = None) -> tuple[dict[str, Any], Path]
     found_path = _default_config_file().resolve()
 
     if found_path.exists():
-        with found_path.open() as f:
+        with found_path.open(encoding="utf-8") as f:
             config = _yaml.load(f) or {}
         return config, found_path
 
@@ -128,7 +128,7 @@ def _load_effective_config(config_path: Path | None = None) -> dict[str, Any]:
     if config_path is not None:
         resolved_path = config_path.resolve()
         if resolved_path.exists():
-            with resolved_path.open() as f:
+            with resolved_path.open(encoding="utf-8") as f:
                 return _yaml.load(f) or {}
         return {}
 
@@ -202,7 +202,7 @@ def _replace_config_section(
 def _save_config(config: dict[str, Any], config_path: Path) -> None:
     """Save config to file, preserving comments."""
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    with config_path.open("w") as f:
+    with config_path.open("w", encoding="utf-8") as f:
         _yaml.dump(config, f)
 
 

--- a/tests/unit/fast_agent/commands/test_config_file_encoding.py
+++ b/tests/unit/fast_agent/commands/test_config_file_encoding.py
@@ -1,0 +1,175 @@
+"""The CLI must read and write config files as UTF-8, not in the platform codec.
+
+`Settings` loads `fastagent.config.yaml` with an explicit `encoding="utf-8"`
+(`config.py`), so the CLI commands that read and rewrite the same file have to
+agree. Where they don't, a config with any non-ASCII in it either fails to load
+under a non-UTF-8 default codec, or - worse - gets rewritten in that codec and
+becomes a file the runtime can no longer read.
+
+The tests force a default codec rather than relying on the host's, so they
+assert the same thing on a UTF-8 CI runner as on a cp936 Windows box.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from fast_agent.cli.commands import check_config as check_config_command
+from fast_agent.cli.commands import config as config_command
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+# Deliberately mixes a character that no legacy Chinese codec can represent
+# (the coffee cup) with ones that cp936 can, so both failure modes are in reach.
+NON_ASCII = "你好，世界 — café ☕"
+CP936_SAFE = "团队默认横幅"
+
+
+@contextlib.contextmanager
+def _default_codec(codec: str) -> Iterator[None]:
+    """Makes implicit text IO use ``codec``, as a non-UTF-8 locale would.
+
+    `pathlib.Path.open` resolves the default encoding inside `io.open`, and
+    patching `locale.getpreferredencoding` does not reach it, so the wrapper
+    goes on `io.open` itself. Only calls that passed no encoding are affected -
+    which is exactly the set of calls under test.
+    """
+    real_open = io.open
+
+    def patched_open(
+        file: Any,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        if "b" not in mode and encoding in (None, "locale"):
+            encoding = codec
+        return real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(io, "open", patched_open)
+        yield
+
+
+def _write_config(path: Path, banner: str) -> None:
+    path.write_text(
+        f'default_model: haiku\nshell_execution:\n  enabled: true\n  banner: "{banner}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_the_forced_codec_actually_bites(tmp_path: Path) -> None:
+    """Guards the tests below from passing because the wrapper does nothing."""
+    path = tmp_path / "probe.txt"
+    path.write_text(NON_ASCII, encoding="utf-8")
+
+    with _default_codec("ascii"), pytest.raises(UnicodeDecodeError):
+        path.open().read()
+
+
+def test_load_config_reads_utf8_under_a_non_utf8_default_codec(tmp_path: Path) -> None:
+    config_path = tmp_path / "fastagent.config.yaml"
+    _write_config(config_path, NON_ASCII)
+
+    with _default_codec("ascii"):
+        config, resolved = config_command._load_config(config_path)
+
+    assert resolved == config_path.resolve()
+    assert config["shell_execution"]["banner"] == NON_ASCII
+
+
+def test_load_effective_config_reads_utf8_under_a_non_utf8_default_codec(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "fastagent.config.yaml"
+    _write_config(config_path, NON_ASCII)
+
+    with _default_codec("ascii"):
+        config = config_command._load_effective_config(config_path)
+
+    assert config["shell_execution"]["banner"] == NON_ASCII
+
+
+def test_load_config_does_not_silently_mojibake_a_cp936_safe_value(
+    tmp_path: Path,
+) -> None:
+    """The quiet half of the bug: cp936 decodes these UTF-8 bytes without error.
+
+    Nothing raises, so the value simply arrives as different characters and is
+    shown that way in the interactive form.
+    """
+    config_path = tmp_path / "fastagent.config.yaml"
+    _write_config(config_path, CP936_SAFE)
+
+    with _default_codec("cp936"):
+        config, _ = config_command._load_config(config_path)
+
+    assert config["shell_execution"]["banner"] == CP936_SAFE
+
+
+def test_saved_config_stays_loadable_by_the_runtime(tmp_path: Path) -> None:
+    """A value entered in the form must survive back through the UTF-8 loader.
+
+    This is the damaging case: written in the platform codec, the file is not
+    valid UTF-8 any more, so `Settings` fails on a config the CLI just wrote.
+    """
+    config_path = tmp_path / "fastagent.config.yaml"
+    _write_config(config_path, "plain")
+
+    with _default_codec("cp936"):
+        config, _ = config_command._load_config(config_path)
+        config["shell_execution"]["banner"] = CP936_SAFE
+        config_command._save_config(config, config_path)
+
+    # Read the way Settings does, and from the bytes on disk rather than through
+    # any default codec.
+    reloaded = yaml.safe_load(config_path.read_bytes().decode("utf-8"))
+    assert reloaded["shell_execution"]["banner"] == CP936_SAFE
+
+
+def test_get_config_summary_reads_utf8_under_a_non_utf8_default_codec(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "fastagent.config.yaml"
+    _write_config(config_path, NON_ASCII)
+
+    with _default_codec("ascii"):
+        summary = check_config_command.get_config_summary(config_path)
+
+    assert summary["status"] == "parsed"
+    assert summary["config"]["shell_execution"]["banner"] == NON_ASCII
+
+
+def test_get_secrets_summary_reads_utf8_under_a_non_utf8_default_codec(
+    tmp_path: Path,
+) -> None:
+    secrets_path = tmp_path / "fastagent.secrets.yaml"
+    secrets_path.write_text(f'openai:\n  api_key: "{NON_ASCII}"\n', encoding="utf-8")
+
+    with _default_codec("ascii"):
+        summary = check_config_command.get_secrets_summary(secrets_path)
+
+    assert summary["status"] == "parsed"
+    assert summary["secrets"]["openai"]["api_key"] == NON_ASCII
+
+
+def test_check_show_reads_utf8_under_a_non_utf8_default_codec(tmp_path: Path) -> None:
+    config_path = tmp_path / "fastagent.config.yaml"
+    _write_config(config_path, NON_ASCII)
+
+    with _default_codec("ascii"):
+        result = CliRunner().invoke(check_config_command.app, ["show", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "YAML syntax is valid" in result.output
+    assert "Error parsing" not in result.output


### PR DESCRIPTION
## Problem

`Settings` loads `fastagent.config.yaml` with an explicit encoding (`src/fast_agent/config.py`):

```python
with path.open("r", encoding="utf-8") as f:
    return yaml.safe_load(f) or {}
```

Seven CLI call sites open the same files with no `encoding=`, so they fall back to the platform default (`locale.getencoding()`):

- `cli/commands/config.py` — `_load_config` (×2), `_load_effective_config`, and `_save_config`
- `cli/commands/check_config.py` — `get_config_summary`, `get_secrets_summary`, `check show`

On any host whose default codec is not UTF-8 (cp936, cp932, cp1251, cp1252 …) that disagreement splits three ways as soon as the config contains non-ASCII — an instruction, a prompt, a server arg, a path with an accent:

1. **Hard failure.** `fast-agent config display`, `fast-agent check show`, and `fast-agent check` raise or report `UnicodeDecodeError` on a config that the runtime itself loads without complaint.
2. **Silent mojibake.** Where the platform codec happens to decode the UTF-8 bytes without raising, the values arrive as different characters and are displayed that way.
3. **Corruption.** `_save_config` rewrites the *whole* file in the platform codec. A value entered in the display form therefore turns a working config into one the runtime can no longer read — the damage outlives the CLI invocation.

## Reproduction

Measured on cp936 Windows 11, `sys.flags.utf8_mode == 0`, against `main`:

| Case | Before | After |
|---|---|---|
| config contains `你好，世界 — café ☕`, then `_load_config` | `UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 26` | loads, value intact |
| config contains a pure-Chinese value | read back as `'浣犲ソ涓栫晫'`, no error, `equals original? False` | round-trips |
| non-ASCII banner entered in the display form and saved | file written as `b'  banner: \xcd\xc5\xb6\xd3\xc4\xac\xc8\xcf\xba\xe1\xb7\xf9\r\n'`, and the runtime then fails with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcd in position 67` | file stays valid UTF-8 and reloads |

## Fix

Pass `encoding="utf-8"` at the seven sites, matching `config.py` and the 152 other explicit `encoding="utf-8"` uses already in the tree. No behaviour change on a UTF-8 host.

## Tests

New `tests/unit/fast_agent/commands/test_config_file_encoding.py` (8 tests). Rather than depending on the runner's locale, they force a default codec by wrapping `io.open` — `pathlib.Path.open` resolves the default encoding inside `io.open`, so patching `locale.getpreferredencoding` or `builtins.open` does not reach it. One test asserts the forcing helper actually bites, so the others cannot pass vacuously.

Coverage: `_load_config`, `_load_effective_config`, `_save_config`, `get_config_summary`, `get_secrets_summary`, and `check show` — including the quiet-mojibake case and a round-trip that reads the saved file back the way `Settings` does, from raw bytes.

Verified locally:

- `uv run pytest tests/unit/fast_agent/commands/test_config_file_encoding.py -q` → **8 passed**
- With the source change reverted → **7 failed, 1 passed** (the survivor is the helper's own guard test)
- `uv run pytest` over the config/check_config suites (`test_check_config*.py`, `test_config_*.py`, `test_mcp_config_migration_command.py`) → **107 passed, 1 failed**; that one failure (`test_migrate_mcp_write_backup_settings_load_and_idempotence`) reproduces identically on the base commit with the change stashed, so it is pre-existing and unrelated
- `uv run pytest tests/unit/fast_agent/commands/ -q` → **863 passed, 11 failed**, all 11 also failing on the clean base tree (Windows-specific, unrelated)
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` on the three touched files → clean
