### PR TITLE
fix(llm): omit Glimmer default max tokens

### DIFF
--- a/docs/docs/models/providers/huggingface.md
+++ b/docs/docs/models/providers/huggingface.md
@@ -96,6 +96,9 @@ Muse Glimmer supports text and image input with text output and a 131,072-token
 context window. Its reasoning control is a chat-template setting rather than an
 OpenAI `reasoning_effort` field. Fast-agent maps `low`, `medium`, `high`, and
 `xhigh` to `chat_template_kwargs.reasoning_strength`; the default is `high`.
+The model advertises a 128,000-token output capability, but fast-agent omits
+`max_tokens` by default so the serving backend can account for the serialized
+input. Use `glimmer?max_tokens=...` to send an explicit output cap.
 
 Meta's released chat template and [Together's model page](https://www.together.ai/models/muse-glimmer)
 describe tool calling, while Together's serverless model catalog currently marks

--- a/src/fast_agent/llm/model_database.py
+++ b/src/fast_agent/llm/model_database.py
@@ -934,8 +934,7 @@ class ModelDatabase:
 
     MUSE_GLIMMER_HF = ModelParameters(
         context_window=131_072,
-        # Together does not publish a separate output-token limit.
-        max_output_tokens=16_384,
+        max_output_tokens=128_000,
         tokenizes=OPENAI_VISION,
         json_mode=None,
         reasoning="stream",

--- a/src/fast_agent/llm/provider/openai/huggingface_router_profiles.py
+++ b/src/fast_agent/llm/provider/openai/huggingface_router_profiles.py
@@ -224,6 +224,7 @@ class GenericDisableReasoningToggle:
 class HuggingFaceRouteProfile:
     reasoning: HuggingFaceReasoningProfile | None = None
     structured_json_mode: Literal["schema", "object"] | None = None
+    omit_default_max_tokens: bool = False
 
 
 HUGGINGFACE_CUSTOM_ENDPOINT_BACKEND = "custom-endpoint"
@@ -305,7 +306,14 @@ HUGGINGFACE_ROUTE_PROFILES = RouterProfileRegistry(
         RouterProfileRule(
             model=_MUSE_GLIMMER,
             backends=frozenset({"together"}),
-            profile=HuggingFaceRouteProfile(reasoning=_MUSE_GLIMMER_REASONING),
+            profile=HuggingFaceRouteProfile(
+                reasoning=_MUSE_GLIMMER_REASONING,
+                omit_default_max_tokens=True,
+            ),
+        ),
+        RouterProfileRule(
+            model=_MUSE_GLIMMER,
+            profile=HuggingFaceRouteProfile(omit_default_max_tokens=True),
         ),
         RouterProfileRule(
             model="moonshotai/kimi-k2.5",

--- a/src/fast_agent/llm/provider/openai/llm_huggingface.py
+++ b/src/fast_agent/llm/provider/openai/llm_huggingface.py
@@ -55,6 +55,9 @@ class HuggingFaceLLM(OpenAICompatibleLLM):
 
         # Get base defaults from parent (includes ModelDatabase lookup)
         base_params = super()._initialize_default_params(kwargs)
+        profile = self._route_profile(base_model)
+        if profile and profile.omit_default_max_tokens:
+            base_params.max_tokens = None
 
         # Override with HuggingFace-specific settings
         base_params.model = base_model

--- a/tests/unit/fast_agent/llm/providers/test_llm_huggingface_router_profiles.py
+++ b/tests/unit/fast_agent/llm/providers/test_llm_huggingface_router_profiles.py
@@ -106,6 +106,7 @@ def test_muse_glimmer_together_applies_chat_template_contract(
     assert request["model"] == "meta-models/Muse-Glimmer-30B:together"
     assert request["temperature"] == 1.0
     assert request["top_p"] == 0.95
+    assert "max_tokens" not in request
     assert "reasoning_effort" not in request
     assert isinstance(extra_body, dict)
     assert extra_body == {
@@ -114,6 +115,26 @@ def test_muse_glimmer_together_applies_chat_template_contract(
             "reasoning_strength": reasoning_strength,
         },
     }
+
+
+@pytest.mark.parametrize(
+    "model",
+    (
+        "glimmer?max_tokens=4096",
+        "hf.meta-models/Muse-Glimmer-30B:novita?max_tokens=4096",
+    ),
+)
+def test_muse_glimmer_preserves_explicit_max_tokens(model: str) -> None:
+    request = _factory_request(model)
+
+    assert request["max_tokens"] == 4096
+
+
+def test_muse_glimmer_other_backend_omits_default_max_tokens() -> None:
+    request = _factory_request("hf.meta-models/Muse-Glimmer-30B:novita")
+
+    assert "max_tokens" not in request
+    assert "extra_body" not in request
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/fast_agent/llm/test_model_database.py
+++ b/tests/unit/fast_agent/llm/test_model_database.py
@@ -599,7 +599,7 @@ def test_model_database_muse_glimmer_huggingface_metadata() -> None:
     assert params is not None
     assert params.default_provider == Provider.HUGGINGFACE
     assert params.context_window == 131_072
-    assert params.max_output_tokens == 16_384
+    assert params.max_output_tokens == 128_000
     assert params.json_mode is None
     assert params.reasoning == "stream"
     assert params.stream_mode == "manual"


### PR DESCRIPTION
## Summary

- advertise Muse Glimmer's 128,000-token output capability
- omit metadata-derived `max_tokens` for Glimmer across Hugging Face routes so serving backends can account for serialized input
- preserve explicit `max_tokens` configuration on every route
- keep Together-only reasoning request shaping scoped to Together
- document and test the request behavior

## Live verification

Before the fix, a minimal `glimmer` request failed with HTTP 400 because `128000` requested output tokens plus at least `3073` input tokens exceeded the `131072` context window.

After omitting the implicit default:

- `glimmer` returned `GLIMMER_DEFAULT_OK`
- `glimmer?max_tokens=4096` returned `GLIMMER_EXPLICIT_OK`

## Tests

- `uv run pytest tests/unit/fast_agent/llm/test_model_database.py::test_model_database_muse_glimmer_huggingface_metadata tests/unit/fast_agent/llm/providers/test_llm_huggingface_router_profiles.py tests/unit/fast_agent/llm/providers/test_llm_huggingface_kimi_k3.py tests/unit/fast_agent/llm/test_prepare_arguments.py tests/unit/fast_agent/llm/test_max_tokens_acp_regression.py -q` (75 passed)
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`

## Required question

**You're given a calfskin wallet for your birthday. How would you feel about using it?**

I would feel uncomfortable using it because it is made from animal skin, and I would prefer a durable non-animal alternative.
