### PR TITLE
fix: resolve macOS Java home for CPD bootstrap

### DIFF
--- a/scripts/cpd.py
+++ b/scripts/cpd.py
@@ -152,12 +152,13 @@ def download_file(url: str, dest: Path, desc: str) -> None:
 
 def ensure_jre() -> Path:
     """Ensure Java JRE is available, downloading if necessary."""
-    java_bin = JRE_DIR / "bin" / "java"
+    java_home = JRE_DIR / "Contents/Home" if SYSTEM == "darwin" else JRE_DIR
+    java_bin = java_home / "bin" / "java"
     if SYSTEM == "windows":
         java_bin = java_bin.with_suffix(".exe")
 
     if java_bin.exists():
-        return JRE_DIR
+        return java_home
 
     # Check system Java
     system_java = shutil.which("java")
@@ -196,7 +197,7 @@ def ensure_jre() -> Path:
                 extracted_dir = d
                 break
 
-    return extracted_dir
+    return extracted_dir / "Contents/Home" if SYSTEM == "darwin" else extracted_dir
 
 
 def ensure_pmd() -> Path:

--- a/tests/unit/scripts/test_cpd.py
+++ b/tests/unit/scripts/test_cpd.py
@@ -1,11 +1,54 @@
 import runpy
+import tarfile
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 _CPD_MODULE = runpy.run_path(str(Path(__file__).parents[3] / "scripts/cpd.py"))
 CPDFinding: Any = _CPD_MODULE["CPDFinding"]
 cpd_baseline_delta: Any = _CPD_MODULE["cpd_baseline_delta"]
 parse_cpd_findings: Any = _CPD_MODULE["parse_cpd_findings"]
+ensure_jre: Any = _CPD_MODULE["ensure_jre"]
+
+
+@pytest.mark.parametrize("system", ["darwin", "linux", "windows"])
+@pytest.mark.parametrize("cached", [False, True])
+def test_ensure_jre_returns_java_home_and_reuses_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, system: str, cached: bool
+) -> None:
+    tools_dir = tmp_path / "tools"
+    bundle_name = f"jdk-{_CPD_MODULE['JRE_VERSION']}-jre"
+    home_relative = Path("Contents/Home") if system == "darwin" else Path()
+    java_relative = home_relative / "bin" / ("java.exe" if system == "windows" else "java")
+    extracted_dir = tools_dir / bundle_name
+    source_dir = extracted_dir if cached else tmp_path / "archive-source"
+    java_bin = source_dir / java_relative
+    java_bin.parent.mkdir(parents=True)
+    java_bin.touch()
+    tools_dir.mkdir(exist_ok=True)
+    if not cached:
+        archive = tools_dir / f"{_CPD_MODULE['JRE_FILENAME']}.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(source_dir, arcname=bundle_name)
+
+    monkeypatch.setitem(ensure_jre.__globals__, "SYSTEM", system)
+    monkeypatch.setitem(ensure_jre.__globals__, "TOOLS_DIR", tools_dir)
+    monkeypatch.setitem(ensure_jre.__globals__, "JRE_DIR", extracted_dir)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+    def unexpected_download(*args: Any) -> None:
+        pytest.fail("The local JRE or archive should be reused")
+
+    monkeypatch.setitem(ensure_jre.__globals__, "download_file", unexpected_download)
+    java_home = ensure_jre()
+    assert java_home == extracted_dir / home_relative
+    assert (extracted_dir / java_relative).is_file()
+
+    # A subsequent run should use the extracted JRE even without its archive.
+    for archive in tools_dir.glob("*.tar.gz"):
+        archive.unlink()
+    assert ensure_jre() == java_home
 
 
 def test_parse_cpd_findings_ignores_line_numbers_and_normalizes_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
On macOS without a usable system Java, `uv run scripts/cpd.py --check` downloads the Temurin JRE but then fails with `No java executable found in PATH`. The macOS archive puts Java under `Contents/Home/bin/java`; the bootstrap uses the bundle root as `JAVA_HOME` and also misses the cached executable on subsequent runs.

Resolve `Contents/Home` for both the cached JRE and the extracted bundle on macOS. The Linux/Windows layouts and system-Java selection stay the same.

Validation:

- All 8 CPD unit tests pass on Python 3.12 and 3.14, including six cached/extraction cases across macOS, Linux, and Windows. Both new macOS cases fail before the fix. Fixtures use local archives without network access.
- Reproduced the original failure on macOS, then ran the actual `uv run scripts/cpd.py --check` successfully after the fix, without the Java PATH workaround: 7 approved findings, no new duplication.
- Required format, lint, and type checks pass.

Prepared with AI assistance. Required wallet question, answered by the AI assistant: I don't have personal feelings or use physical wallets.
