### PR TITLE
fix(marketplace): contain skill and plugin installs

### DIFF
--- a/src/fast_agent/marketplace/provenance_io.py
+++ b/src/fast_agent/marketplace/provenance_io.py
@@ -253,6 +253,28 @@ def normalize_relative_repo_path(path: str, *, allow_current_dir: bool = False) 
     return normalized
 
 
+def normalize_install_dir_name(name: str) -> str | None:
+    raw = name.replace("\\", "/")
+    if not raw or "\0" in raw or re.match(r"^[A-Za-z]:", raw):
+        return None
+    posix_path = PurePosixPath(raw)
+    if posix_path.is_absolute() or raw != posix_path.name or posix_path.name in {".", ".."}:
+        return None
+    return name
+
+
+def resolve_managed_install_dir(destination_root: Path, name: str) -> Path:
+    install_dir_name = normalize_install_dir_name(name)
+    if install_dir_name is None:
+        raise ValueError(f"Invalid marketplace install directory name: {name!r}")
+
+    destination_root = destination_root.resolve()
+    install_dir = (destination_root / install_dir_name).resolve()
+    if install_dir.parent != destination_root:
+        raise ValueError("Marketplace install path is outside of the managed directory.")
+    return install_dir
+
+
 def repo_subdir_for_manifest_path(repo_path: str, manifest_filename: str) -> str:
     path_value = (
         normalize_relative_repo_path(repo_path, allow_current_dir=True) or repo_path.strip()

--- a/src/fast_agent/plugins/marketplace.py
+++ b/src/fast_agent/plugins/marketplace.py
@@ -131,9 +131,12 @@ def parse_marketplace_plugins(
         repo_path = normalize_repo_path(entry.repo_path)
         if not repo_path:
             continue
+        name = entry.name or repo_path
+        if marketplace_provenance_io.normalize_install_dir_name(name) is None:
+            continue
         plugins.append(
             MarketplacePlugin(
-                name=entry.name or repo_path,
+                name=name,
                 description=entry.description,
                 repo_url=entry.repo_url,
                 repo_ref=entry.repo_ref,

--- a/src/fast_agent/plugins/operations.py
+++ b/src/fast_agent/plugins/operations.py
@@ -142,15 +142,19 @@ def install_marketplace_plugin_sync(
 ) -> Path:
     destination_root = destination_root.resolve()
     destination_root.mkdir(parents=True, exist_ok=True)
-    install_dir = destination_root / plugin.install_dir_name
+    install_dir_name = plugin.install_dir_name
+    install_dir = marketplace_provenance_io.resolve_managed_install_dir(
+        destination_root,
+        install_dir_name,
+    )
     if install_dir.exists() and not replace_existing:
-        raise FileExistsError(f"Plugin already exists: {plugin.install_dir_name}")
+        raise FileExistsError(f"Plugin already exists: {install_dir_name}")
 
     with tempfile.TemporaryDirectory(
         dir=destination_root,
-        prefix=f".{plugin.name}.staging-",
+        prefix=f".{install_dir_name}.staging-",
     ) as tmp:
-        staged_dir = Path(tmp) / plugin.install_dir_name
+        staged_dir = Path(tmp) / install_dir_name
         copied_source = _copy_plugin_from_source(
             plugin,
             destination_dir=staged_dir,

--- a/src/fast_agent/skills/marketplace_parsing.py
+++ b/src/fast_agent/skills/marketplace_parsing.py
@@ -193,8 +193,12 @@ def _skill_from_entry_model(model: MarketplaceEntryModel) -> MarketplaceSkill | 
     if not repo_path:
         return None
 
+    name = model.name or repo_path
+    if marketplace_provenance_io.normalize_install_dir_name(name) is None:
+        return None
+
     return MarketplaceSkill(
-        name=model.name or repo_path,
+        name=name,
         description=model.description,
         repo_url=model.repo_url,
         repo_ref=model.repo_ref,

--- a/src/fast_agent/skills/operations.py
+++ b/src/fast_agent/skills/operations.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from fast_agent.marketplace import fetch as marketplace_fetch
 from fast_agent.marketplace import git_sources as marketplace_git_sources
+from fast_agent.marketplace import provenance_io as marketplace_provenance_io
 from fast_agent.marketplace import source_models as marketplace_source_models
 from fast_agent.marketplace import source_urls as marketplace_source_urls
 from fast_agent.marketplace import update_status as marketplace_update_status
@@ -131,7 +132,10 @@ def install_marketplace_skill_sync(skill: MarketplaceSkill, destination_root: Pa
     destination_root = destination_root.resolve()
     destination_root.mkdir(parents=True, exist_ok=True)
 
-    install_dir = destination_root / skill.install_dir_name
+    install_dir = marketplace_provenance_io.resolve_managed_install_dir(
+        destination_root,
+        skill.install_dir_name,
+    )
     if install_dir.exists():
         raise FileExistsError(f"Skill already exists: {install_dir}")
 

--- a/tests/unit/fast_agent/marketplace/test_source_utils.py
+++ b/tests/unit/fast_agent/marketplace/test_source_utils.py
@@ -511,6 +511,35 @@ def test_normalize_relative_repo_path(
 
 
 @pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("alpha", "alpha"),
+        ("Useful Skill", "Useful Skill"),
+        ("../alpha", None),
+        (r"..\alpha", None),
+        ("nested/alpha", None),
+        ("/alpha", None),
+        ("C:alpha", None),
+        (".", None),
+        ("", None),
+    ],
+)
+def test_normalize_install_dir_name(name: str, expected: str | None) -> None:
+    assert provenance_io.normalize_install_dir_name(name) == expected
+
+
+def test_resolve_managed_install_dir_rejects_symlink_escape(tmp_path: Path) -> None:
+    destination_root = tmp_path / "managed"
+    destination_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (destination_root / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="outside of the managed directory"):
+        provenance_io.resolve_managed_install_dir(destination_root, "escape")
+
+
+@pytest.mark.parametrize(
     ("repo_path", "manifest_filename", "expected"),
     [
         ("skills/alpha/SKILL.md", "SKILL.md", "skills/alpha"),

--- a/tests/unit/fast_agent/plugins/test_plugin_marketplace_parsing.py
+++ b/tests/unit/fast_agent/plugins/test_plugin_marketplace_parsing.py
@@ -45,6 +45,22 @@ def test_parse_plugin_marketplace_reads_command_plugins() -> None:
     assert [plugin.name for plugin in plugins] == ["finder"]
 
 
+def test_parse_plugin_marketplace_rejects_traversal_entry_name() -> None:
+    plugins = parse_marketplace_plugins(
+        {
+            "command_plugins": [
+                {
+                    "name": "../../outside",
+                    "repo_url": "https://github.com/example/card-packs",
+                    "repo_path": "plugin.yaml",
+                }
+            ]
+        }
+    )
+
+    assert plugins == []
+
+
 def test_parse_plugin_marketplace_reads_generic_plugin_entries() -> None:
     plugins = parse_marketplace_plugins(
         {

--- a/tests/unit/fast_agent/plugins/test_plugin_operations.py
+++ b/tests/unit/fast_agent/plugins/test_plugin_operations.py
@@ -4,6 +4,9 @@ import json
 import subprocess
 from typing import TYPE_CHECKING
 
+import pytest
+
+from fast_agent.plugins import operations as plugin_operations
 from fast_agent.plugins.models import MarketplacePlugin
 from fast_agent.plugins.operations import (
     apply_plugin_updates,
@@ -59,6 +62,52 @@ def test_select_plugin_by_name_or_index_accepts_install_dir_name_alias() -> None
     plugin = _marketplace_plugin("bundle-entry", "plugins/canonical/PLUGIN.YAML")
 
     assert select_plugin_by_name_or_index([plugin], "canonical") is plugin
+
+
+def test_install_marketplace_plugin_rejects_install_path_escape(tmp_path: Path) -> None:
+    plugin = _marketplace_plugin("../outside", "plugin.yaml")
+
+    with pytest.raises(ValueError, match="Invalid marketplace install directory"):
+        install_marketplace_plugin_sync(plugin, destination_root=tmp_path / "managed")
+
+    assert not (tmp_path / "outside").exists()
+
+
+def test_plugin_staging_prefix_uses_validated_install_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _write_plugin(repo)
+    _commit_all(repo, "initial")
+    plugin = MarketplacePlugin(
+        name="../../../outside",
+        description=None,
+        repo_url=repo.as_posix(),
+        repo_ref=None,
+        repo_path="plugins/finder",
+    )
+    prefixes: list[str] = []
+    temporary_directory = plugin_operations.tempfile.TemporaryDirectory
+
+    def tracked_temporary_directory(*args, **kwargs):
+        prefixes.append(kwargs["prefix"])
+        return temporary_directory(*args, **kwargs)
+
+    monkeypatch.setattr(
+        plugin_operations.tempfile,
+        "TemporaryDirectory",
+        tracked_temporary_directory,
+    )
+
+    install_dir = install_marketplace_plugin_sync(
+        plugin,
+        destination_root=tmp_path / "managed",
+    )
+
+    assert install_dir == (tmp_path / "managed" / "finder").resolve()
+    assert prefixes == [".finder.staging-"]
 
 
 def test_select_plugin_by_name_or_index_rejects_ambiguous_install_dir_name_alias() -> None:

--- a/tests/unit/fast_agent/skills/test_marketplace_parsing.py
+++ b/tests/unit/fast_agent/skills/test_marketplace_parsing.py
@@ -25,6 +25,20 @@ def test_parse_marketplace_payload_returns_empty_for_invalid_payload_shape() -> 
     assert parse_marketplace_payload("not a marketplace") == []
 
 
+def test_parse_marketplace_payload_rejects_traversal_entry_name() -> None:
+    payload = {
+        "entries": [
+            {
+                "name": "../../outside",
+                "repo_url": "https://github.com/example/skills",
+                "repo_path": ".",
+            }
+        ]
+    }
+
+    assert parse_marketplace_payload(payload) == []
+
+
 def test_parse_marketplace_payload_does_not_hide_entry_conversion_failures(
     monkeypatch,
 ) -> None:

--- a/tests/unit/fast_agent/skills/test_operations.py
+++ b/tests/unit/fast_agent/skills/test_operations.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from typing import TYPE_CHECKING
 
+import pytest
+
 from fast_agent.skills.models import MarketplaceSkill
 from fast_agent.skills.operations import (
     _has_skill_manifest,
@@ -67,6 +69,15 @@ def test_select_skill_by_name_or_index_accepts_lowercase_manifest_parent_alias()
 
     assert skill.install_dir_name == "app"
     assert select_skill_by_name_or_index([skill], "app") is skill
+
+
+def test_install_marketplace_skill_rejects_install_path_escape(tmp_path: Path) -> None:
+    skill = _marketplace_skill("outside", ".", install_dir_name_override="../outside")
+
+    with pytest.raises(ValueError, match="Invalid marketplace install directory"):
+        install_marketplace_skill_sync(skill, tmp_path / "managed")
+
+    assert not (tmp_path / "outside").exists()
 
 
 def test_manifest_path_checks_normalize_manifest_filename(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Marketplace payloads can currently use an entry name to escape the managed skills or plugins directory when the repository path falls back to that name. This change rejects names that are not a single relative path component and verifies the resolved installation target remains an immediate child of the managed root.

Plugin staging now uses the validated installation name as its temporary-directory prefix, closing the independent traversal path through the raw marketplace entry name. Legitimate names, including names containing spaces, remain supported.

Resolves #903

## Testing

- `uv run pytest -q tests/unit/fast_agent/marketplace tests/unit/fast_agent/skills tests/unit/fast_agent/plugins` (353 passed)
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`

## Contributor question

> You're given a calfskin wallet for your birthday. How would you feel about using it?

I would feel uncomfortable using an animal-derived gift and would prefer a durable non-animal alternative. I would thank the giver, explain my preference respectfully, and exchange or rehome it rather than waste it.
