### PR TITLE
test: add generate coverage for ChainAgent cumulative mode

### DIFF
--- a/tests/unit/fast_agent/agents/workflow/test_chain_agent.py
+++ b/tests/unit/fast_agent/agents/workflow/test_chain_agent.py
@@ -266,6 +266,134 @@ async def test_cumulative_chain_structured_preserves_prior_response_content_bloc
 
 
 @pytest.mark.asyncio
+async def test_chain_generate_non_cumulative_passes_only_previous_output() -> None:
+    first = RecordingAgent("first", "first output")
+    second = RecordingAgent("second", "second output")
+    chain = ChainAgent(AgentConfig("chain"), [first, second])
+
+    result = await chain.generate(
+        PromptMessageExtended(role="user", content=[text_content("start")])
+    )
+
+    assert result.all_text() == "second output"
+    assert len(first.generate_inputs) == 1
+    assert len(second.generate_inputs) == 1
+    first_input = first.generate_inputs[0]
+    assert len(first_input) == 1
+    assert first_input[0].role == "user"
+    assert first_input[0].all_text() == "start"
+    second_input = second.generate_inputs[0]
+    assert len(second_input) == 1
+    assert second_input[0].role == "user"
+    assert second_input[0].all_text() == "first output"
+
+
+@pytest.mark.asyncio
+async def test_cumulative_chain_generate_calls_all_agents() -> None:
+    first = RecordingAgent("first", "first output")
+    second = RecordingAgent("second", "second output")
+    chain = ChainAgent(AgentConfig("chain"), [first, second], cumulative=True)
+
+    await chain.generate(
+        PromptMessageExtended(role="user", content=[text_content("start")])
+    )
+
+    assert len(first.generate_inputs) == 1, "first agent must be called exactly once"
+    assert len(second.generate_inputs) == 1, "second agent must be called exactly once"
+
+
+@pytest.mark.asyncio
+async def test_cumulative_chain_generate_passes_prior_outputs_as_context() -> None:
+    first = RecordingAgent("first", "first output")
+    second = RecordingAgent("second", "second output")
+    third = RecordingAgent("third", "third output")
+    chain = ChainAgent(AgentConfig("chain"), [first, second, third], cumulative=True)
+
+    await chain.generate(
+        PromptMessageExtended(role="user", content=[text_content("start")])
+    )
+
+    assert len(first.generate_inputs) == 1
+    assert len(second.generate_inputs) == 1
+    assert len(third.generate_inputs) == 1
+    assert [m.all_text() for m in first.generate_inputs[0]] == ["start"]
+    assert [m.all_text() for m in second.generate_inputs[0]] == ["start", "first output"]
+    assert [m.all_text() for m in third.generate_inputs[0]] == [
+        "start",
+        "first output",
+        "second output",
+    ]
+    for msg in second.generate_inputs[0]:
+        assert msg.role == "user"
+    for msg in third.generate_inputs[0]:
+        assert msg.role == "user"
+
+
+@pytest.mark.asyncio
+async def test_cumulative_chain_generate_response_contains_all_outputs() -> None:
+    first = RecordingAgent("first", "first output")
+    second = RecordingAgent("second", "second output")
+    chain = ChainAgent(AgentConfig("chain"), [first, second], cumulative=True)
+
+    result = await chain.generate(
+        PromptMessageExtended(role="user", content=[text_content("start")])
+    )
+
+    response_text = result.all_text()
+    assert "<fastagent:request>start</fastagent:request>" in response_text
+    assert "<fastagent:response agent='first'>first output</fastagent:response>" in response_text
+    assert "<fastagent:response agent='second'>second output</fastagent:response>" in response_text
+
+
+@pytest.mark.asyncio
+async def test_cumulative_chain_generate_preserves_prior_response_content_blocks() -> None:
+    first = MultimodalRecordingAgent("first", "first output")
+    second = RecordingAgent("second", "second output")
+    chain = ChainAgent(AgentConfig("chain"), [first, second], cumulative=True)
+
+    await chain.generate(
+        PromptMessageExtended(role="user", content=[text_content("start")])
+    )
+
+    assert len(second.generate_inputs) == 1
+    prior_response = second.generate_inputs[0][1]
+    assert prior_response.role == "user"
+    assert len(prior_response.content) == 2
+    assert prior_response.content[0] == text_content("first output")
+    assert isinstance(prior_response.content[1], ImageContent)
+
+
+@pytest.mark.asyncio
+async def test_chain_generate_propagates_child_execution_errors() -> None:
+    first = FailingGenerateAgent("first", "ignored")
+    final = RecordingAgent("final", "result")
+    chain = ChainAgent(AgentConfig("chain"), [first, final])
+
+    with pytest.raises(RuntimeError, match="first failed"):
+        await chain.generate(
+            PromptMessageExtended(role="user", content=[text_content("start")])
+        )
+
+    assert final.generate_inputs == []
+
+
+@pytest.mark.asyncio
+async def test_cumulative_chain_generate_propagates_child_execution_errors() -> None:
+    first = RecordingAgent("first", "first output")
+    second = FailingGenerateAgent("second", "ignored")
+    final = RecordingAgent("final", "result")
+    chain = ChainAgent(AgentConfig("chain"), [first, second, final], cumulative=True)
+
+    with pytest.raises(RuntimeError, match="second failed"):
+        await chain.generate(
+            PromptMessageExtended(role="user", content=[text_content("start")])
+        )
+
+    assert len(first.generate_inputs) == 1
+    assert final.generate_inputs == []
+
+
+@pytest.mark.asyncio
 async def test_chain_structured_propagates_child_execution_errors() -> None:
     first = FailingGenerateAgent("first", "ignored")
     final = RecordingAgent("final", "structured")

