### PR TITLE
Add DeepSeek V4 Flash Vision support

### DIFF
--- a/docs/docs/_generated/model_aliases_deepseek.md
+++ b/docs/docs/_generated/model_aliases_deepseek.md
@@ -3,5 +3,7 @@
 | `deepseek` | `deepseek.deepseek-v4-flash` |
 | `DeepSeek V4 Pro` | `deepseek.deepseek-v4-pro` |
 | `deepseek-v4-flash` | `deepseek-v4-flash` |
+| `deepseek-v4-flash-vision-exp` | `deepseek-v4-flash-vision-exp` |
 | `deepseek-v4-pro` | `deepseek-v4-pro` |
 | `deepseekpro` | `deepseek.deepseek-v4-pro` |
+| `deepseekvision` | `deepseek.deepseek-v4-flash-vision-exp` |

--- a/docs/docs/_generated/models_reference.md
+++ b/docs/docs/_generated/models_reference.md
@@ -36,6 +36,7 @@
 | `terra` | `codexresponses` | Text, Vision, Document | `json` (schema) | effort: `none`, `low`, `medium`, `high`, `xhigh`, `max`, `off`<br>Example: `terra?reasoning=high` | `low`, `medium`, `high`<br>Example: `terra?verbosity=low` | — |
 | `deepseek` | `deepseek` | Text | `json` (schema) | effort: `none`, `low`, `high`, `max`, `off`<br>Example: `deepseek?reasoning=max` | — | — |
 | `deepseekpro` | `deepseek` | Text | `json` (schema) | effort: `none`, `low`, `high`, `max`, `off`<br>Example: `deepseekpro?reasoning=max` | — | — |
+| `deepseekvision` | `deepseek` | Text, Vision | `json` (schema) | effort: `none`, `low`, `high`, `max`, `off`<br>Example: `deepseekvision?reasoning=max` | — | — |
 | `passthrough` | `fast-agent` | Text | `json` (schema) | — | — | — |
 | `playback` | `fast-agent` | Text | `json` (schema) | — | — | — |
 | `silent` | `fast-agent` | Text | `json` (schema) | — | — | — |

--- a/docs/docs/models/index.md
+++ b/docs/docs/models/index.md
@@ -194,14 +194,16 @@ stateless Responses API:
 ```bash
 fast-agent --model deepseek
 fast-agent --model deepseekpro
+fast-agent --model deepseekvision
 fast-agent --model "deepseek?reasoning=high"
 fast-agent --model "deepseek?web_search=true"
 ```
 
-The native route supports `deepseek-v4-flash` and `deepseek-v4-pro`. Both
-provide reasoning, function tools, JSON Schema structured output, and
-provider-managed web search. Hugging Face aliases such as `deepseek-hf` are
-separate routes.
+The native route supports `deepseek-v4-flash`,
+`deepseek-v4-flash-vision-exp`, and `deepseek-v4-pro`. All provide reasoning,
+function tools, JSON Schema structured output, and provider-managed web search.
+The experimental vision variant also accepts JPEG, PNG, GIF, and WebP images.
+Hugging Face aliases such as `deepseek-hf` are separate routes.
 
 ### xAI
 

