### PR TITLE
fix: preserve tool results when iteration limit is reached

### DIFF
--- a/src/fast_agent/agents/tool_runner.py
+++ b/src/fast_agent/agents/tool_runner.py
@@ -885,6 +885,9 @@ class ToolRunner:
             )
             if self._last_message is not None:
                 self._last_message.stop_reason = LlmStopReason.MAX_ITERATIONS
+            if self._use_history_enabled():
+                self._stage_tool_response(tool_message)
+                self._append_history_messages(*self._delta_messages)
             self._done = True
             return
 

--- a/src/fast_agent/hooks/history_trimmer.py
+++ b/src/fast_agent/hooks/history_trimmer.py
@@ -65,6 +65,10 @@ def _trim_turn_messages(
         # Not enough messages to trim (need at least: user, assistant, user, assistant)
         return turn_messages
 
+    if turn_messages[-1].role != "assistant":
+        # An interrupted tool loop has no final assistant response to retain.
+        return turn_messages
+
     # Find all assistant messages with tool calls
     tool_call_indices: list[int] = []
     for i, msg in enumerate(turn_messages):

--- a/tests/unit/fast_agent/agents/test_tool_runner_hooks.py
+++ b/tests/unit/fast_agent/agents/test_tool_runner_hooks.py
@@ -201,6 +201,27 @@ async def test_tool_runner_stages_pending_media_as_followup_user_message():
     assert second_call[-1][1] == ["image"]
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_iteration_limit_preserves_pending_media_for_next_turn():
+    llm = MediaStagingLlm()
+    agent = MediaStagingToolAgent(AgentConfig("media"), [stage_media])
+    agent._llm = llm
+
+    result = await agent.generate("hi", RequestParams(max_iterations=0))
+    assert result.stop_reason == LlmStopReason.MAX_ITERATIONS
+
+    await agent.generate("continue")
+
+    assert len(llm.calls) == 2
+    second_call = llm.calls[1]
+    assert all(
+        FAST_AGENT_PENDING_MEDIA_ATTACHMENTS not in channels for _, _, channels in second_call
+    )
+    assert second_call[-2][0] == "user"
+    assert second_call[-2][1] == ["image"]
+
+
 # Track tool invocations globally for the regression test
 _tool_invocations: list[str] = []
 

--- a/tests/unit/fast_agent/agents/test_tool_runner_max_iterations.py
+++ b/tests/unit/fast_agent/agents/test_tool_runner_max_iterations.py
@@ -5,6 +5,7 @@ from fast_agent.acp.server.common import map_llm_stop_reason_to_acp
 from fast_agent.agents import tool_runner
 from fast_agent.agents.agent_types import AgentConfig
 from fast_agent.agents.tool_agent import ToolAgent
+from fast_agent.core.direct_factory import _apply_trim_history_hook
 from fast_agent.llm.internal.passthrough import PassthroughLLM
 from fast_agent.llm.request_params import RequestParams
 from fast_agent.mcp.helpers.content_helpers import text_content
@@ -22,6 +23,7 @@ class AlwaysToolCallingLlm(PassthroughLLM):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.call_count = 0
+        self.inputs: list[list[PromptMessageExtended]] = []
 
     async def _apply_prompt_provider_specific(
         self,
@@ -31,6 +33,7 @@ class AlwaysToolCallingLlm(PassthroughLLM):
         is_template: bool = False,
     ) -> PromptMessageExtended:
         self.call_count += 1
+        self.inputs.append(list(multipart_messages))
         return PromptMessageExtended(
             role="assistant",
             content=[text_content("calling again")],
@@ -56,6 +59,48 @@ async def test_exhausting_max_iterations_reports_a_stop_reason() -> None:
     assert result.stop_reason == LlmStopReason.MAX_ITERATIONS
     # The budget is spent before the loop notices it is exhausted.
     assert llm.call_count == 4
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trim_tool_history", [False, True])
+@pytest.mark.parametrize("use_history", [False, True])
+async def test_iteration_limit_preserves_completed_tool_results(
+    trim_tool_history: bool, use_history: bool
+) -> None:
+    llm = AlwaysToolCallingLlm()
+    config = AgentConfig("looping", trim_tool_history=trim_tool_history, use_history=use_history)
+    agent = ToolAgent(config, [looping_tool])
+    agent._llm = llm
+    _apply_trim_history_hook(agent, config)
+
+    result = await agent.generate("go", RequestParams(max_iterations=2, use_history=use_history))
+
+    assert result.stop_reason == LlmStopReason.MAX_ITERATIONS
+    history = list(agent.message_history)
+    if use_history:
+        assert result.tool_calls
+        assert history[-1].tool_results
+        assert history[-1].tool_results.keys() == result.tool_calls.keys()
+        for request, response in zip(history[1::2], history[2::2], strict=True):
+            assert request.tool_calls
+            assert response.tool_results
+            assert request.tool_calls.keys() == response.tool_results.keys()
+            assert all(
+                tool_result.content == [text_content("tool-result")]
+                for tool_result in response.tool_results.values()
+            )
+    else:
+        assert history == []
+
+    await agent.generate("continue", RequestParams(max_iterations=0, use_history=use_history))
+
+    assert llm.call_count == 4
+    requests = [key for message in llm.inputs[-1] for key in (message.tool_calls or {})]
+    results = [key for message in llm.inputs[-1] for key in (message.tool_results or {})]
+    assert len(requests) == (3 if use_history else 0)
+    assert requests == results
+    assert llm.inputs[-1][-1].last_text() == "continue"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
When `ToolRunner` reaches `max_iterations`, the final tool call has already executed, but the loop exits before staging its result. A subsequent `generate()` receives that tool call without a matching result. Pending media from the tool are also lost.

Persist the completed result through the existing media-staging path when history is enabled. Leave turns without a final assistant response untrimmed so history trimming cannot separate tool calls from their results. The existing iteration counting and `MAX_ITERATIONS` return value are unchanged.

Regression coverage drives the real `ToolAgent.generate()` loop with the existing scripted LLM fixtures: history on/off, trimming on/off, the next provider request, and pending media. Before the fix, three new cases fail; after it, all 29 tests across the affected tool-runner and history-trimmer modules pass.

Validation:

- Format, lint, typecheck, CPD baseline, and internal-resource checks pass.
- Full unit suite on macOS with Python 3.14.7: **7,684 passed, 5 skipped, 2 failed**. Both failures also reproduce on unmodified `bc2ce572` in the same environment: `test_durable_process_stop_is_file_backed_and_idempotent` (missing expected `ready` output) and `test_normalize_local_attachment_reference_accepts_file_scheme_case_insensitively` (`/tmp` resolves to `/private/tmp` on macOS).

Prepared with AI assistance. Required wallet question, answered by the AI assistant: I don't have personal feelings or use physical wallets.