--- a/tests/unit/fast_agent/agents/workflow/test_chain_agent.py
+++ b/tests/unit/fast_agent/agents/workflow/test_chain_agent.py
@@ -294,9 +294,7 @@ async def test_cumulative_chain_generate_calls_all_agents() -> None:
     second = RecordingAgent("second", "second output")
     chain = ChainAgent(AgentConfig("chain"), [first, second], cumulative=True)
 
-    await chain.generate(
-        PromptMessageExtended(role="user", content=[text_content("start")])
-    )
+    await chain.generate(PromptMessageExtended(role="user", content=[text_content("start")]))
 
     assert len(first.generate_inputs) == 1, "first agent must be called exactly once"
     assert len(second.generate_inputs) == 1, "second agent must be called exactly once"
@@ -309,9 +307,7 @@ async def test_cumulative_chain_generate_passes_prior_outputs_as_context() -> No
     third = RecordingAgent("third", "third output")
     chain = ChainAgent(AgentConfig("chain"), [first, second, third], cumulative=True)
 
-    await chain.generate(
-        PromptMessageExtended(role="user", content=[text_content("start")])
-    )
+    await chain.generate(PromptMessageExtended(role="user", content=[text_content("start")]))
 
     assert len(first.generate_inputs) == 1
     assert len(second.generate_inputs) == 1
@@ -351,9 +347,7 @@ async def test_cumulative_chain_generate_preserves_prior_response_content_blocks
     second = RecordingAgent("second", "second output")
     chain = ChainAgent(AgentConfig("chain"), [first, second], cumulative=True)
 
-    await chain.generate(
-        PromptMessageExtended(role="user", content=[text_content("start")])
-    )
+    await chain.generate(PromptMessageExtended(role="user", content=[text_content("start")]))
 
     assert len(second.generate_inputs) == 1
     prior_response = second.generate_inputs[0][1]
@@ -370,9 +364,7 @@ async def test_chain_generate_propagates_child_execution_errors() -> None:
     chain = ChainAgent(AgentConfig("chain"), [first, final])
 
     with pytest.raises(RuntimeError, match="first failed"):
-        await chain.generate(
-            PromptMessageExtended(role="user", content=[text_content("start")])
-        )
+        await chain.generate(PromptMessageExtended(role="user", content=[text_content("start")]))
 
     assert final.generate_inputs == []
 
@@ -385,9 +377,7 @@ async def test_cumulative_chain_generate_propagates_child_execution_errors() -> 
     chain = ChainAgent(AgentConfig("chain"), [first, second, final], cumulative=True)
 
     with pytest.raises(RuntimeError, match="second failed"):
-        await chain.generate(
-            PromptMessageExtended(role="user", content=[text_content("start")])
-        )
+        await chain.generate(PromptMessageExtended(role="user", content=[text_content("start")]))
 
     assert len(first.generate_inputs) == 1
     assert final.generate_inputs == []


### PR DESCRIPTION
## Summary

- Adds tests for `ChainAgent.generate` in both cumulative and non-cumulative modes (previously untested)
- Verifies that all agents in a cumulative chain are called for LLM generation, not just the first one
- Checks that each successive agent receives the correct set of prior outputs as user-role context messages
- Confirms multimodal content blocks are preserved when forwarded between agents
- Confirms error propagation works for both cumulative and non-cumulative paths

## Background

Issue #88 reported that `ChainAgent.generate` with `cumulative=True` only invoked the first agent's LLM. The `generate_impl` path was entirely untested: the existing test suite covered `structured` and `structured_schema` but had no coverage for `generate`. This PR closes that gap.

## Test plan

- [x] `test_chain_generate_non_cumulative_passes_only_previous_output`: agent 2 receives only agent 1's output, not the original prompt
- [x] `test_cumulative_chain_generate_calls_all_agents`: both agents in a two-agent cumulative chain are invoked
- [x] `test_cumulative_chain_generate_passes_prior_outputs_as_context`: three-agent chain; each agent receives all prior outputs as user messages
- [x] `test_cumulative_chain_generate_response_contains_all_outputs`: the XML-formatted response includes every agent's response
- [x] `test_cumulative_chain_generate_preserves_prior_response_content_blocks`: multimodal content blocks survive the cumulative wrapping
- [x] `test_chain_generate_propagates_child_execution_errors`: an error in the first agent halts the chain and the second agent is not called
- [x] `test_cumulative_chain_generate_propagates_child_execution_errors`: an error in a middle agent halts the rest of the chain
- [x] All 16 chain agent tests pass; the 12 pre-existing failures in unrelated test files remain unchanged

Fixes #88
