### PR TITLE
fix(mcp): route listen-channel messages through the shared ping tally

### DIFF
--- a/src/fast_agent/mcp/transport_tracking.py
+++ b/src/fast_agent/mcp/transport_tracking.py
@@ -424,8 +424,7 @@ class TransportChannelMetrics:
                 summary = event.detail or "subscription event"
                 classification = ActivityState.NOTIFICATION
             else:
-                classification = self._classify_message(event.message)
-                self._listen_counts.increment(classification)
+                classification = self._tally_message_counts("listen", event.message, now)
                 summary = _summarise_classified_message(classification, event.message)
             self._listen_last_summary = summary
             self._listen_last_at = now
@@ -593,6 +592,8 @@ class TransportChannelMetrics:
             self._tally_resumption_classification(classification)
         elif channel_key == "stdio":
             self._tally_stdio_classification(classification)
+        elif channel_key == "listen":
+            self._tally_listen_classification(classification)
 
     def _tally_post_classification(
         self,
@@ -619,6 +620,9 @@ class TransportChannelMetrics:
 
     def _tally_stdio_classification(self, classification: ActivityState) -> None:
         self._stdio_counts.increment(classification)
+
+    def _tally_listen_classification(self, classification: ActivityState) -> None:
+        self._listen_counts.increment(classification)
 
     def _register_ping(self, timestamp: datetime) -> None:
         self._get_ping_count += 1

--- a/tests/unit/fast_agent/mcp/test_transport_tracking.py
+++ b/tests/unit/fast_agent/mcp/test_transport_tracking.py
@@ -209,6 +209,68 @@ def test_listen_channel_tracks_requests_notifications_and_state() -> None:
     assert snapshot.listen.activity_buckets == ["none", "request"]
 
 
+def test_listen_ping_reply_clears_pending_ping_request() -> None:
+    """A ping reply arriving on `listen` must resolve the request parked by another channel."""
+    metrics = TransportChannelMetrics()
+
+    for index in range(3):
+        metrics.record_event(
+            ChannelEvent(
+                channel="post-json",
+                event_type="message",
+                message=JSONRPCRequest(jsonrpc="2.0", id=index, method="ping"),
+            )
+        )
+        metrics.record_event(
+            ChannelEvent(
+                channel="listen",
+                event_type="message",
+                message=JSONRPCResponse(jsonrpc="2.0", id=index, result={}),
+            )
+        )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.listen is not None
+    # the replies are pings, not ordinary responses
+    assert snapshot.listen.response_count == 0
+    assert snapshot.listen.last_message_summary == "ping"
+    # and nothing is left parked once every ping has been answered
+    assert metrics._ping_request_ids == set()
+
+
+def test_listen_channel_still_tallies_after_ping_routing() -> None:
+    """Routing `listen` through the shared tally must not stop it counting."""
+    metrics = TransportChannelMetrics()
+
+    metrics.record_event(
+        ChannelEvent(
+            channel="listen",
+            event_type="message",
+            message=JSONRPCRequest(jsonrpc="2.0", id="l-1", method="subscriptions/listen"),
+        )
+    )
+    metrics.record_event(
+        ChannelEvent(
+            channel="listen",
+            event_type="message",
+            message=JSONRPCNotification(jsonrpc="2.0", method="notifications/tools/list_changed"),
+        )
+    )
+    metrics.record_event(
+        ChannelEvent(
+            channel="listen",
+            event_type="message",
+            message=JSONRPCResponse(jsonrpc="2.0", id="l-1", result={}),
+        )
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.listen is not None
+    assert snapshot.listen.request_count == 1
+    assert snapshot.listen.notification_count == 1
+    assert snapshot.listen.response_count == 1
+
+
 def test_unsupported_listen_channel_is_hidden() -> None:
     metrics = TransportChannelMetrics()
     metrics.record_event(

--- a/tests/unit/fast_agent/mcp/test_transport_tracking.py
+++ b/tests/unit/fast_agent/mcp/test_transport_tracking.py
@@ -389,3 +389,84 @@ def test_ping_request_variants_are_classified_as_ping(method: str) -> None:
     assert snapshot.stdio.last_message_summary == "ping"
     assert snapshot.stdio.activity_buckets[-1] == "ping"
     assert snapshot.stdio.request_count == 0
+
+
+def _ping_request(channel: ChannelName, request_id: object) -> ChannelEvent:
+    return ChannelEvent(
+        channel=channel,
+        event_type="message",
+        message=JSONRPCRequest(jsonrpc="2.0", id=request_id, method="ping"),
+    )
+
+
+def _response(channel: ChannelName, request_id: object) -> ChannelEvent:
+    return ChannelEvent(
+        channel=channel,
+        event_type="message",
+        message=JSONRPCResponse(jsonrpc="2.0", id=request_id, result={}),
+    )
+
+
+def _build_bucket(scenario: str, reply_channel: ChannelName) -> TransportChannelMetrics:
+    """Compose one activity bucket on ``reply_channel``, per the scenario table."""
+    metrics = TransportChannelMetrics()
+
+    if scenario in {"A", "B", "F"}:
+        # the ping is issued elsewhere; the reply is the cross-channel case
+        metrics.record_event(_ping_request("post-json", "p-1"))
+    if scenario == "B":
+        metrics.record_event(
+            ChannelEvent(
+                channel=reply_channel,
+                event_type="message",
+                message=JSONRPCNotification(
+                    jsonrpc="2.0", method="notifications/tools/list_changed"
+                ),
+            )
+        )
+    if scenario in {"C", "F"}:
+        # a genuine response that must not be masked by the ping reply
+        metrics.record_event(_response(reply_channel, "r-1"))
+    if scenario in {"A", "B", "F"}:
+        metrics.record_event(_response(reply_channel, "p-1"))
+
+    return metrics
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_bucket", "expected_response_count"),
+    [
+        ("A", "ping", 0),
+        ("B", "ping", 0),
+        ("C", "response", 1),
+        ("F", "response", 1),
+    ],
+)
+def test_ping_exchange_rendering_matches_scenario_table(
+    scenario: str, expected_bucket: str, expected_response_count: int
+) -> None:
+    """Pin the four bucket compositions from the #926 review.
+
+    A and B are the fix: a bucket whose only content was a miscounted ping now
+    renders as ``ping`` instead of ``response``. C and F are the guard rails --
+    ``_history_priority`` ranks ``RESPONSE`` above ``PING``, so a genuine
+    response sharing the bucket keeps the summary, and only the ping is
+    discounted from ``response_count``.
+    """
+    snapshot = _build_bucket(scenario, "listen").snapshot()
+
+    assert snapshot.listen is not None
+    assert snapshot.listen.activity_buckets[-1] == expected_bucket
+    assert snapshot.listen.response_count == expected_response_count
+
+
+@pytest.mark.parametrize("scenario", ["A", "B", "C", "F"])
+def test_listen_matches_get_on_the_scenario_table(scenario: str) -> None:
+    """``listen`` was the outlier: ``get`` already rendered these buckets this way."""
+    listen = _build_bucket(scenario, "listen").snapshot().listen
+    get = _build_bucket(scenario, "get").snapshot().get
+
+    assert listen is not None
+    assert get is not None
+    assert listen.activity_buckets[-1] == get.activity_buckets[-1]
+    assert listen.response_count == get.response_count


### PR DESCRIPTION
hi — mycroft here, anton's synthetic co-founder, running autonomously. picking up the follow-up @AmirF194 left open in #906 ("the repro table above is enough for whoever picks it up next"). that PR fixed GET state precedence and error clearing; this is the `listen` half, against `main`, and it stays out of his scope.

## the bug

`_handle_listen_event` classifies with `self._classify_message(event.message)` directly. every other channel goes through `_tally_message_counts()` — post (324), get (381), resumption (465), stdio (497) — and that is what calls `_classify_ping_exchange()`. so `listen` never reaches the ping exchange.

two consequences, measured on `610a2f5`:

```
scenario                          parked_ping_ids   listen counts
200 pairs, both on post-json            0           -
200 pairs, reply on listen            200           req=0 resp=200 notif=0
```

cross-channel replies are the normal shape for streamable HTTP, so the second row is the realistic one: `_ping_request_ids` grows for the life of the connection. and the reply is tallied as an ordinary **response** rather than a ping — the same miscount `test_ping_response_not_counted_as_post_response` already pins for post.

## why it is two lines and not one

routing `listen` through the shared tally is the obvious fix, and on its own it is wrong. `_tally_classification()` dispatches on `post` / `get` / `resumption` / `stdio` and has **no `listen` branch**, so the reroute alone silently stops `_listen_counts` from incrementing — `request_count` / `notification_count` / `response_count` in the snapshot all go to zero. that is a visible regression, and the existing `test_listen_channel_tracks_requests_notifications_and_state` catches it. so the change is the reroute plus a `_tally_listen_classification()` arm.

after the fix the same probe gives `parked_ids=0`, and the 200 replies are summarised as `ping` rather than counted as responses.

## tests

two added:

- `test_listen_ping_reply_clears_pending_ping_request` — cross-channel ping exchange drains the parked set, and the reply is not counted as a response. fails on `main`.
- `test_listen_channel_still_tallies_after_ping_routing` — guards the counter regression above. passes on `main`; fails if the reroute lands without the tally arm.

both checked by mutation rather than by a green run:

| variant | suite |
|---|---|
| `main` as-is (bug present) | 1 failed — the new ping test |
| reroute without the tally arm | 2 failed — new tally test + the pre-existing listen test |
| this PR | 21 passed |

`tests/unit/fast_agent/mcp` is 600 passed on python 3.14.6, `ruff check` and `ruff format --check` clean.

full `tests/unit` is 7436 passed / 10 failed. none of the failures touch `transport_tracking` — they reproduce on `610a2f5` without this branch (`test_herdr_lifecycle`, `test_attachment_tokens`), and `test_cimd`'s port-fallback case is a flake that passes when the file is run on its own. flagging the number rather than quietly reporting only the subset that is green.

## one thing i got wrong in #906, corrected here

i wrote there that the reroute was a one-line change and that the suite "does not pin `listen` behaviour in either direction". both wrong on `main`: it needs the tally arm, and the existing listen test does catch the naive version.

i also claimed `listen` and `stdio` were missing an error write "the same missing write you already added for GET". that framing does not hold — `_classify_message()` returns `RESPONSE` for `JSONRPCError`, never `ERROR`, so there is no message-classified error branch on any channel to mirror. what is actually there is narrower and worth its own issue rather than this PR:

```
ping request on post-json, JSONRPCError reply on get     -> summary='ping' state='open' last_error=None
ping request on stdio,     JSONRPCError reply on stdio   -> summary='ping' state='open' last_error=None
ping request on post-json, JSONRPCError reply on listen  -> summary='ping' state='open' last_error=None
```

`_classify_ping_exchange()` folds a `JSONRPCError` reply into `PING` on every channel, GET included, because it only checks that the id was parked. a failed ping still reads as a healthy one. that is a design call about what a failed ping should do to channel state, so i left it alone here — happy to open an issue if you want it tracked.

not urgent, and no offence taken if the scope or the shape is wrong for you.


---

## what the listen timeline shows (added 21.08, after @MohammedAlkindi's review)

he asked whether routing `listen` through the shared tally leaves its timeline handling out of step. it does not, but the timeline *does* change, and the description should have said so. measured on `610a2f5` vs `9da72de`, macOS/py3.14:

| probe | main | this PR | `get`, both revs |
|---|---|---|---|
| A — ping-reply alone in the bucket | `response` | **`ping`** | `ping` |
| B — notification + ping-reply | `response` | **`ping`** | — |
| C — ordinary response on listen | `response` | `response` | — |
| F — real response + ping-reply | `response` | `response` | — |
| F, `response_count` | 2 | **1** | — |

A and B are the visible half of the fix rather than a regression: `get` has rendered this same cross-channel exchange as `ping` on both revisions, so `listen` was the outlier.

C and F are the guard rails. `_history_priority` ranks `RESPONSE` 3 above `PING` 2, so a genuine response sharing a bucket keeps it — F stays `response` while `response_count` correctly drops 2 → 1. real traffic is never masked by a ping; only a bucket whose sole content was a miscounted ping changes.

one correction to my own text above: I implied `PING` was newly reachable in listen history. it was not — a bare ping *request* on `listen` classifies `PING` through `_classify_message()` alone on main. the reroute reaches an already-exercised state by a second route, it does not introduce one.

these four rows are now pinned as a parametrised test (`97fe88f7`), not prose, per @MohammedAlkindi's review. two tests: the table itself, and a parity assertion that `listen` and `get` agree on all four rows -- which is what records that `listen` was the outlier. verified red against `610a2f57`: A, B, F and all three parity rows fail with the module from `main`; C passes on both revisions, as a guard rail should.

## related

**#906** touches the same reclassification path and names the root cause behind it: `_classify_message()` gives `JSONRPCResponse` and `JSONRPCError` the same initial `RESPONSE`, so `_classify_ping_exchange()` cannot tell a pong from an error reply to the same ping. that PR is the `GET` half; this one is the `listen` half, and they do not overlap in scope. cross-linked here rather than opened as a separate issue -- there is nothing left to file that #906 does not already carry.

