### PR TITLE
fix(cli): write scaffold files as UTF-8

### DIFF
--- a/src/fast_agent/cli/commands/setup.py
+++ b/src/fast_agent/cli/commands/setup.py
@@ -73,7 +73,7 @@ def create_file(path: Path, content: str, force: bool = False) -> bool:
             console.print(f"Skipping {path}")
             return False
 
-    path.write_text(content.strip() + "\n")
+    path.write_text(content.strip() + "\n", encoding="utf-8")
     console.print(f"[green]Created[/green] {path}")
     return True
 

--- a/tests/unit/fast_agent/commands/test_setup_quickstart.py
+++ b/tests/unit/fast_agent/commands/test_setup_quickstart.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import io
 import shlex
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from typer.testing import CliRunner
@@ -34,6 +35,31 @@ def test_setup_creates_preferred_config_and_secrets_filenames(tmp_path: Path) ->
     assert "Created config file:" in result.output
     assert "Created secrets file:" in result.output
     assert "fastagent.config.yaml" not in result.output
+
+
+def test_setup_create_file_writes_utf8_under_non_utf8_default_codec(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    real_open = io.open
+
+    def ascii_default_open(
+        file: Any,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        if "b" not in mode and encoding in (None, "locale"):
+            encoding = "ascii"
+        return real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+    monkeypatch.setattr(io, "open", ascii_default_open)
+    target = tmp_path / "agent.py"
+
+    assert setup.create_file(target, "instruction = '你好，café'", force=True)
+    assert target.read_bytes().decode("utf-8") == "instruction = '你好，café'\n"
 
 
 def test_setup_template_resource_names_are_table_driven() -> None:


### PR DESCRIPTION
## Root cause

The scaffold writer relied on the platform default text codec. On systems whose default codec is not UTF-8, generating a scaffold containing non-ASCII text could either raise `UnicodeEncodeError` or produce files that other fast-agent paths cannot reliably read as UTF-8.

## Changes

- Write scaffold output with an explicit UTF-8 encoding.
- Add a regression test that forces an ASCII default codec and verifies non-ASCII scaffold content is emitted as valid UTF-8.

This is a focused follow-up to the config-file encoding consistency work in #925.

## Tests

- `uv run pytest tests/unit/fast_agent/commands/test_setup_quickstart.py -q` (13 passed)
- `uv run pytest tests/unit -q` (7602 passed, 1 skipped)
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`

## Calfskin wallet

I would feel uncomfortable using it because it is made from calfskin; I would prefer a non-animal alternative.
