### PR TITLE
fix: decode HTTP text sources as UTF-8

### DIFF
--- a/src/fast_agent/io/source_resolver.py
+++ b/src/fast_agent/io/source_resolver.py
@@ -31,8 +31,7 @@ def read_text_source(source: str | Path, *, label: str = "source") -> str:
             response.raise_for_status()
         except requests.RequestException as exc:
             raise ValueError(f"Could not read {label} {source_text}: {exc}") from exc
-        response.encoding = response.encoding or "utf-8"
-        return response.text
+        return response.content.decode("utf-8")
 
     if parsed.scheme == "hf":
         return _read_hf_text_source(source_text, label=label)

--- a/tests/unit/core/test_instruction_builder.py
+++ b/tests/unit/core/test_instruction_builder.py
@@ -244,8 +244,7 @@ class TestInstructionBuilderUrlPatterns:
         import requests
 
         class MockResponse:
-            encoding = None
-            text = "Remote content"
+            content = b"Remote content"
 
             def raise_for_status(self):
                 pass

--- a/tests/unit/fast_agent/io/test_source_resolver.py
+++ b/tests/unit/fast_agent/io/test_source_resolver.py
@@ -104,6 +104,22 @@ def test_read_text_source_delegates_hf_scheme(monkeypatch):
     assert calls == [("hf://buckets/evalstate/home/demo.md", "prompt file")]
 
 
+def test_read_text_source_decodes_http_content_as_utf8(monkeypatch):
+    response = requests.Response()
+    response.status_code = 200
+    response._content = "你好, café".encode("utf-8")
+    response.encoding = "ISO-8859-1"
+
+    def fake_get(source: str, *, timeout: int) -> requests.Response:
+        assert source == "https://example.com/prompt.md"
+        assert timeout == 30
+        return response
+
+    monkeypatch.setattr(source_resolver.requests, "get", fake_get)
+
+    assert read_text_source("https://example.com/prompt.md") == "你好, café"
+
+
 def test_read_text_source_wraps_http_request_errors(monkeypatch):
     def fake_get(source: str, *, timeout: int):
         assert source == "https://example.com/missing.md"


### PR DESCRIPTION
## Summary

- decode HTTP(S) prompt, instruction, template, and schema sources from raw response bytes as UTF-8
- avoid Requests' legacy ISO-8859-1 default for `text/*` responses that omit a `charset`
- add a non-ASCII regression test and update the existing HTTP response test double to expose response bytes

## Root cause

`read_text_source` previously used `response.encoding = response.encoding or "utf-8"` before reading `response.text`. Requests already assigns ISO-8859-1 to `text/plain` responses without an explicit charset, so the UTF-8 fallback was never selected and valid UTF-8 text was returned as mojibake.

The resolver documents a UTF-8 text-source contract, so decoding `response.content` directly as UTF-8 makes HTTP sources consistent with local and Hugging Face sources.

## Testing

- `uv run pytest tests/unit/fast_agent/io/test_source_resolver.py tests/unit/core/test_instruction_builder.py -q --tb=short`
- `uv run pytest tests/unit -q --tb=short` — 7445 passed, 1 skipped
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `git diff --check`

## Related issue

No existing issue or open pull request matching this defect was found.

## Repository question

> You're given a calfskin wallet for your birthday. How would you feel about using it?

I would appreciate the thought behind the gift, but I would feel uncomfortable using calfskin and would prefer to exchange it for a durable non-animal alternative if possible.
