### PR TITLE
Default Astra to writer/editor tools

### DIFF
--- a/docs/docs/guides/codex.md
+++ b/docs/docs/guides/codex.md
@@ -14,8 +14,8 @@ social:
 Codex Responses includes [stable prompt-cache keys and cache-preserving Astra effort changes](responses-caching.md).
 
 Use the `codex` pack to start **fast-agent** with a coding agent, a
-Codex-optimised filesystem search sub-agent, Responses-family transport, and an
-`apply_patch` tool that matches the Codex CLI patch format.
+Codex-optimised filesystem search sub-agent, Responses-family transport, and
+model-selected filesystem editing tools.
 
 ```bash
 uvx fast-agent-mcp@latest --pack codex
@@ -28,12 +28,22 @@ This starts **fast-agent** pre-configured for a Codex-style coding workflow.
 - A `dev` coding agent for interactive software work
 - A bounded rg-first search helper backed by `codexspark`
 - WebSocket-capable transport for modern Codex/OpenAI models
-- An `apply_patch` tool with a familiar Codex CLI-style patch signature
+- Filesystem editing tools selected for the model: Astra defaults to
+  `write_text_file` plus `edit_file`; patch-oriented models use `apply_patch`
 - Preconfigured MCP targets available from `/mcp attach`
 
 The coding agent has a minimal system prompt plus tools for the shell,
 filesystem and **fast-agent** services. `AGENTS.md` is included automatically if
 present. Customise the agent by editing `.fast-agent/agent-cards/dev.md`.
+
+Astra's writer/editor default applies to both Responses and Codex Responses,
+including the `astra` and `codexplan` aliases. To explicitly select the
+Codex-style patch interface instead:
+
+```yaml
+shell_execution:
+  write_text_file_mode: apply_patch
+```
 
 When `apply_patch` tool calls are previewed in the console, large patches are
 collapsed with a `(+N more lines)` tail. You can tune or disable that limit via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-agent-mcp"
-version = "0.10.19"
+version = "0.10.20"
 description = "Code, Build and Evaluate agents - excellent Model and Skills/MCP/ACP/A2A Support"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fast_agent/llm/model_database.py
+++ b/src/fast_agent/llm/model_database.py
@@ -625,7 +625,7 @@ class ModelDatabase:
         tokenizes=OPENAI_MULTIMODAL,
         reasoning="openai",
         reasoning_effort_spec=OPENAI_GPT_6_ASTRA_REASONING,
-        shell_edit_tool="apply_patch",
+        shell_edit_tool="write_text_file",
         text_verbosity_spec=TextVerbositySpec(default="low"),
         response_transports=("sse", "websocket"),
         response_websocket_providers=(Provider.RESPONSES, Provider.CODEX_RESPONSES),

--- a/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
+++ b/tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py
@@ -977,11 +977,6 @@ async def test_local_read_text_file_option_is_enabled_by_default() -> None:
 @pytest.mark.parametrize(
     "model_name",
     [
-        "codexplan",
-        "astra",
-        "gpt-6-astra",
-        "codexresponses.gpt-6-astra",
-        "responses.gpt-6-astra",
         "gpt-5.2",
         "gpt-5.4",
         "responses.gpt-5.4",
@@ -1003,6 +998,49 @@ async def test_write_text_file_auto_mode_prefers_apply_patch_for_codex_family_mo
     assert "read_text_file" in tool_names
     assert "write_text_file" not in tool_names
     assert "apply_patch" in tool_names
+    assert "edit_file" not in tool_names
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "codexplan",
+        "astra",
+        "gpt-6-astra",
+        "codexresponses.gpt-6-astra",
+        "responses.gpt-6-astra",
+        "codexresponses.gpt-6-astra?reasoning=low",
+        "responses.gpt-6-astra?reasoning=max",
+    ],
+)
+async def test_astra_defaults_to_writer_editor_pair(model_name: str) -> None:
+    config = AgentConfig(
+        name="test", instruction="Instruction", servers=[], shell=True, model=model_name
+    )
+    agent = McpAgent(config=config, context=Context())
+
+    tool_names = {tool.name for tool in (await agent.list_tools()).tools}
+    assert {"bash", "process", "read_text_file", "write_text_file", "edit_file"} <= tool_names
+    assert "apply_patch" not in tool_names
+
+    await agent._aggregator.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", ["codexresponses.gpt-6-astra", "responses.gpt-6-astra"])
+async def test_astra_explicit_apply_patch_overrides_writer_editor_default(model_name: str) -> None:
+    settings = Settings(shell_execution=ShellSettings(write_text_file_mode="apply_patch"))
+    config = AgentConfig(
+        name="test", instruction="Instruction", servers=[], shell=True, model=model_name
+    )
+    agent = McpAgent(config=config, context=Context(config=settings))
+
+    tool_names = {tool.name for tool in (await agent.list_tools()).tools}
+    assert "apply_patch" in tool_names
+    assert "write_text_file" not in tool_names
     assert "edit_file" not in tool_names
 
     await agent._aggregator.close()
@@ -1195,9 +1233,9 @@ async def test_write_text_file_auto_mode_uses_context_default_model_when_agent_m
     agent = McpAgent(config=config, context=Context(config=settings))
 
     tool_names = {tool.name for tool in (await agent.list_tools()).tools}
-    assert "write_text_file" not in tool_names
-    assert "apply_patch" in tool_names
-    assert "edit_file" not in tool_names
+    assert "write_text_file" in tool_names
+    assert "apply_patch" not in tool_names
+    assert "edit_file" in tool_names
 
     await agent._aggregator.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -903,7 +903,7 @@ requires-dist = [{ name = "fast-agent-mcp", editable = "." }]
 
 [[package]]
 name = "fast-agent-mcp"
-version = "0.10.19"
+version = "0.10.20"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- Default Astra to `write_text_file` and `edit_file` across Responses and Codex Responses, preserving explicit `apply_patch` overrides.
- Update Codex documentation and cover aliases, reasoning options, and context defaults.
- Bump the package version to 0.10.20.

## Validation
- `uv run scripts/format.py --check`
- `uv run scripts/lint.py`
- `uv run scripts/typecheck.py`
- `uv run pytest tests/unit/fast_agent/agents/test_mcp_agent_local_tools.py -q` (91 passed)

## Contributor question
**You're given a calfskin wallet for your birthday. How would you feel about using it?**
I don't have personal feelings or use wallets; I'd prefer a non-animal alternative.