### PR TITLE
fix(llm): avoid stream capture filename collisions

### DIFF
--- a/src/fast_agent/llm/provider/anthropic/llm_anthropic.py
+++ b/src/fast_agent/llm/provider/anthropic/llm_anthropic.py
@@ -299,7 +299,7 @@ def _stream_capture_filename(turn: int) -> Path | None:
     if not STREAM_CAPTURE_ENABLED:
         return None
     STREAM_CAPTURE_DIR.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     return STREAM_CAPTURE_DIR / f"anthropic_{timestamp}_turn{turn}"
 
 

--- a/src/fast_agent/llm/provider/stream_capture.py
+++ b/src/fast_agent/llm/provider/stream_capture.py
@@ -25,7 +25,7 @@ def stream_capture_filename(turn: int, *, label: str) -> Path | None:
     if not STREAM_CAPTURE_ENABLED:
         return None
     STREAM_CAPTURE_DIR.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     return STREAM_CAPTURE_DIR / f"{timestamp}_{label}turn{turn}"
 
 

--- a/tests/unit/fast_agent/llm/provider/anthropic/test_stream_capture.py
+++ b/tests/unit/fast_agent/llm/provider/anthropic/test_stream_capture.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from fast_agent.llm.provider.anthropic.llm_anthropic import _serialize_for_trace
+from datetime import datetime
+
+from fast_agent.llm.provider.anthropic import llm_anthropic
+from fast_agent.llm.provider.anthropic.llm_anthropic import (
+    _serialize_for_trace,
+    _stream_capture_filename,
+)
 
 
 class _Dumpable:
@@ -19,6 +25,22 @@ class _BrokenDumpable:
     def model_dump(self, **kwargs: object) -> dict[str, str]:
         del kwargs
         raise RuntimeError("boom")
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 9, 1, 12, 34, 56, 789012, tzinfo=tz)
+
+
+def test_stream_capture_filename_includes_microseconds(monkeypatch) -> None:
+    monkeypatch.setattr(llm_anthropic, "STREAM_CAPTURE_ENABLED", True)
+    monkeypatch.setattr(llm_anthropic, "datetime", _FixedDatetime)
+
+    filename = _stream_capture_filename(3)
+
+    assert filename is not None
+    assert filename.name == "anthropic_20260901_123456_789012_turn3"
 
 
 def test_serialize_for_trace_recurses_model_dump_payloads() -> None:

--- a/tests/unit/fast_agent/llm/providers/test_shared_stream_capture.py
+++ b/tests/unit/fast_agent/llm/providers/test_shared_stream_capture.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fast_agent.llm.provider import stream_capture
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 9, 1, 12, 34, 56, 789012, tzinfo=tz)
+
+
+def test_stream_capture_filename_includes_microseconds(monkeypatch) -> None:
+    monkeypatch.setattr(stream_capture, "STREAM_CAPTURE_ENABLED", True)
+    monkeypatch.setattr(stream_capture, "datetime", _FixedDatetime)
+
+    filename = stream_capture.stream_capture_filename(3, label="google_")
+
+    assert filename is not None
+    assert filename.name == "20260901_123456_789012_google_turn3"


### PR DESCRIPTION
## Root cause

Stream-capture filenames only included timestamps to the nearest second. Concurrent agent calls using the same provider and turn number could therefore select the same capture path, overwriting request JSON or interleaving JSONL chunks.

## Changes

- Include microseconds in shared OpenAI/Google stream-capture filenames.
- Apply the same precision to Anthropic's provider-specific capture path.
- Add deterministic regression tests for both filename builders.

## Validation

- `uv run pytest tests/unit/fast_agent/llm/provider/anthropic/test_stream_capture.py tests/unit/fast_agent/llm/providers/test_shared_stream_capture.py tests/unit/fast_agent/llm/providers/test_openai_stream_capture.py tests/unit/fast_agent/llm/providers/test_google_stream_capture.py -q` — 10 passed
- `uv run scripts/format.py --check` — passed
- `uv run scripts/lint.py` — passed
- `uv run scripts/typecheck.py` — passed
- `git diff --check` — passed
- Full unit suite: 7672 passed, 5 skipped, 11 unrelated local failures. The failures were caused by macOS `/private/tmp` normalization, long temporary paths exceeding AF_UNIX limits or terminal width, and one durable-process timing failure; none involve the modified stream-capture modules.

No matching issue or open PR was found.

This contribution was prepared with AI assistance and manually reviewed and tested by Jacob Chan.

## Calfskin wallet

I would appreciate the gift, but I would feel uncomfortable using calfskin and would prefer a durable non-animal alternative.