--- a/docs/docs/models/llm_providers.md
+++ b/docs/docs/models/llm_providers.md
@@ -42,7 +42,7 @@ The `default_headers` option is available for OpenAI-compatible providers (inclu
 | Groq | `groq` | `GROQ_API_KEY` | Additional provider; OpenAI-compatible hosted inference |
 | xAI / Grok | `xai` | `XAI_API_KEY` | Grok models, reasoning, web search, and X Search |
 | MetaAI | `metaai` | `META_AI_API_KEY` | Muse Spark Responses API models |
-| [DeepSeek](providers/deepseek/) | `deepseek` | `DEEPSEEK_API_KEY` | Native stateless Responses API; `deepseek-v4-flash`, `deepseek-v4-pro` |
+| [DeepSeek](providers/deepseek/) | `deepseek` | `DEEPSEEK_API_KEY` | Native stateless Responses API; V4 Flash, experimental Flash Vision, and V4 Pro |
 | Z.ai | `zai` | `ZAI_API_KEY` | Native GLM Chat Completions API |
 | Moonshot | `moonshot` | `MOONSHOT_API_KEY` | Native Kimi Chat Completions API |
 | Aliyun | `aliyun` | `ALIYUN_API_KEY` | Additional provider; DashScope compatible-mode endpoint |

--- a/docs/docs/models/providers/deepseek.md
+++ b/docs/docs/models/providers/deepseek.md
@@ -10,8 +10,8 @@ social:
 # DeepSeek
 
 Use the `deepseek` provider for fast-agent's native DeepSeek Responses route.
-It uses a stateless Responses API over SSE and supports `deepseek-v4-flash`
-and `deepseek-v4-pro`.
+It uses a stateless Responses API over SSE and supports `deepseek-v4-flash`,
+`deepseek-v4-flash-vision-exp`, and `deepseek-v4-pro`.
 
 ## Setup
 
@@ -46,6 +46,22 @@ or its explicit model string:
 deepseek.deepseek-v4-pro
 ```
 
+Select the experimental vision model with:
+
+```bash
+fast-agent go --model deepseekvision --message "Describe this image."
+```
+
+or its explicit model string:
+
+```text
+deepseek.deepseek-v4-flash-vision-exp
+```
+
+The vision model accepts JPEG, PNG, GIF, and WebP images from inline data or
+public URLs. Attach images through the TUI or other fast-agent input surfaces;
+the native adapter sends them as Responses API `input_image` parts.
+
 The native provider rejects other model names such as `deepseek-chat` and
 `deepseek-reasoner`.
 
@@ -73,8 +89,9 @@ deepseek:
 ```
 
 `base_url`, `default_model`, and `default_headers` are optional. A configured
-`default_model` must be `deepseek-v4-flash` or `deepseek-v4-pro`. Flash remains
-the default when this setting is omitted.
+`default_model` must be `deepseek-v4-flash`,
+`deepseek-v4-flash-vision-exp`, or `deepseek-v4-pro`. Flash remains the default
+when this setting is omitted.
 
 Run `fast-agent check` after configuring credentials.
 
@@ -133,7 +150,8 @@ DeepSeek's route differs from OpenAI's stateful Responses API:
 - requests use SSE; WebSocket transport is not supported;
 - server-side response storage and continuation are not used;
 - service tiers are not supported;
-- image, PDF, audio, video, and file inputs are not supported;
+- image input is supported only by `deepseek-v4-flash-vision-exp`;
+- PDF, audio, video, and general file inputs are not supported;
 - OpenAI-only request fields such as `include`, `parallel_tool_calls`,
   `service_tier`, and `store` are omitted.
 
@@ -159,6 +177,8 @@ route.
 
 - [DeepSeek platform](https://platform.deepseek.com/)
 - [DeepSeek API documentation](https://api-docs.deepseek.com/)
+- [DeepSeek vision guide](https://api-docs.deepseek.com/guides/vision)
+- [DeepSeek models and pricing](https://api-docs.deepseek.com/quick_start/pricing)
 
 See [Models Reference](../models_reference/) for the generated capability row,
 context limit, output limit, and supported input modalities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.10.12"
+version = "0.10.13"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/llm/model_aliases.py
+++ b/src/fast_agent/llm/model_aliases.py
@@ -41,6 +41,7 @@ BUILTIN_MODEL_ALIASES: Final[dict[str, str]] = {
     "fable5": "claude-fable-5",
     "deepseek": "deepseek.deepseek-v4-flash",
     "deepseekpro": "deepseek.deepseek-v4-pro",
+    "deepseekvision": "deepseek.deepseek-v4-flash-vision-exp",
     "gemini": "gemini-3.7-flash",
     "gemini2": "gemini-2.0-flash",
     "gemini25": "gemini-2.5-flash",

--- a/src/fast_agent/llm/model_database.py
+++ b/src/fast_agent/llm/model_database.py
@@ -784,6 +784,9 @@ class ModelDatabase:
         }
     )
     DEEPSEEK_V4_PRO = DEEPSEEK_V4_FLASH
+    DEEPSEEK_V4_FLASH_VISION = DEEPSEEK_V4_FLASH.model_copy(
+        update={"tokenizes": [*OPENAI_VISION, "image/gif"]}
+    )
 
     DEEPSEEK_V_32 = ModelParameters(
         context_window=65536,
@@ -1318,6 +1321,7 @@ class ModelDatabase:
         "claude-haiku-4-5": _with_fast(ANTHROPIC_SONNET_4_VERSIONED),
         # DeepSeek Models
         "deepseek-v4-flash": _with_fast(DEEPSEEK_V4_FLASH),
+        "deepseek-v4-flash-vision-exp": _with_fast(DEEPSEEK_V4_FLASH_VISION),
         "deepseek-v4-pro": DEEPSEEK_V4_PRO,
         "deepseek-ai/deepseek-v4-flash-0731": _with_fast(DEEPSEEK_V4_FLASH_HF),
         # Z.ai models

--- a/src/fast_agent/llm/model_selection.py
+++ b/src/fast_agent/llm/model_selection.py
@@ -145,6 +145,11 @@ class ModelSelectionCatalog:
                 fast=True,
             ),
             _builtin_entry(
+                "deepseekvision",
+                display_label="DeepSeek V4 Flash Vision (experimental)",
+                fast=True,
+            ),
+            _builtin_entry(
                 "DeepSeek V4 Pro",
                 display_label="DeepSeek V4 Pro",
             ),

--- a/src/fast_agent/llm/provider/openai/llm_deepseek.py
+++ b/src/fast_agent/llm/provider/openai/llm_deepseek.py
@@ -27,6 +27,7 @@ DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash"
 DEFAULT_DEEPSEEK_REASONING_EFFORT = "max"
 SUPPORTED_DEEPSEEK_MODELS: Final = (
     DEFAULT_DEEPSEEK_MODEL,
+    "deepseek-v4-flash-vision-exp",
     "deepseek-v4-pro",
 )
 

--- a/tests/unit/fast_agent/llm/providers/test_deepseek_responses.py
+++ b/tests/unit/fast_agent/llm/providers/test_deepseek_responses.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
-from mcp.types import TextContent
+from mcp.types import ImageContent, TextContent
 
 from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.llm_agent import LlmAgent
@@ -74,6 +74,29 @@ def test_deepseek_factory_builds_sse_responses_adapter() -> None:
 
     assert isinstance(llm, DeepSeekResponsesLLM)
     assert llm.configured_transport == "sse"
+
+
+def test_deepseek_vision_model_serializes_inline_image_for_responses() -> None:
+    llm = DeepSeekResponsesLLM(
+        context=Context(config=Settings()),
+        model="deepseek-v4-flash-vision-exp",
+    )
+
+    parts = llm._convert_content_parts(
+        [
+            TextContent(type="text", text="What is in this image?"),
+            ImageContent(type="image", data="aW1hZ2U=", mime_type="image/png"),
+        ],
+        role="user",
+    )
+
+    assert parts == [
+        {"type": "input_text", "text": "What is in this image?"},
+        {
+            "type": "input_image",
+            "image_url": "data:image/png;base64,aW1hZ2U=",
+        },
+    ]
 
 
 def test_deepseek_factory_forwards_web_search_override() -> None:

--- a/tests/unit/fast_agent/llm/providers/test_provider_default_models.py
+++ b/tests/unit/fast_agent/llm/providers/test_provider_default_models.py
@@ -182,7 +182,10 @@ def test_deepseek_provider_defaults_to_v4_flash() -> None:
     assert llm.default_request_params.model == "deepseek-v4-flash"
 
 
-@pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
+@pytest.mark.parametrize(
+    "model",
+    ["deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"],
+)
 def test_deepseek_provider_config_default_model_used_when_model_missing(model: str) -> None:
     settings = Settings(deepseek=DeepSeekSettings(default_model=model))
     llm = DeepSeekResponsesLLM(context=Context(config=settings), model="")

--- a/tests/unit/fast_agent/llm/test_model_database.py
+++ b/tests/unit/fast_agent/llm/test_model_database.py
@@ -505,6 +505,9 @@ def test_model_database_supports_mime_basic():
         "deepseek-v4-flash",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
+    for mime_type in ("image/jpeg", "image/png", "image/gif", "image/webp"):
+        assert ModelDatabase.supports_mime("deepseek-v4-flash-vision-exp", mime_type)
+    assert not ModelDatabase.supports_mime("deepseek-v4-flash-vision-exp", "application/pdf")
 
     # Wildcard checks
     assert ModelDatabase.supports_mime("gpt-4o", "image/*")

--- a/tests/unit/fast_agent/llm/test_model_factory.py
+++ b/tests/unit/fast_agent/llm/test_model_factory.py
@@ -1104,6 +1104,17 @@ def test_deepseek_pro_alias_resolves_to_deepseek_responses_model() -> None:
     assert config.model_name == "deepseek-v4-pro"
 
 
+@pytest.mark.parametrize(
+    "model",
+    ("deepseekvision", "deepseek-v4-flash-vision-exp"),
+)
+def test_deepseek_vision_model_resolves_to_deepseek_responses(model: str) -> None:
+    config = ModelFactory.parse_model_string(model)
+
+    assert config.provider == Provider.DEEPSEEK
+    assert config.model_name == "deepseek-v4-flash-vision-exp"
+
+
 def test_deepseek_hf_aliases_resolve_to_hf_deepseek_v4_pro():
     for alias in ("deepseek-hf", "deepseek4-hf", "deepseek4pro-hf", "deepseekv4pro-hf"):
         config = ModelFactory.parse_model_string(alias)
@@ -1111,7 +1122,10 @@ def test_deepseek_hf_aliases_resolve_to_hf_deepseek_v4_pro():
         assert config.model_name == "deepseek-ai/DeepSeek-V4-Pro:together"
 
 
-@pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
+@pytest.mark.parametrize(
+    "model",
+    ["deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"],
+)
 def test_deepseek_responses_model_resolves_to_official_provider(model: str) -> None:
     config = ModelFactory.parse_model_string(model)
 

--- a/tests/unit/fast_agent/llm/test_model_selection_catalog.py
+++ b/tests/unit/fast_agent/llm/test_model_selection_catalog.py
@@ -129,9 +129,9 @@ def test_codex_picker_aliases_resolve_through_the_canonical_runtime_presets() ->
         ) == ModelFactory.parse_model_string(model_spec)
 
 
-def test_deepseek_catalog_exposes_both_responses_models() -> None:
+def test_deepseek_catalog_exposes_native_responses_models() -> None:
     aliases = ModelSelectionCatalog.list_current_aliases(Provider.DEEPSEEK)
-    assert aliases == ["deepseek", "DeepSeek V4 Pro"]
+    assert aliases == ["deepseek", "deepseekvision", "DeepSeek V4 Pro"]
 
 
 def test_non_current_aliases_are_listed_but_not_current() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -872,7 +872,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.10.12"
+version = "0.10.13"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- add native `deepseek-v4-flash-vision-exp` Responses support
- advertise JPEG, PNG, GIF, and WebP input capabilities
- add the `deepseekvision` alias and model-picker entry
- document the vision route and regenerate model references

## Verification

- `uv run pytest -q tests/unit/fast_agent/llm/providers/test_deepseek_responses.py tests/unit/fast_agent/llm/providers/test_provider_default_models.py tests/unit/fast_agent/llm/test_model_database.py tests/unit/fast_agent/llm/test_model_factory.py tests/unit/fast_agent/llm/test_model_selection_catalog.py` — 382 passed
- `TEST_MODEL=deepseekvision uv run pytest -q -s tests/e2e/llm/test_llm_e2e.py::test_vision_model_reads_name` — live DeepSeek API vision test passed
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `uv run scripts/docs.py build`

## Pricing

Companion pricing PR: https://github.com/fast-agent-ai/card-packs/pull/10

## Required question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it because it is made from calfskin, and I would likely choose a non-animal alternative instead.